### PR TITLE
Log original error with Babel compatibility info

### DIFF
--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -1,1 +1,3 @@
+/* eslint-disable import/export */
+// This file is just used as an entry point for rollup.
 export * from "./src/lingui"

--- a/packages/cli/src/api/compat.js
+++ b/packages/cli/src/api/compat.js
@@ -7,14 +7,14 @@ function catchBabelVersionMismatch(fn) {
       fn.apply(null, arguments)
     } catch (e) {
       let logged = false
-      
+
       if (
         e.message.startsWith(
           "Plugin/Preset files are not allowed to export objects"
         )
       ) {
         logged = true
-        
+
         const { makeInstall } = require("../lingui-init")
         const install = makeInstall()
         console.log(chalk.red("Please install missing Babel 6 core package:"))
@@ -27,7 +27,7 @@ function catchBabelVersionMismatch(fn) {
         )
       ) {
         logged = true
-        
+
         const { makeInstall } = require("../lingui-init")
         const install = makeInstall()
         console.log(chalk.red("Please install missing Babel 7 core packages:"))
@@ -35,7 +35,7 @@ function catchBabelVersionMismatch(fn) {
         console.log(install("babel-core@^7.0.0-bridge.0 @babel/core", true))
         console.log()
       }
-      
+
       if (logged) {
         console.log("Original error:")
         console.log(e)

--- a/packages/cli/src/api/compat.js
+++ b/packages/cli/src/api/compat.js
@@ -6,31 +6,39 @@ function catchBabelVersionMismatch(fn) {
     try {
       fn.apply(null, arguments)
     } catch (e) {
+      let logged = false
+      
       if (
         e.message.startsWith(
           "Plugin/Preset files are not allowed to export objects"
         )
       ) {
+        logged = true
+        
         const { makeInstall } = require("../lingui-init")
         const install = makeInstall()
         console.log(chalk.red("Please install missing Babel 6 core package:"))
         console.log()
         console.log(install("babel-core@^6.0.0", true))
         console.log()
-
-        process.exit(1)
       } else if (
         e.message.startsWith(
           'Requires Babel "^7.0.0-0", but was loaded with "6.26.3".'
         )
       ) {
+        logged = true
+        
         const { makeInstall } = require("../lingui-init")
         const install = makeInstall()
         console.log(chalk.red("Please install missing Babel 7 core packages:"))
         console.log()
         console.log(install("babel-core@^7.0.0-bridge.0 @babel/core", true))
         console.log()
-
+      }
+      
+      if (logged) {
+        console.log("Original error:")
+        console.log(e)
         process.exit(1)
       } else {
         throw e

--- a/packages/cli/src/lingui-add-locale.js
+++ b/packages/cli/src/lingui-add-locale.js
@@ -28,7 +28,9 @@ export default function command(config: LinguiConfig, locales: Array<string>) {
   // At least one language was added successfully
   if (results.filter(Boolean).length) {
     console.log()
-    console.log(`(use "${chalk.yellow(helpRun("extract"))}" to extract messages)`)
+    console.log(
+      `(use "${chalk.yellow(helpRun("extract"))}" to extract messages)`
+    )
   }
 }
 


### PR DESCRIPTION
I encountered a problem where lingui thought I needed to install `babel-core` version 6 however the actual problem was being obscured because the error message which prompts lingui to log these instructions is not itself shared with the developer.

The actual problem I was having was that the lib `babel-preset-react-app` was not up-to-date, so the instructions to "please install missing Babel 6 core package" were misleading.

This PR makes the Babel compat. messages also print the original error in order to help people debugging cases like this.

Thanks for a great library!

Edit: Let me know what needs to be done re: tests and I will fix up the PR accordingly.