### PR TITLE
fix: new fixes for flow typing of React API with Flow 0.92

### DIFF
--- a/packages/react/src/I18nProvider.js
+++ b/packages/react/src/I18nProvider.js
@@ -27,7 +27,7 @@ type LinguiPublisher = {|
 
   unsubscribe(callback: Function): void,
 
-  update(?{ catalogs?: Catalogs, language?: string, locales?: string }): void
+  update(?{ catalogs?: Catalogs, language?: string, locales?: Locales }): void
 |}
 
 /*
@@ -54,7 +54,11 @@ export function makeLinguiPublisher(i18n: I18n): LinguiPublisher {
     },
 
     update(
-      params: ?{ catalogs?: Catalogs, language?: string, locales?: string } = {}
+      params: ?{
+        catalogs?: Catalogs,
+        language?: string,
+        locales?: Locales
+      } = {}
     ) {
       if (!params) return
       const { catalogs, language, locales } = params

--- a/packages/react/src/Select.js
+++ b/packages/react/src/Select.js
@@ -48,7 +48,6 @@ const Select = withI18n()(
 
 const PluralFactory = (ordinal = false) => {
   const displayName = !ordinal ? "Plural" : "SelectOrdinal"
-  const pluralType = !ordinal ? "plural" : "selectOrdinal"
 
   return class extends React.Component<*, PluralProps> {
     displayName = displayName
@@ -76,11 +75,13 @@ const PluralFactory = (ordinal = false) => {
         }
       )
 
+      const translateFunction = !ordinal ? i18n.plural : i18n.selectOrdinal
+
       return (
         <Render
           className={className}
           render={render}
-          value={i18n[pluralType](pluralProps)}
+          value={translateFunction(pluralProps)}
         />
       )
     }


### PR DESCRIPTION
Turns out there was still issues after https://github.com/lingui/js-lingui/pull/448 - that arised after using it in a project with Flow 0.92

I've built lingui/react with these changes and used them in my project (https://github.com/4ian/GDevelop) and don't have any Flow errors anymore.

* `yarn flow` is passing
* `yarn lint` give two errors, that were already there:
```
  38:22  error  Replace `"{count,·plural,·one·{{countString}·book}·other·{{countString}·books}}"` with `⏎········"{count,·plural,·one·{{countString}·book}·other·{{countString}·books}}"⏎······`  prettier/prettier
  39:15  error  Replace `"{count,·plural,·one·{{countString}·ƀōōķ}·other·{{countString}·ƀōōķś}}"` with `⏎······"{count,·plural,·one·{{countString}·ƀōōķ}·other·{{countString}·ƀōōķś}}"⏎····`      prettier/prettier

✖ 2 problems (2 errors, 0 warnings)
  2 errors and 0 warnings potentially fixable with the `--fix` option.
```

* `flow` (with flow version 0.92.0) is down from 5 errors to 2, that are in `packages/cli/src/api/compile.js` (line 142 and 144) like in https://github.com/lingui/js-lingui/pull/448 but I've not fixed them because my goal was to get lingui/react to be free of flow errors when using it.

I know that you've just released a new version but wanted to open the PR earlier and forgot about this!