### PR TITLE
Show hint for missing babel-core package

### DIFF
--- a/packages/cli/src/api/compat.js
+++ b/packages/cli/src/api/compat.js
@@ -1,0 +1,45 @@
+import chalk from "chalk"
+import * as core from "babel-core"
+
+function catchBabelVersionMismatch(fn) {
+  return function() {
+    try {
+      fn.apply(null, arguments)
+    } catch (e) {
+      if (
+        e.message.startsWith(
+          "Plugin/Preset files are not allowed to export objects"
+        )
+      ) {
+        const { makeInstall } = require("../lingui-init")
+        const install = makeInstall()
+        console.log(chalk.red("Please install missing Babel 6 core package:"))
+        console.log()
+        console.log(install("babel-core@^6.0.0", true))
+        console.log()
+
+        process.exit(1)
+      } else if (
+        e.message.startsWith(
+          'Requires Babel "^7.0.0-0", but was loaded with "6.26.3".'
+        )
+      ) {
+        const { makeInstall } = require("../lingui-init")
+        const install = makeInstall()
+        console.log(chalk.red("Please install missing Babel 7 core packages:"))
+        console.log()
+        console.log(install("babel-core@^7.0.0-bridge.0 @babel/core", true))
+        console.log()
+
+        process.exit(1)
+      } else {
+        throw e
+      }
+    }
+  }
+}
+
+export const transform = catchBabelVersionMismatch(core.transform)
+export const transformFileSync = catchBabelVersionMismatch(
+  core.transformFileSync
+)

--- a/packages/cli/src/api/extractors/babel.js
+++ b/packages/cli/src/api/extractors/babel.js
@@ -1,5 +1,5 @@
 // @flow
-import { transformFileSync } from "babel-core"
+import { transformFileSync } from "../compat"
 
 import linguiTransformJs from "@lingui/babel-plugin-transform-js"
 import linguiTransformReact from "@lingui/babel-plugin-transform-react"

--- a/packages/cli/src/api/extractors/typescript.js
+++ b/packages/cli/src/api/extractors/typescript.js
@@ -1,6 +1,6 @@
 // @flow
 import fs from "fs"
-import { transform } from "babel-core"
+import { transform } from "../compat"
 
 import linguiTransformJs from "@lingui/babel-plugin-transform-js"
 import linguiTransformReact from "@lingui/babel-plugin-transform-react"


### PR DESCRIPTION
I use this approach in `next` branch and it works fine. In `next` branch I would probably make `@babel/core` the default one.