### PR TITLE
fix: allow leading space in i18n description comments

### DIFF
--- a/packages/babel-plugin-extract-messages/src/index.js
+++ b/packages/babel-plugin-extract-messages/src/index.js
@@ -204,7 +204,7 @@ export default function({ types: t }) {
         const comment =
           path.node.leadingComments &&
           path.node.leadingComments.filter(node =>
-            node.value.startsWith("i18n")
+            node.value.match(/^\s*i18n/)
           )[0]
 
         if (!comment || visited.has(path.node)) {

--- a/packages/babel-plugin-extract-messages/test/__snapshots__/index.js.snap
+++ b/packages/babel-plugin-extract-messages/test/__snapshots__/index.js.snap
@@ -49,7 +49,35 @@ Object {
       ],
       Array [
         packages/babel-plugin-extract-messages/test/fixtures/js/macro.js,
-        21,
+        36,
+      ],
+    ],
+  },
+  Message With Description Multiline: Object {
+    description: description
+multiline,
+    origin: Array [
+      Array [
+        packages/babel-plugin-extract-messages/test/fixtures/js/macro.js,
+        20,
+      ],
+    ],
+  },
+  Message With Description No Colon: Object {
+    description: description,
+    origin: Array [
+      Array [
+        packages/babel-plugin-extract-messages/test/fixtures/js/macro.js,
+        13,
+      ],
+    ],
+  },
+  Message With Description Spaced: Object {
+    description: description,
+    origin: Array [
+      Array [
+        packages/babel-plugin-extract-messages/test/fixtures/js/macro.js,
+        9,
       ],
     ],
   },
@@ -57,7 +85,7 @@ Object {
     origin: Array [
       Array [
         packages/babel-plugin-extract-messages/test/fixtures/js/macro.js,
-        14,
+        29,
       ],
     ],
   },
@@ -66,7 +94,7 @@ Object {
     origin: Array [
       Array [
         packages/babel-plugin-extract-messages/test/fixtures/js/macro.js,
-        9,
+        24,
       ],
     ],
   },

--- a/packages/babel-plugin-extract-messages/test/fixtures/js/macro.js
+++ b/packages/babel-plugin-extract-messages/test/fixtures/js/macro.js
@@ -6,6 +6,21 @@ const withDescription = /*i18n: description*/{
   id: 'Message With Description'
 }
 
+const withDescriptionSpaced = /* i18n: description */{
+  id: 'Message With Description Spaced'
+}
+
+const withDescriptionNoColon = /*i18n description */{
+  id: 'Message With Description No Colon'
+}
+
+const withDescriptionMultiline = /*i18n 
+description
+multiline
+*/{
+  id: 'Message With Description Multiline'
+}
+
 const withId = /*i18n*/{
   id: 'msg.id',
   defaults: 'Message With Description'


### PR DESCRIPTION
`lingui extract` ignores messages with leading space in description comment.

Example source code:
```js
/* i18n: description */t`Message`
```

Expected messages:
```
{
  "Message": {
    "translation": "Message",
    "description": "description",
    "origin": [
      [
        "test.js",
        1
      ]
    ]
  }
}
```

Actual messages:
```
{}
```