### PR TITLE
fixes to react native docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Documentation uses Sphinx and reStructuredText. Source inside the
 
 2. Run `pipenv install` to setup Python environemnt (requires Python 3.6).
    If you encounter `ValueError('unknown locale: %s' % localename)`,
-   run `export LC_ALL=en_US.UTF-8`, `export LANG=en_US.UTF-8` and try again.
+   run `export LC_ALL=en_US.UTF-8 && export LANG=en_US.UTF-8` and try again.
 
 3. Run `pipenv run make livehtml` to build the docs, watch for changes and preview
    documentation locally at [http://127.0.0.1:8000](http://127.0.0.1:8000).

--- a/docs/tutorials/react-native.rst
+++ b/docs/tutorials/react-native.rst
@@ -121,7 +121,7 @@ example:
     <YourRootComponent someProp="someValue" />
   </I18nProvider>
 
-  const Inbox = (({ markAsRead, i18n }) => {
+  const Inbox = (({ markAsRead }) => {
     return (
       <View>
         <View>
@@ -129,6 +129,7 @@ example:
             <Trans>Message Inbox</Trans>
           </Text>
           <Trans>See all unread messages or</Trans>
+          {/* you can also use the withI18n HOC */}
           <I18n>
             {({ i18n }) => (
               <Button onPress={markAsRead} title={i18n._(t`mark messages as read`)} />
@@ -143,11 +144,7 @@ example:
 
 .. note::
 
-   The important thing about both the :component:`Trans` (and the other provided components)
-   and ``withI18n`` HOC is that when you change the active language (through the
-   ``language`` prop passed to :component:`I18nProvider`), all the components that show
-   translated text will re-render, making sure the UI shows the correct translations. The
-   two approaches are equivalent in their result.
+   There are several ways to render translations: You may use the the :component:`Trans` component, the ``withI18n`` HOC or the :component:`I18n` component that provides a render prop. The important thing about all of these approaches is that when you change the active language (through the ``language`` prop passed to :component:`I18nProvider`), all the components that show translated text will re-render, making sure the UI shows the correct translations. All of these approaches are equivalent in their result.
 
 Internationalization Outside of React Components
 =================================================


### PR DESCRIPTION
hi! I have noticed there were some changes to the RN docs and noticed some minor problems. This should fix them. If you're updating the docs in the future, I can do a review for them if you like.

also, does js-lingui provide an easy way to migrate from "i18n.t`mark messages as read`" to "i18n._(t`mark messages as read`)"? I didn't notice this change happening, what was the reason for it? (the old api is nicely compact). Thanks!