### PR TITLE
Fix typo on macro Babel plugin config

### DIFF
--- a/docs/tutorials/javascript.rst
+++ b/docs/tutorials/javascript.rst
@@ -57,13 +57,13 @@ Let's start with the three major packages:
       yarn add --dev babel-core
 
 
-2. Add ``macro`` plugin to Babel config (e.g: ``.babelrc``):
+2. Add ``macros`` plugin to Babel config (e.g: ``.babelrc``):
 
    .. code-block:: json
 
       {
         "plugins": [
-          "macro"
+          "macros"
         ]
       }
 


### PR DESCRIPTION
Otherwise, you'll get an error:

```
Metro Bundler ready.

Loading dependency graph, done.
error: bundling failed: ReferenceError: Unknown plugin "macro" specified in
{{ a bunch of line errors }}
...
```