### PR TITLE
Add support for culture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ results/
 junit.xml
 
 __pycache__/
+
+.DS_Store

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ test_script:
   - node --version
   - yarn --version
   # run tests
-  - env NODE_ICU_DATA=./node_modules/full-icu node scripts/test.js
+  - node --icu-data-dir=node_modules/full-icu scripts/test.js
 
 # Don't actually build.
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ test_script:
   - node --version
   - yarn --version
   # run tests
-  - NODE_ICU_DATA=./node_modules/full-icu node scripts/test.js
+  - env NODE_ICU_DATA=./node_modules/full-icu node scripts/test.js
 
 # Don't actually build.
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ environment:
 install:
   # Get the latest stable version of Node.js or io.js
   - ps: Install-Product node $env:nodejs_version
+  - yarn add full-icu -W
   # install modules
   - yarn install
   - yarn global add yalc
@@ -15,7 +16,7 @@ test_script:
   - node --version
   - yarn --version
   # run tests
-  - node scripts/test.js
+  - NODE_ICU_DATA=./node_modules/full-icu node scripts/test.js
 
 # Don't actually build.
 build: off

--- a/circle.yml
+++ b/circle.yml
@@ -10,11 +10,6 @@ workflows:
 #          requires:
 #            - test-linter
 
-#      - build-docs:
-#          requires:
-#            - test-node6
-#            - test-node8
-
 jobs:
   test-node8: &test-template
     docker:

--- a/circle.yml
+++ b/circle.yml
@@ -40,7 +40,7 @@ jobs:
 
       - run:
           name: Add the entire ICU (full-icu) 2
-          command: node install full-icu
+          command: npm install full-icu
 
       - save_cache:
           key: node-modules-{{ checksum "yarn.lock" }}

--- a/circle.yml
+++ b/circle.yml
@@ -43,7 +43,7 @@ jobs:
           paths:
               - node_modules
 
-      - run: NODE_ICU_DATA=./node_modules/full-icu node scripts/test.js
+      - run: node --icu-data-dir=node_modules/full-icu scripts/test.js
 
       - run:
           name: Send coverage report

--- a/circle.yml
+++ b/circle.yml
@@ -47,17 +47,25 @@ jobs:
           key: node-modules-{{ checksum "yarn.lock" }}
 
       - run:
-          name: Add the entire ICU (full-icu)
-          command: npm install full-icu
+          name: Testing full-icu
+          command: env NODE_ICU_DATA=./node_modules/full-icu node test-full-icu.js
 
       - run:
           name: Install dependencies
           command: yarn install
 
+      - run:
+          name: Testing full-icu
+          command: env NODE_ICU_DATA=./node_modules/full-icu node test-full-icu.js
+
       - save_cache:
           key: node-modules-{{ checksum "yarn.lock" }}
           paths:
               - node_modules
+
+      - run:
+          name: Testing full-icu
+          command: env NODE_ICU_DATA=./node_modules/full-icu node test-full-icu.js
 
       - run: env NODE_ICU_DATA=./node_modules/full-icu node scripts/test.js
 

--- a/circle.yml
+++ b/circle.yml
@@ -31,12 +31,16 @@ jobs:
           key: node-modules-{{ checksum "yarn.lock" }}
 
       - run:
-          name: Add the entire ICU (full-icu)
-          command: yarn add full-icu -W
+          name: Add the entire ICU (full-icu) 1
+          command: node install full-icu
 
       - run:
           name: Install dependencies
           command: yarn install
+
+      - run:
+          name: Add the entire ICU (full-icu) 2
+          command: node install full-icu
 
       - save_cache:
           key: node-modules-{{ checksum "yarn.lock" }}

--- a/circle.yml
+++ b/circle.yml
@@ -28,20 +28,16 @@ jobs:
           command: node -v
 
       - run:
-          name: List installed node versions
-          command: nvm ls
+          name: Print node version
+          command: npm install full-icu
 
       - run:
