### PR TITLE
Allow symlinks in srcPathDirs config for extract cli

### DIFF
--- a/packages/cli/src/api/extract.js
+++ b/packages/cli/src/api/extract.js
@@ -51,7 +51,7 @@ export function extract(
     )
       return
 
-    if (fs.lstatSync(srcFilename).isDirectory()) {
+    if (fs.statSync(srcFilename).isDirectory()) {
       const subdirs = fs
         .readdirSync(srcFilename)
         .map(filename => path.join(srcFilename, filename))


### PR DESCRIPTION
Hello! Thanks so much for this project. It's been a pleasure to integrate so far. However, my project has an unconventional use case that would benefit from symlinks in srcPathDirs being followed so I'm wondering if we can make a minor change to the extract api.

### Notes
My understanding is that `lstatSync` only differs from `statSync` in that it does not follow symlinks. This change would allow symlinked directories to be read since isDirectory() would now return true and readdirSync already works for symlinks.