### PR TITLE
Add lingui init command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+<a name="2.4.0"></a>
+## [2.4.0 (unreleased)](https://github.com/lingui/js-lingui/compare/v2.3.0...v2.4.0) (TBA)
+
+Support for Create React App.
+
+### New Features
+
+* New `lingui init` command which detects project type and install all required packages
+* `lingui extract` detects ``create-react-app` projects and extracts messages using
+  ``rect-app`` babel preset
+
 <a name="2.3.0"></a>
 ## [2.3.0](https://github.com/lingui/js-lingui/compare/v2.2.0...v2.3.0) (2018-07-23)
 

--- a/docs/ref/cli.rst
+++ b/docs/ref/cli.rst
@@ -67,6 +67,20 @@ or locally:
 Commands
 ========
 
+``init``
+--------
+
+.. lingui-cli:: init [--dry-run]
+
+Installs all required packages based on project type. Recognized projects are:
+
+- `Create React App <https://github.com/facebook/create-react-app>`_
+- General React app
+
+.. lingui-cli-option:: --dry-run
+
+Output commands which would run, but don't execute them.
+
 ``add-locale``
 --------------
 

--- a/docs/tutorials/react.rst
+++ b/docs/tutorials/react.rst
@@ -67,6 +67,9 @@ We're trying to use most of them to show the full power of jsLingui.
 
 Let's start with the three major packages:
 
+``@lingui/cli``
+   CLI for i18n management and working with message catalogs
+
 ``@lingui/react``
    React components for translation and formatting
 
@@ -74,17 +77,31 @@ Let's start with the three major packages:
    Transforms messages wrapped in components from ``@lingui/react`` to ICU
    MessageFormat and validates them
 
-``@lingui/cli``
-   CLI for working with message catalogs
-
-1. Install ``@lingui/babel-preset-react`` as a development dependency,
-   ``@lingui/react`` as a runtime dependency and ``@lingui/cli`` globally:
+1. ``@lingui/cli`` comes with handy :cli:`init` command, which detects the
+   project type and install all required packages automatically. Feel free to run
+   it with ``lingui init --dry-run`` option to inspect what commands will be run:
 
    .. code-block:: shell
 
       npm install -g @lingui/cli
-      npm install --save @lingui/react
-      npm install --save-dev @lingui/babel-preset-react
+      lingui init
+
+   Yarn is supported as well:
+
+   .. code-block:: shell
+
+      yarn global add @lingui/cli
+      lingui init
+
+   .. note::
+
+      Under the hood it installs ``@lingui/babel-preset-react`` as a development
+      dependency and ``@lingui/react`` as a runtime dependency (in React projects):
+
+      .. code-block:: shell
+
+         npm install --save @lingui/react
+         npm install --save-dev @lingui/babel-preset-react
 
 2. Add ``@lingui/babel-preset-react`` preset to Babel config (e.g: ``.babelrc``):
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -50,6 +50,7 @@
     "cli-table": "^0.3.1",
     "commander": "^2.16.0",
     "glob": "^7.1.2",
+    "inquirer": "^6.1.0",
     "make-plural": "^4.1.1",
     "messageformat-parser": "^2.0.0",
     "mkdirp": "^0.5.1",

--- a/packages/cli/src/lingui-init.js
+++ b/packages/cli/src/lingui-init.js
@@ -1,0 +1,56 @@
+// @flow
+import path from "path"
+import fs from "fs"
+import program from "commander"
+import { execSync } from "child_process"
+
+import { projectType, detect } from "./api/detect"
+
+function hasYarn() {
+  return fs.existsSync(path.resolve("yarn.lock"))
+}
+
+function makeInstall() {
+  const withYarn = hasYarn()
+
+  return (packageName, dev = false) =>
+    withYarn
+      ? `yarn add ${dev ? "--dev " : ""}${packageName}`
+      : `npm install ${dev ? "--save-dev" : "--save"} ${packageName}`
+}
+
+type CommandInit = {|
+  dryRun: boolean
+|}
+
+export function command(program: CommandInit) {
+  const install = makeInstall()
+
+  const type = detect()
+  const usesReact = type === projectType.CRA || type === projectType.REACT
+
+  const commands = [
+    ...(usesReact
+      ? [install("@lingui/react"), install("@lingui/babel-preset-react", true)]
+      : [install("@lingui/core"), install("@lingui/babel-preset-js", true)])
+  ].filter(Boolean)
+
+  if (program.dryRun) {
+    commands.forEach(command => console.log(command))
+  } else {
+    commands.forEach(command => execSync(command))
+  }
+
+  return true
+}
+
+if (require.main === module) {
+  program
+    .option(
+      "--dry-run",
+      "Output commands that would be run, but don't execute them."
+    )
+    .parse(process.argv)
+
+  command(program)
+}

