### PR TITLE
Update docs to account for Context caveat

### DIFF
--- a/docs/tutorials/react.rst
+++ b/docs/tutorials/react.rst
@@ -271,8 +271,9 @@ Let's load this file into our app and set active language to ``cs``:
 
    import { I18nProvider } from '@lingui/react'
 
+   const catalogs = { cs: catalogCs };
    const App = () => (
-     <I18nProvider language="cs" catalogs={{ cs: catalogCs }}>
+     <I18nProvider language="cs" catalogs={catalogs}>
        <Inbox />
      </I18nProvider>
    )


### PR DESCRIPTION
I was bitten by the context caveat as described in the official react docs: https://reactjs.org/docs/context.html#caveats.

Quote from the docs:

> Because context uses reference identity to determine when to re-render, there are some gotchas that could trigger unintentional renders in consumers when a provider’s parent re-renders.

I understand that in the original example, the `<App>` can never rerender, so the context caveat actually doesn't apply. However, there's a significant performance hit when users of the lib copy/paste the `<I18nProvider>` snippet into a component that _does_ update. This will cause **all** `<Trans>` components in the entire app to rerender.