### PR TITLE
fix: made pseudolocales to take into account variable names

### DIFF
--- a/packages/cli/src/api/pseudoLocalize.js
+++ b/packages/cli/src/api/pseudoLocalize.js
@@ -23,9 +23,9 @@ Example: https://regex101.com/r/zXWiQR/3
 const PluralRegex = /{\w*,\s*plural,\s*\w*\s*{|}\s*\w*\s*({|})/g
 /*
 Regex should match js-lingui variables
-Example: https://regex101.com/r/kD7K2b/1
+Example: https://regex101.com/r/dw1QHb/2
 */
-const VariableRegex = /({|})/g
+const VariableRegex = /({\s*[a-zA-Z_$][a-zA-Z_$0-9]*\s*})/g
 
 function addDelimitersHTMLTags(message) {
   return message.replace(HTMLRegex, matchedString => {

--- a/packages/cli/src/api/pseudoLocalize.test.js
+++ b/packages/cli/src/api/pseudoLocalize.test.js
@@ -36,7 +36,7 @@ describe("PseudoLocalization", () => {
     ).toEqual("{value, plural, one {# ƀōōķ} other {# ƀōōķś}}")
   })
 
-  it("should pseudolocalize variables", () => {
+  it("shouldn't pseudolocalize variables", () => {
     expect(pseudoLocalize("replace {count}")).toEqual("ŕēƥĺàćē {count}")
     expect(pseudoLocalize("replace { count }")).toEqual("ŕēƥĺàćē { count }")
   })

--- a/packages/cli/src/api/pseudoLocalize.test.js
+++ b/packages/cli/src/api/pseudoLocalize.test.js
@@ -35,4 +35,9 @@ describe("PseudoLocalization", () => {
       pseudoLocalize("{value, plural, one {# book} other {# books}}")
     ).toEqual("{value, plural, one {# ƀōōķ} other {# ƀōōķś}}")
   })
+
+  it("should pseudolocalize variables", () => {
+    expect(pseudoLocalize("replace {count}")).toEqual("ŕēƥĺàćē {count}")
+    expect(pseudoLocalize("replace { count }")).toEqual("ŕēƥĺàćē { count }")
+  })
 })


### PR DESCRIPTION
Updated pseudolocale regex in order to take into account variable names. 
Previously the string: ```replace {count}``` would have been replaced with ```ŕēƥĺàćē  {ćōũńţ}```.
This would introduce an issue at runtime when the interpolator tries to find the variable ```ćōũńţ``` in the current variables context which does not exists.

With this change the variable names remain intact and the translation message is created as such: ```ŕēƥĺàćē {count}```