### PR TITLE
fix: flow typing of React API with Flow 0.92

### DIFF
--- a/packages/react/src/I18nProvider.js
+++ b/packages/react/src/I18nProvider.js
@@ -17,11 +17,24 @@ export type I18nProviderProps = {
   defaultRender: ?any
 }
 
+type LinguiPublisher = {|
+  i18n: I18n,
+  i18nHash: null,
+
+  getSubscribers(): Array<Function>,
+
+  subscribe(callback: Function): void,
+
+  unsubscribe(callback: Function): void,
+
+  update(?{ catalogs?: Catalogs, language?: string, locales?: string }): void
+|}
+
 /*
  * I18nPublisher - Connects to lingui-i18n/I18n class
  * Allows listeners to subscribe for changes
  */
-export function LinguiPublisher(i18n: I18n) {
+export function makeLinguiPublisher(i18n: I18n): LinguiPublisher {
   let subscribers: Array<Function> = []
 
   return {
@@ -40,11 +53,11 @@ export function LinguiPublisher(i18n: I18n) {
       subscribers = subscribers.filter(cb => cb !== callback)
     },
 
-    update({
-      catalogs,
-      language,
-      locales
-    }: { catalogs?: Catalogs, language?: string, locales?: string } = {}) {
+    update(
+      params: ?{ catalogs?: Catalogs, language?: string, locales?: string } = {}
+    ) {
+      if (!params) return
+      const { catalogs, language, locales } = params
       if (!catalogs && !language && !locales) return
 
       if (catalogs) i18n.load(catalogs)
@@ -81,7 +94,7 @@ export default class I18nProvider extends React.Component<I18nProviderProps> {
         locales,
         catalogs
       })
-    this.linguiPublisher = new LinguiPublisher(i18n)
+    this.linguiPublisher = makeLinguiPublisher(i18n)
     this.linguiPublisher.i18n._missing = this.props.missing
   }
 
@@ -106,6 +119,6 @@ export default class I18nProvider extends React.Component<I18nProviderProps> {
   }
 
   render() {
-    return this.props.children
+    return this.props.children || null
   }
 }

--- a/packages/react/src/I18nProvider.test.js
+++ b/packages/react/src/I18nProvider.test.js
@@ -4,7 +4,7 @@ import { shallow, mount } from "enzyme"
 
 import { setupI18n } from "@lingui/core"
 import { I18nProvider, Trans } from "@lingui/react"
-import { LinguiPublisher } from "./I18nProvider"
+import { makeLinguiPublisher } from "./I18nProvider"
 import { mockConsole } from "./mocks"
 
 describe("I18nProvider", function() {
@@ -132,7 +132,7 @@ describe("I18nProvider", function() {
 
 describe("I18nPublisher", function() {
   it("should pass active language and messages to underlying I18n class", function() {
-    const linguiPublisher = new LinguiPublisher(
+    const linguiPublisher = makeLinguiPublisher(
       setupI18n({
         language: "en",
         catalogs: {
@@ -169,7 +169,7 @@ describe("I18nPublisher", function() {
   })
 
   it("should subscribe/unsubscribe listeners for context changes", function() {
-    const linguiPublisher = new LinguiPublisher(
+    const linguiPublisher = makeLinguiPublisher(
       setupI18n({
         language: "en",
         catalogs: { en: {} }
@@ -188,7 +188,7 @@ describe("I18nPublisher", function() {
 
   it("should notify listeners only when relevant data changes", function() {
     const listener = jest.fn()
-    const linguiPublisher = new LinguiPublisher(
+    const linguiPublisher = makeLinguiPublisher(
       setupI18n({
         language: "en",
         catalogs: { en: {}, fr: {} }

--- a/packages/react/src/Render.js
+++ b/packages/react/src/Render.js
@@ -23,7 +23,7 @@ export default class Render extends React.Component<RenderComponentProps> {
     let render = this.props.render || this.context.linguiDefaultRender
 
     if (render === null || render === undefined) {
-      return value
+      return value || null
     } else if (typeof render === "string") {
       // Built-in element: h1, p
       return React.createElement(render, { className }, value)


### PR DESCRIPTION
Nice library! Very well done :)

I've run into a few flow errors when trying to add it on my project (https://github.com/4ian/GDevelop) with Flow 0.92. 
I've made a few fixes, hope they are ok. 

## Changes

* I'm not sure about LinguiPublisher, I think it should be named `createLinguiPublisher` or `makeLinguiPublisher` as it's returning an object rather than being a constructor (i.e: it's not modifying `this`). I've changed the name and changed its usage to remove the `new`.
  * I've not seen any reference to `LinguiPublisher` when googling it. If you think this is breaking the API, we can go back to have it being named `LinguiPublisher` and have the type named `LinguiPublisherType`.
* A test case is there to ensure `update` of `LinguiPublisher` can be called without any arguments. But the typing was incorrect then. I've named the parameter (`param`, not very original) and checked for its existence before destructuring it.
* A few `|| null` to ensure you're not returning undefined in renders.

## Test plan

* Ran `yarn lint` and got in pseudoLocalize.test.js:

```
  38:22  error  Replace "{count,·plural,·one·{{countString}·book}·other·{{countString}·books}}" with ⏎········"{count,·plural,·one·{{countString}·book}·other·{{countString}·books}}"⏎······  prettier/prettier
  39:15  error  Replace "{count,·plural,·one·{{countString}·ƀōōķ}·other·{{countString}·ƀōōķś}}" with ⏎······"{count,·plural,·one·{{countString}·ƀōōķ}·other·{{countString}·ƀōōķś}}"⏎····      prettier/prettier

✖ 2 problems (2 errors, 0 warnings)
  2 errors and 0 warnings potentially fixable with the --fix option.
```

  but this seems to be unrelated to my changes?

* `yarn flow` is still passing.
* `flow` (with flow version 0.92.0) is down from 5 errors to 2, that are in `packages/cli/src/api/compile.js` (line 142 and 144):
  
  ```
Cannot call pseudoLocalize with translation bound to message because MessageType [1] is incompatible with string [2].
  ```

I've not fixed them because my goal was to get the React API without flow errors :)

Also if you feel more comfortable fixing yourself the issues with Flow 0.92 rather than merging/asking changes on this PR, feel free to steal my fixes :)