### PR TITLE
Issue #427: fix edge case bug in plural pseudolocalization

### DIFF
--- a/packages/cli/src/api/pseudoLocalize.js
+++ b/packages/cli/src/api/pseudoLocalize.js
@@ -18,9 +18,9 @@ Example: https://regex101.com/r/bDHD9z/3
 const HTMLRegex = /<\/?\w+((\s+\w+(\s*=\s*(?:".*?"|'.*?'|[^'">\s]+))?)+\s*|\s*)\/?>/g
 /*
 Regex should match js-lingui plurals
-Example: https://regex101.com/r/zXWiQR/3
+Example: https://regex101.com/r/utnbQw/1
 */
-const PluralRegex = /{\w*,\s*plural,\s*\w*\s*{|}\s*\w*\s*({|})/g
+const PluralRegex = /{\w*,\s*plural,\s*\w*\s*{|}\s*(zero|one|two|few|many|other)\s*({|})/g
 /*
 Regex should match js-lingui variables
 Example: https://regex101.com/r/kD7K2b/1

--- a/packages/cli/src/api/pseudoLocalize.test.js
+++ b/packages/cli/src/api/pseudoLocalize.test.js
@@ -34,5 +34,8 @@ describe("PseudoLocalization", () => {
     expect(
       pseudoLocalize("{value, plural, one {# book} other {# books}}")
     ).toEqual("{value, plural, one {# ƀōōķ} other {# ƀōōķś}}")
+    expect(
+      pseudoLocalize("{count, plural, one {{countString} book} other {{countString} books}}")
+    ).toEqual("{count, plural, one {{countString} ƀōōķ} other {{countString} ƀōōķś}}")
   })
 })


### PR DESCRIPTION
Fixes issue #427.
Depends on PR #419 - the test added here will fail on this branch until that PR is incorporated.

This fix will still fail in the case that a variable placeholder in a template string inside a `plural` macro is followed by a single word which matches one of the plural rules, e.g. `{count, plural, one {{countString} other} other {{countString} others}}`.

This is a much more extreme edge case, though - it must be
1. A template string
1. Inside a `plural` expression
1. With a variable placeholder
1. Followed by `zero|one|two|few|many|other`
1. With no other words or punctuation after that word
1. With pseudolocalization enabled

IMO this is an acceptable tradeoff for a more readable regular expression.