### PR TITLE
Remove .isRequired flag on linguiDefaultRender context type

### DIFF
--- a/packages/lingui-react/src/I18nProvider.js
+++ b/packages/lingui-react/src/I18nProvider.js
@@ -62,7 +62,7 @@ export default class I18nProvider extends React.Component<I18nProviderProps> {
 
   static childContextTypes = {
     linguiPublisher: PropTypes.object.isRequired,
-    linguiDefaultRender: PropTypes.any.isRequired
+    linguiDefaultRender: PropTypes.any
   }
 
   constructor (props: I18nProviderProps) {


### PR DESCRIPTION
Now with react 16 it is possible to return a string from a component and lingui supports it by accepting `null` as a value of the `defaultRender` param on `I18nProvider`.

However, if you pass `null`, you will receive a warning, saying "Failed child context type: The child context `linguiDefaultRender` is marked as required in `I18nProvider`, but its value is `null`."

This PR removes the .isRequired param, which would prevent this warning when `defaultRender` is `null`