### PR TITLE
Fix escaped backticks in macro-transformed template strings

### DIFF
--- a/packages/macro/src/js.js
+++ b/packages/macro/src/js.js
@@ -239,7 +239,7 @@ export default function({ types: t }) {
 
     parts.forEach(item => {
       if (t.isTemplateElement(item)) {
-        props.text += item.value.raw
+        props.text += item.value.raw.replace(/\\`/g, "`")
       } else if (
         t.isCallExpression(item) &&
         (isI18nMethod(item.callee) ||

--- a/packages/macro/test/fixtures/t/actual.js
+++ b/packages/macro/test/fixtures/t/actual.js
@@ -13,4 +13,5 @@ t`
   constant ${42},
   object ${new Date()}
   anything ${props.messages[index].value()}
+  \`escaped backticks\`
 `

--- a/packages/macro/test/fixtures/t/expected.js
+++ b/packages/macro/test/fixtures/t/expected.js
@@ -17,7 +17,7 @@ const a = /*i18n*/{
 });
 
 ( /*i18n*/{
-  id: 'Property {0}, function {1}, array {2}, constant {3}, object {4} anything {5}',
+  id: 'Property {0}, function {1}, array {2}, constant {3}, object {4} anything {5} `escaped backticks`',
   values: {
     0: props.name,
     1: random(),


### PR DESCRIPTION
To use a literal backtick in a template string (such as for markdown code blocks), it needs to be escaped (```const str = `\``;```).

Unfortunately, this gets picked up as ``\\` `` due to `value.raw`, which ends up as a literal ``\` `` in the translation string.

In turn, this leads to final translation strings ending up with the literal ``\` ``, which is broken syntax, throwing a `Error: Can't parse message. Please check correct syntax"`.

This PR provides a quick fix for the issue, allowing backticks to be used.