### PR TITLE
Don't prevent babel options to help setup lingui in monorepos

### DIFF
--- a/packages/conf/src/index.js
+++ b/packages/conf/src/index.js
@@ -44,6 +44,8 @@ export const defaultConfig = {
 const exampleConfig = {
   ...defaultConfig,
   extractBabelOptions: {
+    extends: "babelconfig.js",
+    rootMode: "rootmode",
     plugins: ["plugin"],
     presets: ["preset"]
   }


### PR DESCRIPTION
Currently, lingui complains with option validation issues if you attempt to use the `extends` or `rootMode` babel options. In a monorepo, with Babel 7, you often want message extraction to happen in each module, but using a common babel configuration that exists in a top level "workspace"

We should allow these options without throwing warnings. I'm not sure we should actually have any validation on the babel options (since whats allowed depends on babel version, and theres not much need to limit he feature set) so potentially, this validation could be removed entirely.