### PR TITLE
Disable eslint in generated message catalog files

### DIFF
--- a/packages/cli/src/api/compile.js
+++ b/packages/cli/src/api/compile.js
@@ -135,7 +135,7 @@ export function createCompiledCatalog(
     )
   )
 
-  return generate(ast, {
+  return '/* eslint-disable */' + generate(ast, {
     minified: true
   }).code
 }

--- a/packages/loader/test/__snapshots__/loader.test.js.snap
+++ b/packages/loader/test/__snapshots__/loader.test.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`lingui-loader should compile catalog 1`] = `module.exports={languageData:{"plurals":function(n,ord){var s=String(n).split("."),v0=!s[1],t0=Number(s[0])==n,n10=t0&&s[0].slice(-1),n100=t0&&s[0].slice(-2);if(ord)return n10==1&&n100!=11?"one":n10==2&&n100!=12?"two":n10==3&&n100!=13?"few":"other";return n==1&&v0?"one":"other"}},messages:{"Hello World":"Hello World","My name is {name}":function(a){return["My name is ",a("name")]}}};`;
+exports[`lingui-loader should compile catalog 1`] = `/* eslint-disable */module.exports={languageData:{"plurals":function(n,ord){var s=String(n).split("."),v0=!s[1],t0=Number(s[0])==n,n10=t0&&s[0].slice(-1),n100=t0&&s[0].slice(-2);if(ord)return n10==1&&n100!=11?"one":n10==2&&n100!=12?"two":n10==3&&n100!=13?"few":"other";return n==1&&v0?"one":"other"}},messages:{"Hello World":"Hello World","My name is {name}":function(a){return["My name is ",a("name")]}}};`;


### PR DESCRIPTION
This change improves support for non-ejected `create-react-app` apps by effectively disabling eslint in generated build artefacts (`.js` catalog files).