### PR TITLE
Update testing example

### DIFF
--- a/docs/guides/testing.rst
+++ b/docs/guides/testing.rst
@@ -3,22 +3,93 @@ Testing
 
 .. warning:: This is an incomplete draft of a guide.
 
-Components using :component:`Trans` or :js:func:`withI18n` must be wrapped in
-:component:`I18nProvider` in tests:
+Components using :component:`Trans` or :js:func:`withI18n` require access to the context of :component:`I18nProvider`. This is not available when mounting single components in Enzyme. These helper functions aim to address that and wrap a valid, context around them.
+
+Adapted from this gist_.
+
+.. _gist: https://gist.github.com/mirague/c05f4da0d781a9b339b501f1d5d33c37/
 
 .. code-block:: jsx
 
    import React from 'react'
-   import { mount } from 'enzyme'
+   import { shape, object } from 'prop-types'
+   import { mount, shallow } from 'enzyme'
    import { I18nProvider } from '@lingui/react'
-   import Component from './Component'
 
-   describe('Component', function () {
-     it('should render correctly', function () {
-        const tree = mount(<I18nProvider><Component /></I18nProvider>
-        expect(tree).toMatchSnapshot()
-     })
-   })
+   // Create the I18nProvider to retrieve context for wrapping around.
+   const language = 'de-DE'
+   const intlProvider = new I18nProvider({
+     language,
+     catalogs: {
+       [language]: {}
+     }
+   }, {})
+
+   const {
+     linguiPublisher: {
+       i18n: originalI18n
+     }
+   } = intlProvider.getChildContext()
+
+   // You customize the i18n object here:
+   const i18n = {
+     ...originalI18n,
+     _: key => key // provide _ macro, for just passing down the key
+   }
+
+   /**
+    * When using Lingui `withI18n` on components, props.i18n is required.
+    */
+   function nodeWithI18nProp(node) {
+     return React.cloneElement(node, { i18n })
+   }
+
+   /*
+    * Methods to use
+    */
+   export function shallowWithIntl(node, { context } = {}) {
+     return shallow(
+       nodeWithI18nProp(node),
+       {
+         context: Object.assign({}, context, { i18n })
+       }
+     )
+   }
+
+   export function mountWithIntl(node, { context, childContextTypes } = {}) {
+     const newContext = Object.assign({}, context, { linguiPublisher: { i18n } })
+     /*
+      * I18nProvider sets the linguiPublisher in the context for withI18n to get
+      * the i18n object from.
+      */
+     const newChildContextTypes = Object.assign({},
+       {
+         linguiPublisher: shape({
+           i18n: object.isRequired
+         }).isRequired
+       },
+       childContextTypes
+     )
+     return mount(
+       nodeWithI18nProp(node),
+       {
+         context: newContext,
+         childContextTypes: newChildContextTypes
+       }
+     )
+   }
+
+Usage:
+
+.. code-block:: jsx
+
+   import { mountWithIntl } from 'enzyme-test-helper.js'
+
+   const wrapper = mountWithIntl(
+     <OurComponent />
+   );
+
+   expect(wrapper.state('prop')).to.equal('value')
 
 Snapshot testing
 ----------------


### PR DESCRIPTION
Hey there,

The current testing example is a little bit problematic, especially when you want to mount and test stateful components.

Enzyme's mount gives you access only to the root component's state. That means that by doing: `<I18nProvider><YourComponent /></I18nProvider>` you can't access `YourComponent`'s state for testing.

In `react-intl`, we were using a higher order component [taken from this gist](https://gist.github.com/mirague/c05f4da0d781a9b339b501f1d5d33c37/), which extracts the context from the provider and passes it down to the component tree. That solves the issue, and makes testing great again (:yikes:).

We have adapted that solution for the I18nProvider and it works great for us.

I updated the documentation, and I hope you also find it useful.

Cheers 🍻 