### PR TITLE
set localTransComponentName only if importDeclarations[Trans] is defi…

### DIFF
--- a/packages/babel-plugin-extract-messages/src/index.js
+++ b/packages/babel-plugin-extract-messages/src/index.js
@@ -84,7 +84,9 @@ export default function({ types: t }) {
             importDeclarations[specifier.imported.name] = specifier.local.name
           })
 
-          localTransComponentName = importDeclarations["Trans"]
+          if (importDeclarations["Trans"]) {
+            localTransComponentName = importDeclarations["Trans"]
+          }
         }
 
         // Remove imports of i18nMark identity


### PR DESCRIPTION
…ned to avoid accidental override with undefined

When importing the following from lingui-react:

```
import { withI18n, Trans as T } from 'lingui-react';
import type { I18n } from 'lingui-react';
```

the text wrapped in <T><\T> is no longer extracted and deleted from messages.json. This happens because `localTransComponentName` in 'packages/babel-plugin-extract-messages/src/index.js' is set after each import parse which in our case leads to it having `undefined` value.

This short fix solves the above issue.