### PR TITLE
Order extracted messages alphabetically by message ID

### DIFF
--- a/packages/cli/src/api/__snapshots__/extract.test.js.snap
+++ b/packages/cli/src/api/__snapshots__/extract.test.js.snap
@@ -50,3 +50,53 @@ Object {
   },
 }
 `;
+
+exports[`order should order messages alphabetically 1`] = `
+Object {
+  en: Object {
+    LabelA: Object {
+      translation: A,
+    },
+    LabelB: Object {
+      translation: B,
+    },
+    LabelC: Object {
+      translation: C,
+    },
+    LabelD: Object {
+      translation: D,
+    },
+  },
+  fr: Object {
+    LabelA: Object {
+      translation: A,
+    },
+    LabelB: Object {
+      translation: B,
+    },
+    LabelC: Object {
+      translation: C,
+    },
+    LabelD: Object {
+      translation: D,
+    },
+  },
+}
+`;
+
+exports[`order should order messages alphabetically 2`] = `
+Object {
+  en: Array [
+    LabelA,
+    LabelB,
+    LabelC,
+    LabelD,
+  ],
+  fr: Array [
+    LabelA,
+    LabelB,
+    LabelC,
+    LabelD,
+  ],
+}
+`;

--- a/packages/cli/src/api/extract.js
+++ b/packages/cli/src/api/extract.js
@@ -78,3 +78,18 @@ export function collect(buildDir: string) {
 export function cleanObsolete(catalogs: AllCatalogsType) {
   return R.map(R.filter(message => !message.obsolete), catalogs)
 }
+
+export function order(catalogs: AllCatalogsType) {
+  return R.map(orderByMessageId, catalogs)
+}
+
+function orderByMessageId(messages) {
+  const orderedMessages = {}
+  Object.keys(messages)
+    .sort()
+    .forEach(function(key) {
+      orderedMessages[key] = messages[key]
+    })
+
+  return orderedMessages
+}

--- a/packages/cli/src/api/extract.test.js
+++ b/packages/cli/src/api/extract.test.js
@@ -156,3 +156,51 @@ describe("cleanObsolete", function() {
     expect(cleanObsolete(catalogs)).toMatchSnapshot()
   })
 })
+
+describe("order", function() {
+  it("should order messages alphabetically", function() {
+    const { order } = require("./extract")
+
+    const catalogs = {
+      en: {
+        LabelB: {
+          translation: "B"
+        },
+        LabelA: {
+          translation: "A"
+        },
+        LabelD: {
+          translation: "D"
+        },
+        LabelC: {
+          translation: "C"
+        }
+      },
+      fr: {
+        LabelB: {
+          translation: "B"
+        },
+        LabelA: {
+          translation: "A"
+        },
+        LabelD: {
+          translation: "D"
+        },
+        LabelC: {
+          translation: "C"
+        }
+      }
+    }
+
+    const orderedCatalogs = order(catalogs)
+
+    // Test that the message content is the same as before
+    expect(orderedCatalogs).toMatchSnapshot()
+
+    // Jest snapshot order the keys automatically, so test that the key order explicitly
+    expect({
+      en: Object.keys(orderedCatalogs.en),
+      fr: Object.keys(orderedCatalogs.fr)
+    }).toMatchSnapshot()
+  })
+})

--- a/packages/cli/src/lingui-extract.js
+++ b/packages/cli/src/lingui-extract.js
@@ -8,7 +8,7 @@ import program from "commander"
 import { getConfig } from "@lingui/conf"
 
 import type { LinguiConfig, CatalogFormat } from "./api/formats/types"
-import { extract, collect, cleanObsolete } from "./api/extract"
+import { extract, collect, cleanObsolete, order } from "./api/extract"
 import { printStats } from "./api/stats"
 
 type ExtractOptions = {|
@@ -48,7 +48,7 @@ export default function command(
   console.log("Collecting all messages…")
   const clean = options.clean ? cleanObsolete : id => id
   const catalog = collect(buildDir)
-  const catalogs = clean(convertFormat.merge(catalog))
+  const catalogs = order(clean(convertFormat.merge(catalog)))
   options.verbose && console.log()
 
   console.log("Writing message catalogues…")


### PR DESCRIPTION
This is my try to implement #229.

- I did not work with ramda before, so I am sure there is a better way to implement `orderByMessageId`.
- Only a part of the tests ran locally for me, so I'm going to see what CI says
- I also did not test the actual output of the built command, since the build failed for me locally
- Feel free to completely discard this if there is a better way to implement it 😄 