--- a/packages/cli/src/lingui-init.test.js
+++ b/packages/cli/src/lingui-init.test.js
@@ -1,0 +1,74 @@
+import mockFs from "mock-fs"
+import { command } from "./lingui-init"
+import { mockConsole } from "./mocks"
+
+describe("lingui init", function() {
+  afterEach(mockFs.restore)
+
+  it("should use yarn when available", () => {
+    mockFs({
+      "yarn.lock": mockFs.file(),
+      "package.json": JSON.stringify({
+        dependencies: {}
+      })
+    })
+
+    mockConsole(console => {
+      expect(command({ dryRun: true })).toBeTruthy()
+      expect(console.log).toBeCalledWith("yarn add @lingui/core")
+      expect(console.log).toBeCalledWith(
+        "yarn add --dev @lingui/babel-preset-js"
+      )
+    })
+  })
+
+  it("should use npm when yarn isn't available", () => {
+    mockFs({
+      "package.json": JSON.stringify({
+        dependencies: {}
+      })
+    })
+
+    mockConsole(console => {
+      expect(command({ dryRun: true })).toBeTruthy()
+      expect(console.log).toBeCalledWith("npm install --save @lingui/core")
+      expect(console.log).toBeCalledWith(
+        "npm install --save-dev @lingui/babel-preset-js"
+      )
+    })
+  })
+
+  it("should detect create-react-app project", () => {
+    mockFs({
+      "package.json": JSON.stringify({
+        dependencies: {
+          "react-scripts": "2.0.0"
+        }
+      })
+    })
+
+    mockConsole(console => {
+      expect(command({ dryRun: true })).toBeTruthy()
+      expect(console.log).toBeCalledWith("npm install --save @lingui/react")
+      expect(console.log).toBeCalledWith(
+        "npm install --save-dev @lingui/babel-preset-react"
+      )
+    })
+  })
+
+  it("should install core only for other projects", () => {
+    mockFs({
+      "package.json": JSON.stringify({
+        dependencies: {}
+      })
+    })
+
+    mockConsole(console => {
+      expect(command({ dryRun: true })).toBeTruthy()
+      expect(console.log).toBeCalledWith("npm install --save @lingui/core")
+      expect(console.log).toBeCalledWith(
+        "npm install --save-dev @lingui/babel-preset-js"
+      )
+    })
+  })
+})

--- a/packages/cli/src/lingui-init.test.js
+++ b/packages/cli/src/lingui-init.test.js
@@ -1,73 +1,120 @@
 import mockFs from "mock-fs"
-import { command } from "./lingui-init"
+import { installPackages } from "./lingui-init"
 import { mockConsole } from "./mocks"
