### PR TITLE
Fix doc typos

### DIFF
--- a/docs/guides/dynamic-loading-catalogs.rst
+++ b/docs/guides/dynamic-loading-catalogs.rst
@@ -80,7 +80,7 @@ our component until the message catalog is loaded. Let's add a
 
 .. code-block:: js
 
-   shouldComponentUpdate(newProps, nextState) {
+   shouldComponentUpdate(nextProps, nextState) {
       const { language } = nextProps
       const { catalogs } = nextState
 
@@ -115,7 +115,7 @@ Here we use the dynamic import syntax to load the message catalog:
    loadCatalog = async (language) => {
      const catalog = await import(
        /* webpackMode: "lazy", webpackChunkName: "i18n-[index]" */
-       `locale/data/${language}/messages.js`)
+       `locale/${language}/messages.js`)
 
      this.setState(state => ({
        catalogs: {

--- a/docs/guides/dynamic-loading-catalogs.rst
+++ b/docs/guides/dynamic-loading-catalogs.rst
@@ -24,11 +24,11 @@ Setup
 
 We are using the `Dynamic Import() Proposal <https://github.com/tc39/proposal-dynamic-import>`_
 to ECMAScript. We need to install ``babel-plugin-syntax-dynamic-import`` and 
-``babel-plugin-dynamic-import-node`` to make it work:
+``babel-plugin-dynamic-import-node`` to make it work. Also, the code examples given here make use of ``babel-plugin-transform-class-properties``
 
 .. code-block:: shell
 
-   yarn add --dev babel-plugin-syntax-dynamic-import babel-plugin-dynamic-import-node
+   yarn add --dev babel-plugin-syntax-dynamic-import babel-plugin-dynamic-import-node babel-plugin-transform-class-properties
 
 .. warning::
 
@@ -39,12 +39,14 @@ to ECMAScript. We need to install ``babel-plugin-syntax-dynamic-import`` and
    // .babelrc
    {
      "plugins": [
-       "syntax-dynamic-import"
+       "syntax-dynamic-import",
+       "transform-class-properties"
      ],
      "env": {
        "test": {
          "plugins": [
-           "dynamic-import-node"
+           "dynamic-import-node",
+           "transform-class-properties"
          ]
        }
      }

--- a/docs/guides/dynamic-loading-catalogs.rst
+++ b/docs/guides/dynamic-loading-catalogs.rst
@@ -45,8 +45,7 @@ to ECMAScript. We need to install ``babel-plugin-syntax-dynamic-import`` and
      "env": {
        "test": {
          "plugins": [
-           "dynamic-import-node",
-           "transform-class-properties"
+           "dynamic-import-node"
          ]
        }
      }


### PR DESCRIPTION
- `newProps` -> `nextProps`
- remove `data` from folder path.

Also there's another thing that I had to change to get the example working:

``` js
// Doc version
loadCatalog = async (language) => {/* ... */}

// My version
async loadCatalog(language) {/* ... */}
```

The reason for that change is that in the doc version, the arrow function doesn't have any `this` bound to it. I can also change that in the PR if you also experienced some troubles with it.