### PR TITLE
Update react-intl.rst

### DIFF
--- a/docs/misc/react-intl.rst
+++ b/docs/misc/react-intl.rst
@@ -216,6 +216,7 @@ components in both variables and the message itself.
 
       <Plural
          id="welcome"
+         value={number}
          one={<>Hello <b>{name}</b>, you have <NumberFormat value={number} /> message.</>}
          other={<>Hello <b>{name}</b>, you have <NumberFormat value={number} /> messages.</>}
       />

--- a/docs/misc/react-intl.rst
+++ b/docs/misc/react-intl.rst
@@ -216,8 +216,8 @@ components in both variables and the message itself.
 
       <Plural
          id="welcome"
-         one={Hello <b>{name}</b>, you have <NumberFormat value={number} message.}
-         other={Hello <b>{name}</b>, you have <NumberFormat value={number} messages.}
+         one={<>Hello <b>{name}</b>, you have <NumberFormat value={number} /> message.</>}
+         other={<>Hello <b>{name}</b>, you have <NumberFormat value={number} /> messages.</>}
       />
 
    Even though both variants are syntactically valid in ICU MessageFormat, the second


### PR DESCRIPTION
The code block was invalid:

- forgot to close `<NumberFormat>`
- `one` and `other` params were invalid JSX, since they weren't wrapped in a tag. I wrapped them in a fragment now.