-          name: (Re)Install node with full-icu
-          command: nvm install -s v8 --with-intl=full-icu --download=all
-
-      - run:
-          name: Print node version again
-          command: node -v
+          name: pwd
+          command: pwd
 
       - run:
           name: Testing full-icu
-          command: node test-full-icu.js
+          command: env NODE_ICU_DATA=./node_modules/full-icu node test-full-icu.js
 
       - run:
           name: Install build tools
@@ -63,7 +59,7 @@ jobs:
           paths:
               - node_modules
 
-      - run: env NODE_ICU_DATA=/node_modules/full-icu node scripts/test.js
+      - run: env NODE_ICU_DATA=./node_modules/full-icu node scripts/test.js
 
       - run:
           name: Send coverage report

--- a/circle.yml
+++ b/circle.yml
@@ -32,7 +32,7 @@ jobs:
 
       - run:
           name: Add the entire ICU (full-icu) 1
-          command: node install full-icu
+          command: npm install full-icu
 
       - run:
           name: Install dependencies

--- a/circle.yml
+++ b/circle.yml
@@ -4,11 +4,16 @@ workflows:
   version: 2
   test_n_deploy:
     jobs:
-#      - test-linter
-
-      - test-node8:
+      - test-node8
 #          requires:
 #            - test-linter
+
+#      - build-docs:
+#          requires:
+#            - test-node6
+#            - test-node8
+
+      - test-linter
 
 jobs:
   test-node8: &test-template

--- a/circle.yml
+++ b/circle.yml
@@ -4,6 +4,8 @@ workflows:
   version: 2
   test_n_deploy:
     jobs:
+      - test-linter
+
       - test-node8
 #          requires:
 #            - test-linter
@@ -12,8 +14,6 @@ workflows:
 #          requires:
 #            - test-node6
 #            - test-node8
-
-      - test-linter
 
 jobs:
   test-node8: &test-template
@@ -31,16 +31,16 @@ jobs:
           key: node-modules-{{ checksum "yarn.lock" }}
 
       - run:
-          name: Add the entire ICU (full-icu) 1
-          command: npm install full-icu
+          name: Add the entire ICU (full-icu)
+          command: yarn add full-icu -W
 
       - run:
           name: Install dependencies
           command: yarn install
 
       - run:
-          name: Add the entire ICU (full-icu) 2
-          command: npm install full-icu
+          name: Add the entire ICU (full-icu)
+          command: yarn add full-icu -W
 
       - save_cache:
           key: node-modules-{{ checksum "yarn.lock" }}

--- a/circle.yml
+++ b/circle.yml
@@ -47,7 +47,7 @@ jobs:
           paths:
               - node_modules
 
-      - run: node --icu-data-dir=node_modules/full-icu scripts/test.js
+      - run: env NODE_ICU_DATA=/node_modules/full-icu node scripts/test.js
 
       - run:
           name: Send coverage report

--- a/circle.yml
+++ b/circle.yml
@@ -34,12 +34,16 @@ jobs:
           name: Install dependencies
           command: yarn install
 
+      - run:
+          name: Embed the entire ICU (full-icu)
+          command: yarn add full-icu -W
+
       - save_cache:
           key: node-modules-{{ checksum "yarn.lock" }}
           paths:
               - node_modules
 
-      - run: node scripts/test.js
+      - run: NODE_ICU_DATA=./node_modules/full-icu node scripts/test.js
 
       - run:
           name: Send coverage report

--- a/circle.yml
+++ b/circle.yml
@@ -31,19 +31,17 @@ jobs:
           key: node-modules-{{ checksum "yarn.lock" }}
 
       - run:
-          name: Install dependencies
-          command: yarn install
+          name: Add the entire ICU (full-icu)
+          command: yarn add full-icu -W
 
       - run:
-          name: Embed the entire ICU (full-icu)
-          command: yarn add full-icu -W
+          name: Install dependencies
+          command: yarn install
 
       - save_cache:
           key: node-modules-{{ checksum "yarn.lock" }}
           paths:
               - node_modules
-
-      - run: npm list --depth=0
 
       - run: NODE_ICU_DATA=./node_modules/full-icu node scripts/test.js
 