+import inquirer from "inquirer"
 
 describe("lingui init", function() {
-  afterEach(mockFs.restore)
+  let inquirerPrompt
 
-  it("should use yarn when available", () => {
-    mockFs({
-      "yarn.lock": mockFs.file(),
-      "package.json": JSON.stringify({
-        dependencies: {}
-      })
-    })
-
-    mockConsole(console => {
-      expect(command({ dryRun: true })).toBeTruthy()
-      expect(console.log).toBeCalledWith("yarn add @lingui/core")
-      expect(console.log).toBeCalledWith(
-        "yarn add --dev @lingui/babel-preset-js"
-      )
-    })
+  beforeAll(() => {
+    inquirerPrompt = inquirer.prompt
+    inquirer.prompt = jest.fn()
   })
 
-  it("should use npm when yarn isn't available", () => {
-    mockFs({
-      "package.json": JSON.stringify({
-        dependencies: {}
-      })
-    })
-
-    mockConsole(console => {
-      expect(command({ dryRun: true })).toBeTruthy()
-      expect(console.log).toBeCalledWith("npm install --save @lingui/core")
-      expect(console.log).toBeCalledWith(
-        "npm install --save-dev @lingui/babel-preset-js"
-      )
-    })
+  afterAll(() => {
+    inquirer.prompt = inquirerPrompt
   })
 
-  it("should detect create-react-app project", () => {
-    mockFs({
-      "package.json": JSON.stringify({
-        dependencies: {
-          "react-scripts": "2.0.0"
-        }
-      })
-    })
-
-    mockConsole(console => {
-      expect(command({ dryRun: true })).toBeTruthy()
-      expect(console.log).toBeCalledWith("npm install --save @lingui/react")
-      expect(console.log).toBeCalledWith(
-        "npm install --save-dev @lingui/babel-preset-react"
-      )
-    })
+  afterEach(() => {
+    mockFs.restore()
+    inquirer.prompt.mockReset()
   })
 
-  it("should install core only for other projects", () => {
-    mockFs({
-      "package.json": JSON.stringify({
-        dependencies: {}
-      })
+  describe("install packages", function() {
+    beforeEach(() => {
+      inquirer.prompt = jest.fn(prompt =>
+        Promise.resolve({ [prompt.name]: true })
+      )
     })
 
-    mockConsole(console => {
-      expect(command({ dryRun: true })).toBeTruthy()
-      expect(console.log).toBeCalledWith("npm install --save @lingui/core")
-      expect(console.log).toBeCalledWith(
-        "npm install --save-dev @lingui/babel-preset-js"
+    it("should use yarn when available", () => {
+      mockFs({
+        "yarn.lock": mockFs.file(),
+        "package.json": JSON.stringify({
+          dependencies: {}
+        })
+      })
+
+      expect.assertions(3)
+      return mockConsole(console =>
+        installPackages(true).then(result => {
+          expect(result).toBeTruthy()
+          expect(console.log).toBeCalledWith("yarn add @lingui/core")
+          expect(console.log).toBeCalledWith(
+            "yarn add --dev @lingui/babel-preset-js"
+          )
+        })
+      )
+    })
+
+    it("should use npm when yarn isn't available", () => {
+      mockFs({
+        "package.json": JSON.stringify({
+          dependencies: {}
+        })
+      })
+
+      expect.assertions(3)
+      return mockConsole(console =>
+        installPackages(true)
+          .then(result => {
+            expect(result).toBeTruthy()
+            expect(console.log).toBeCalledWith(
+              "npm install --save @lingui/core"
+            )
+            expect(console.log).toBeCalledWith(
+              "npm install --save-dev @lingui/babel-preset-js"
+            )
+          })
+          .catch(error => console.log({ error }))
+      )
+    })
+
+    it("should detect create-react-app project", () => {
+      mockFs({
+        "package.json": JSON.stringify({
+          dependencies: {
+            "react-scripts": "2.0.0"
+          }
+        })
+      })
+
+      expect.assertions(3)
+      return mockConsole(console =>
+        installPackages(true)
+          .then(result => {
+            expect(result).toBeTruthy()
+            expect(console.log).toBeCalledWith(
+              "npm install --save @lingui/react"
+            )
+            expect(console.log).toBeCalledWith(
+              "npm install --save-dev @lingui/babel-preset-react"
+            )
+          })
+          .catch(error => console.log({ error }))
+      )
+    })
+
+    it("should install core only for other projects", () => {
+      mockFs({
+        "package.json": JSON.stringify({
+          dependencies: {}
+        })
+      })
+
+      expect.assertions(3)
+      return mockConsole(console =>
+        installPackages(true)
+          .then(result => {
+            expect(result).toBeTruthy()
+            expect(console.log).toBeCalledWith(
+              "npm install --save @lingui/core"
+            )
+            expect(console.log).toBeCalledWith(
+              "npm install --save-dev @lingui/babel-preset-js"
+            )
+          })
+          .catch(error => console.log({ error }))
       )
     })
   })

--- a/packages/cli/src/lingui.js
+++ b/packages/cli/src/lingui.js
@@ -11,6 +11,7 @@ try {
 
 program
   .version(version)
+  .command("init", "Install all required packages")
   .command(
     "add-locale [locales...]",
     "Add new locale (generate empty message catalogues for this locale)"

--- a/packages/cli/src/mocks.js
+++ b/packages/cli/src/mocks.js
@@ -1,4 +1,8 @@
 export function mockConsole(testCase, mock = {}) {
+  function restoreConsole() {
+    global.console = originalConsole
+  }
+
   const originalConsole = global.console
 
   const defaults = {
@@ -11,12 +15,18 @@ export function mockConsole(testCase, mock = {}) {
     ...mock
   }
 
+  let result
   try {
-    testCase(global.console)
+    result = testCase(global.console)
   } catch (e) {
-    global.console = originalConsole
+    restoreConsole()
     throw e
   }
 
-  global.console = originalConsole
+  if (result && typeof result.then === "function") {
+    return result.then(restoreConsole).catch(restoreConsole)
+  } else {
+    restoreConsole()
+    return result
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1287,6 +1287,10 @@ chardet@^0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
 
+chardet@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.5.0.tgz#fe3ac73c00c3d865ffcc02a0682e2c20b6a06029"
+
 cheerio@^1.0.0-rc.2:
   version "1.0.0-rc.2"
   resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.2.tgz#4b9f53a81b27e4d5dac31c0ffd0cfa03cc6830db"
@@ -2342,6 +2346,14 @@ external-editor@^2.1.0:
     iconv-lite "^0.4.17"
     tmp "^0.0.33"
 
+external-editor@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.0.0.tgz#dc35c48c6f98a30ca27a20e9687d7f3c77704bb6"
+  dependencies:
+    chardet "^0.5.0"
+    iconv-lite "^0.4.22"
+    tmp "^0.0.33"
+
 extglob@^0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-0.3.2.tgz#2e18ff3d2f49ab2765cec9023f011daa8d8349a1"
@@ -2827,7 +2839,13 @@ iconv-lite@0.4.19:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
-iconv-lite@^0.4.17, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@^0.4.17:
+  version "0.4.21"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.21.tgz#c47f8733d02171189ebc4a400f3218d348094798"
+  dependencies:
+    safer-buffer "^2.1.0"
+
+iconv-lite@^0.4.22, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   version "0.4.23"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.23.tgz#297871f63be507adcfbfca715d0cd0eed84e9a63"
   dependencies:
@@ -2914,6 +2932,24 @@ inquirer@^5.2.0:
     mute-stream "0.0.7"
     run-async "^2.2.0"
     rxjs "^5.5.2"
+    string-width "^2.1.0"
+    strip-ansi "^4.0.0"
+    through "^2.3.6"
+
+inquirer@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.1.0.tgz#8f65c7b31c498285f4ddf3b742ad8c487892040b"
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.0"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^3.0.0"
+    figures "^2.0.0"
+    lodash "^4.3.0"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rxjs "^6.1.0"
     string-width "^2.1.0"
     strip-ansi "^4.0.0"
     through "^2.3.6"
@@ -5181,6 +5217,12 @@ rxjs@^5.5.2:
   dependencies:
     symbol-observable "1.0.1"
 
+rxjs@^6.1.0:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.2.2.tgz#eb75fa3c186ff5289907d06483a77884586e1cf9"
+  dependencies:
+    tslib "^1.9.0"
+
 safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
@@ -5715,6 +5757,10 @@ tr46@^1.0.1:
 trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
+
+tslib@^1.9.0:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
 
 tty-browserify@0.0.0:
   version "0.0.0"


### PR DESCRIPTION
This command installs all required packages based on project type (e.g. React vs VanillaJS). In future it should also support bootstrapping config, adding patterns to `.gitignore`, etc.