### PR TITLE
fix: macros generates invalid ICU message for nested selects

### DIFF
--- a/packages/macro/src/js.js
+++ b/packages/macro/src/js.js
@@ -117,7 +117,7 @@ export default function({ types: t }) {
           value = props.text
         } else if (t.isCallExpression(attr.value)) {
           props = transformMethod(attr.value, file, { ...props, text: "" })
-          value = props.text
+          value = `{${props.text}}`
         } else {
           value = attr.value.value
         }

--- a/packages/macro/test/fixtures/select/actual.js
+++ b/packages/macro/test/fixtures/select/actual.js
@@ -32,3 +32,14 @@ select('id', {
   female: `She is ${gender}`,
   other: `They is ${gender}`
 });
+
+select('id', {
+  value: "male",
+  "male": select({
+    value: true,
+    true: "He invites guests",
+    other: "He does not invite guests"
+  }),
+  female: `She is ${gender}`,
+  other: `They is ${gender}`
+});

--- a/packages/macro/test/fixtures/select/expected.js
+++ b/packages/macro/test/fixtures/select/expected.js
@@ -1,5 +1,5 @@
 ( /*i18n*/{
-  id: "{gender, select, male {numOfGuests, plural, one {He invites one guest} other {He invites # guests}} female {She is {gender}} other {They is {gender}}}",
+  id: "{gender, select, male {{numOfGuests, plural, one {He invites one guest} other {He invites # guests}}} female {She is {gender}} other {They is {gender}}}",
   values: {
     gender: gender,
     numOfGuests: numOfGuests
@@ -8,7 +8,7 @@
 
 ( /*i18n*/{
   id: "id",
-  defaults: "{0, select, male {1, plural, one {He invites one guest} other {He invites # guests}} female {She is {gender}} other {They is {gender}}}",
+  defaults: "{0, select, male {{1, plural, one {He invites one guest} other {He invites # guests}}} female {She is {gender}} other {They is {gender}}}",
   values: {
     0: "male",
     1: 42,
@@ -18,10 +18,20 @@
 
 /*i18n: description*/({
   id: "id",
-  defaults: "{0, select, male {1, plural, one {He invites one guest} other {He invites # guests}} female {She is {gender}} other {They is {gender}}}",
+  defaults: "{0, select, male {{1, plural, one {He invites one guest} other {He invites # guests}}} female {She is {gender}} other {They is {gender}}}",
   values: {
     0: "male",
     1: 42,
+    gender: gender
+  }
+});
+
+( /*i18n*/{
+  id: "id",
+  defaults: "{0, select, male {{1, select, true {He invites guests} other {He does not invite guests}}} female {She is {gender}} other {They is {gender}}}",
+  values: {
+    0: "male",
+    1: true,
     gender: gender
   }
 });


### PR DESCRIPTION
Babel macros generates invalid ICU messages for nested select/plural.

Example source code:
```js
select('id', {
  value: "male",
  male: select({
    value: true,
    true: "He invites guests",
    other: "He does not invite guests"
  }),
  female: `She is ${gender}`,
  other: `They is ${gender}`
});
```

Expected message:
```
{0, select, male {{1, select, true {He invites guests} other {He does not invite guests}}} female {She is {gender}} other {They is {gender}}}
```

Actual message (missing brackets after `male`):
```
{0, select, male {1, select, true {He invites guests} other {He does not invite guests}} female {She is {gender}} other {They is {gender}}}
```

`lingui complie` throws error for this message:
```
Error: Can't parse message. Please check correct syntax: "{0, select, male {1, select, true {He invites guests} other {He does not invite guests}} female {She is {gender}} other {They is {gender}}}"
```