### PR TITLE
Optional --config argument for advanced configuration scenarios

### DIFF
--- a/docs/ref/cli.rst
+++ b/docs/ref/cli.rst
@@ -44,6 +44,14 @@ Install
          }
       }
 
+Global options
+==============
+
+.. lingui-cli-option:: --config <config>
+
+Path to LinguiJS configuration file. If not set, the default file
+is loaded as described in :doc:`LinguiJS configuration </ref/conf>` reference.
+
 Commands
 ========
 

--- a/packages/cli/src/api/pseudoLocalize.test.js
+++ b/packages/cli/src/api/pseudoLocalize.test.js
@@ -35,8 +35,12 @@ describe("PseudoLocalization", () => {
       pseudoLocalize("{value, plural, one {# book} other {# books}}")
     ).toEqual("{value, plural, one {# ƀōōķ} other {# ƀōōķś}}")
     expect(
-      pseudoLocalize("{count, plural, one {{countString} book} other {{countString} books}}")
-    ).toEqual("{count, plural, one {{countString} ƀōōķ} other {{countString} ƀōōķś}}")
+      pseudoLocalize(
+        "{count, plural, one {{countString} book} other {{countString} books}}"
+      )
+    ).toEqual(
+      "{count, plural, one {{countString} ƀōōķ} other {{countString} ƀōōķś}}"
+    )
   })
 
   it("shouldn't pseudolocalize variables", () => {

--- a/packages/cli/src/lingui-add-locale.js
+++ b/packages/cli/src/lingui-add-locale.js
@@ -41,6 +41,7 @@ if (require.main === module) {
         "directory from your localeDir (e.g. ./locale/en)"
     )
     .arguments("<locale...>")
+    .option("--config <path>", "Path to the config file")
     .option("--format <format>", "Format of message catalog")
     .on("--help", function() {
       console.log("\n  Examples:\n")

--- a/packages/cli/src/lingui-compile.js
+++ b/packages/cli/src/lingui-compile.js
@@ -117,6 +117,7 @@ if (require.main === module) {
     .description(
       "Add compile message catalogs and add language data (plurals) to compiled bundle."
     )
+    .option("--config <path>", "Path to the config file")
     .option("--strict", "Disable defaults for missing translations")
     .option("--verbose", "Verbose output")
     .option("--format <format>", "Format of message catalog")

--- a/packages/cli/src/lingui-extract.js
+++ b/packages/cli/src/lingui-extract.js
@@ -134,6 +134,7 @@ export default function command(
 
 if (require.main === module) {
   program
+    .option("--config <path>", "Path to the config file")
     .option("--overwrite", "Overwrite translations for source locale")
     .option("--clean", "Remove obsolete translations")
     .option(

--- a/packages/conf/src/index.js
+++ b/packages/conf/src/index.js
@@ -1,4 +1,5 @@
 const path = require("path")
+const fs = require("fs")
 const chalk = require("chalk")
 const cosmiconfig = require("cosmiconfig")
 const { validate } = require("jest-validate")
@@ -74,10 +75,30 @@ const configValidation = {
   comment: "See https://lingui.js.org/ref/conf.html for a list of valid options"
 }
 
+function configFilePathFromArgs() {
+  const configIndex = process.argv.indexOf("--config")
+
+  if (
+    configIndex >= 0 &&
+    process.argv.length > configIndex &&
+    fs.existsSync(process.argv[configIndex + 1])
+  ) {
+    return process.argv[configIndex + 1]
+  }
+
+  return null
+}
+
 export function getConfig({ cwd } = {}) {
-  const defaultRootDir = cwd || process.cwd()
   const configExplorer = cosmiconfig("lingui")
-  const result = configExplorer.searchSync(defaultRootDir)
+  const defaultRootDir = cwd || process.cwd()
+  const configPath = configFilePathFromArgs()
+
+  const result =
+    configPath == null
+      ? configExplorer.searchSync(defaultRootDir)
+      : configExplorer.loadSync(configPath)
+
   const raw = { ...defaultConfig, ...(result ? result.config : {}) }
 
   validate(raw, configValidation)

--- a/packages/conf/src/index.test.js
+++ b/packages/conf/src/index.test.js
@@ -1,4 +1,29 @@
 import { getConfig, replaceRootDir } from "@lingui/conf"
+import cosmiconfig from "cosmiconfig"
+
+const mockExplorer = {
+  searchSync: jest.fn(),
+  loadSync: jest.fn()
+}
+
+jest.mock("cosmiconfig", function() {
+  return function() {
+    return mockExplorer
+  }
+})
+
+jest.mock("fs", function() {
+  return {
+    existsSync: function() {
+      return true
+    }
+  }
+})
+
+beforeEach(function() {
+  cosmiconfig().loadSync.mockClear()
+  cosmiconfig().searchSync.mockClear()
+})
 
 describe("lingui-conf", function() {
   it("should return default config", function() {
@@ -26,5 +51,27 @@ describe("lingui-conf", function() {
     expect(config.boolean).toEqual(false)
     expect(config.localeDir).toEqual("/Root")
     expect(config.srcPathDirs).toEqual(["/Root", "rootDir"])
+  })
+
+  it("searches for a config file", function() {
+    getConfig()
+    expect(cosmiconfig().searchSync).toHaveBeenCalled()
+  })
+
+  describe("with --config command line argument", function() {
+    beforeEach(function() {
+      process.argv.push("--config")
+      process.argv.push("./lingui/myconfig")
+    })
+
+    afterEach(function() {
+      process.argv.splice(process.argv.length - 2, 2)
+    })
+
+    it("allows specific config file to be loaded", function() {
+      getConfig()
+      expect(cosmiconfig().searchSync).not.toHaveBeenCalled()
+      expect(cosmiconfig().loadSync).toHaveBeenCalledWith("./lingui/myconfig")
+    })
   })
 })


### PR DESCRIPTION
## Overview

I have an advanced configuration scenario that requires multiple locale targets and with multiple source directories. I want to end up with multiple catalogs that are loaded in different circumstances.

Presently, I work around the obvious config issue by swapping out my .linguirc file in between runs of `lingui extract` and `lingui compile`. This isn't ideal and I thought lingui might benefit from a CLI  option to specify a configuration file.

This change allows a `--config <path>` option on add-locale, compile, and extract commands. If the path exists, I use `cosmiconfig#loadSync` instead of the normal config file probe.

If you find this change welcome, I can work more to add details to the docs.

## Tradeoffs

- Adding a new option could make each command to be perceived as slightly more complex
