### PR TITLE
Support locales with hyphens in Lingui Loader

### DIFF
--- a/packages/cli/src/api/compile.js
+++ b/packages/cli/src/api/compile.js
@@ -93,7 +93,7 @@ export function compile(message: string) {
 }
 
 export function createCompiledCatalog(locale: string, messages: CatalogType) {
-  const [language] = locale.split("_")
+  const [language] = locale.split(/[_-]/)
   const pluralRules = plurals[language]
 
   const compiledMessages = R.keys(messages).map(key => {


### PR DESCRIPTION
This adds further support for locales that have a hyphen rather than an underscore (e.g. `pt-BR`). I ran into an error when trying to do the following in version `2.0.8`:
```
catalog = await import( // eslint-disable-line function-paren-newline
      /* webpackMode: "lazy", webpackChunkName: "i18n-[index]" */
        '@lingui/loader!../locale/pt-BR/messages.json');
```
This was the error:
```
Error in @lingui/loader!../locale/pt-BR/messages.json
Module build failed: TypeError: Cannot read property 'toString' of undefined
    at createCompiledCatalog (/Users/spencermefford/dev/project/node_modules/@lingui/cli/api/compile.js:101:110)
    at Object._default (/Users/spencermefford/dev/project/node_modules/@lingui/loader/index.js:43:41)
```