### PR TITLE
Remove "macros" from the list of cli babel plugins

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -65,6 +65,7 @@
     "mockdate": "^2.0.2"
   },
   "peerDependencies": {
-    "babel-core": "6.x || ^7.0.0-bridge.0"
+    "babel-core": "6.x || ^7.0.0-bridge.0",
+    "babel-plugin-macros": "^2.4.2"
   }
 }

--- a/packages/cli/src/api/extractors/babel.js
+++ b/packages/cli/src/api/extractors/babel.js
@@ -32,7 +32,6 @@ const extractor: ExtractorType = {
         // here until we have a better way to run extract-messages plugin
         // *after* all plugins/presets.
         // Transform plugins are idempotent, so they can run twice.
-        "macros",
         linguiTransformJs,
         linguiTransformReact,
         [linguiExtractMessages, { localeDir }],


### PR DESCRIPTION
Should fix #359 by emphasis on documentation and peer dependencies rather than forcing babel plugin macros which should already be present