--- a/circle.yml
+++ b/circle.yml
@@ -24,6 +24,26 @@ jobs:
       - checkout
 
       - run:
+          name: Print node version
+          command: node -v
+
+      - run:
+          name: List installed node versions
+          command: nvm ls
+
+      - run:
+          name: (Re)Install node with full-icu
+          command: nvm install -s v8 --with-intl=full-icu --download=all
+
+      - run:
+          name: Print node version again
+          command: node -v
+
+      - run:
+          name: Testing full-icu
+          command: node test-full-icu.js
+
+      - run:
           name: Install build tools
           command: sudo yarn global add codecov yalc
 
@@ -32,15 +52,11 @@ jobs:
 
       - run:
           name: Add the entire ICU (full-icu)
-          command: yarn add full-icu -W
+          command: npm install full-icu
 
       - run:
           name: Install dependencies
           command: yarn install
-
-      - run:
-          name: Add the entire ICU (full-icu)
-          command: yarn add full-icu -W
 
       - save_cache:
           key: node-modules-{{ checksum "yarn.lock" }}

--- a/circle.yml
+++ b/circle.yml
@@ -43,6 +43,8 @@ jobs:
           paths:
               - node_modules
 
+      - run: npm list --depth=0
+
       - run: NODE_ICU_DATA=./node_modules/full-icu node scripts/test.js
 
       - run:

--- a/circle.yml
+++ b/circle.yml
@@ -4,11 +4,11 @@ workflows:
   version: 2
   test_n_deploy:
     jobs:
-      - test-linter
+#      - test-linter
 
       - test-node8:
-          requires:
-            - test-linter
+#          requires:
+#            - test-linter
 
 #      - build-docs:
 #          requires:

--- a/packages/core/src/select.js
+++ b/packages/core/src/select.js
@@ -26,7 +26,6 @@ const _plural = type => (i18n: any) => ({
   other,
   ...pluralForms
 }: PluralProps): string => {
-  console.log(culture)
   const diff = value - offset
   const intl = new Intl.NumberFormat(culture)
   const diffAsString = intl.format(diff)

--- a/packages/core/src/select.js
+++ b/packages/core/src/select.js
@@ -11,21 +11,30 @@ type PluralForms = {
 
 type PluralProps = {
   value: number,
-  offset?: number
+  offset?: number,
+  culture?: string
 } & PluralForms
+
+declare var Intl: {
+  NumberFormat: any
+}
 
 const _plural = type => (i18n: any) => ({
   value,
   offset = 0,
+  culture = "en-UK",
   other,
   ...pluralForms
 }: PluralProps): string => {
+  console.log(culture)
   const diff = value - offset
+  const intl = new Intl.NumberFormat(culture)
+  const diffAsString = intl.format(diff)
   const translation =
     pluralForms[value.toString()] || // exact match
     pluralForms[i18n.pluralForm(diff, type)] || // plural form
     other // fallback
-  return translation.replace("#", diff.toString())
+  return translation.replace("#", diffAsString)
 }
 
 const plural = _plural("cardinal")

--- a/packages/core/src/select.test.js
+++ b/packages/core/src/select.test.js
@@ -61,10 +61,10 @@ describe("plural", function() {
     expect(
       p({
         value: 1,
-        other: "# كتاب",
+        other: "لدي # كتاب",
         culture: "ar-AS"
       })
-    ).toEqual("١ كتاب")
+    ).toEqual("لدي ١ كتاب")
   })
 })
 

--- a/packages/core/src/select.test.js
+++ b/packages/core/src/select.test.js
@@ -49,6 +49,30 @@ describe("plural", function() {
         other: "Their and # books"
       })
     ).toEqual("Their and 4 books")
+
+    expect(
+      p({
+        value: 1,
+        other: "# كتاب",
+        culture: "ar"
+      })
+    ).toEqual("١ " + "كتاب")
+
+    expect(
+      p({
+        value: 1,
+        other: "# كتاب",
+        culture: "en"
+      })
+    ).toEqual("1 " + "كتاب")
+
+    expect(
+      p({
+        value: 1,
+        other: "# كتاب",
+        culture: "ar-AS"
+      })
+    ).toEqual("١ " + "كتاب")
   })
 })
 

