### PR TITLE
support locales with hyphens in cli compile

### DIFF
--- a/packages/cli/src/lingui-compile.js
+++ b/packages/cli/src/lingui-compile.js
@@ -41,7 +41,7 @@ function command(config, format, options) {
   console.log("Compiling message catalogs…")
 
   return locales.map(locale => {
-    const [language] = locale.split("_")
+    const [language] = locale.split(/[_-]/)
     if (!plurals[language]) {
       console.log(
         chalk.red(


### PR DESCRIPTION
my locale files are written with an hyphen, thanks to #219.

unfortunately `lingui compile` doesn't support them yet,
this fixed it on my project. 😄 

---

this was the log emitted before the changes.

```
Error: Invalid locale en-US (missing plural rules)!
Error: Invalid locale pt-BR (missing plural rules)!
Error: Invalid locale zh-CN (missing plural rules)!
```

they are all supported by `make-plural` package.