### PR TITLE
Resolve babel-plugin-syntax-jsx relative to the @lingui/cli package

### DIFF
--- a/packages/cli/src/api/extractors/typescript.js
+++ b/packages/cli/src/api/extractors/typescript.js
@@ -51,7 +51,7 @@ const extractor: ExtractorType = {
     ]
 
     if (isTsx) {
-      plugins.unshift("syntax-jsx")
+      plugins.unshift(require.resolve("babel-plugin-syntax-jsx"))
     }
 
     transform(stripped.outputText, {


### PR DESCRIPTION
This fixes an issue where 'babel-plugin-syntax-jsx' cannot be resolved
when using strict package managers such as pnpm or yarn pnp:

```
> project@1.0.0 lingui:extract /path/to/project
> lingui extract

/path/to/project/temp/node_modules/.registry.npmjs.org/@lingui/cli/2.7.4/27dd1e49dd60dcd69cab3f50f64bc261/node_modules/@lingui/cli/api/compat.js:56
        throw e;
        ^

Error: Cannot find module 'babel-plugin-syntax-jsx' from '/path/to/project'
    at Function.module.exports [as sync] (/path/to/project/temp/node_modules/.registry.npmjs.org/resolve/1.10.1/node_modules/resolve/lib/sync.js:58:15)
    at resolveStandardizedName (/path/to/project/temp/node_modules/.registry.npmjs.org/@babel/core/7.4.3/node_modules/@babel/core/lib/config/files/plugins.js:101:31)
    at resolvePlugin (/path/to/project/temp/node_modules/.registry.npmjs.org/@babel/core/7.4.3/node_modules/@babel/core/lib/config/files/plugins.js:54:10)
    at loadPlugin (/path/to/project/temp/node_modules/.registry.npmjs.org/@babel/core/7.4.3/node_modules/@babel/core/lib/config/files/plugins.js:62:20)
    at createDescriptor (/path/to/project/temp/node_modules/.registry.npmjs.org/@babel/core/7.4.3/node_modules/@babel/core/lib/config/config-descriptors.js:154:9)
    at items.map (/path/to/project/temp/node_modules/.registry.npmjs.org/@babel/core/7.4.3/node_modules/@babel/core/lib/config/config-descriptors.js:109:50)
    at Array.map (<anonymous>)
    at createDescriptors (/path/to/project/temp/node_modules/.registry.npmjs.org/@babel/core/7.4.3/node_modules/@babel/core/lib/config/config-descriptors.js:109:29)
    at createPluginDescriptors (/path/to/project/temp/node_modules/.registry.npmjs.org/@babel/core/7.4.3/node_modules/@babel/core/lib/config/config-descriptors.js:105:10)
    at alias (/path/to/project/temp/node_modules/.registry.npmjs.org/@babel/core/7.4.3/node_modules/@babel/core/lib/config/config-descriptors.js:63:49)
```