--- a/packages/core/src/select.test.js
+++ b/packages/core/src/select.test.js
@@ -54,17 +54,9 @@ describe("plural", function() {
       p({
         value: 1,
         other: "# كتاب",
-        culture: "ar"
+        culture: "en-UK"
       })
-    ).toEqual("١ " + "كتاب")
-
-    expect(
-      p({
-        value: 1,
-        other: "# كتاب",
-        culture: "en"
-      })
-    ).toEqual("1 " + "كتاب")
+    ).toEqual("1 كتاب")
 
     expect(
       p({
@@ -72,7 +64,7 @@ describe("plural", function() {
         other: "# كتاب",
         culture: "ar-AS"
       })
-    ).toEqual("١ " + "كتاب")
+    ).toEqual("١ كتاب")
   })
 })
 

--- a/packages/core/src/select.test.js
+++ b/packages/core/src/select.test.js
@@ -2,6 +2,19 @@
 import { plural, select, selectOrdinal } from "./select"
 import { setupI18n } from "@lingui/core"
 
+const hasFullICU = (() => {
+  try {
+    const january = new Date(9e8);
+    const spanish = new Intl.DateTimeFormat('es', { month: 'long' });
+    return spanish.format(january) === 'enero';
+  } catch (err) {
+    console.log(err)
+    return false;
+  }
+})();
+
+console.log("hasFullICU:", hasFullICU)
+
 describe("plural", function() {
   const i18n = setupI18n({
     language: "en",

--- a/packages/react/src/Select.js
+++ b/packages/react/src/Select.js
@@ -14,7 +14,8 @@ type PluralProps = {
   two?: any,
   few?: any,
   many?: any,
-  other: any
+  other: any,
+  culture?: string
 } & withI18nProps &
   RenderProps
 

--- a/packages/react/src/Select.test.js
+++ b/packages/react/src/Select.test.js
@@ -74,6 +74,20 @@ describe("Categories", function() {
       expect(t()).toEqual("5 knih")
     })
 
+    it("should use plural forms based on culture", function() {
+      const node = mount(
+        <Plural value="1000" one="#" other="#" culture="de" />,
+        languageContext("de")
+      )
+
+      const t = () => node.find("Render").text()
+
+      expect(t()).toEqual("1.000")
+
+      node.setProps({ value: 2000 })
+      expect(t()).toEqual("2.000")
+    })
+
     it("should offset value", function() {
       const node = mount(
         <Plural

--- a/packages/react/src/Select.test.js
+++ b/packages/react/src/Select.test.js
@@ -76,7 +76,7 @@ describe("Categories", function() {
 
     it("should use plural forms based on culture", function() {
       const node = mount(
-        <Plural value="1000" one="#" other="#" culture="de" />,
+        <Plural value="1000" one="#" other="#" culture="de-DE" />,
         languageContext("de")
       )
 

--- a/test-full-icu.js
+++ b/test-full-icu.js
@@ -1,0 +1,2 @@
+console.log("*** Testing full-icu ***");
+console.log(new Intl.DateTimeFormat('es',{month:'long'}).format(new Date(9E8)));


### PR DESCRIPTION
There are multiple types of numerals, even the arabic numberals have multiple representations: https://en.wikipedia.org/wiki/Eastern_Arabic_numerals#Numerals

This change is adding support for different type of "cultures" by taking advantage of the standard [Intl.NumberFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat)

The language itself is not enough to format the numerals because there are languages which support multiple formats.

Questions:
1. Should both the arguments of the Intl.NumberFormat constructor - `locales` and `options` - be further exposed through the js-lingui API?
2. Should the `locales` be further exposed as `locales` or `culture`? Other languages are using culture, or cultureNames...
3. Should the information regarding the culture (or locales) be passed as arguments as in this PR or stored in `i18n`?