### PR TITLE
Fixes --config option processing

### DIFF
--- a/packages/cli/src/lingui-add-locale.js
+++ b/packages/cli/src/lingui-add-locale.js
@@ -55,7 +55,7 @@ if (require.main === module) {
 
   if (!program.args.length) program.help()
 
-  const config = getConfig()
+  const config = getConfig({ configPath: program.config })
   if (program.format) {
     const msg =
       "--format option is deprecated and will be removed in @lingui/cli@3.0.0." +

--- a/packages/cli/src/lingui-compile.js
+++ b/packages/cli/src/lingui-compile.js
@@ -140,7 +140,7 @@ if (require.main === module) {
     })
     .parse(process.argv)
 
-  const config = getConfig()
+  const config = getConfig({ configPath: program.config })
 
   if (program.format) {
     const msg =

--- a/packages/cli/src/lingui-extract.js
+++ b/packages/cli/src/lingui-extract.js
@@ -149,7 +149,7 @@ if (require.main === module) {
     )
     .parse(process.argv)
 
-  const config = getConfig()
+  const config = getConfig({ configPath: program.config })
 
   if (program.format) {
     const msg =

--- a/packages/conf/src/index.js
+++ b/packages/conf/src/index.js
@@ -75,29 +75,17 @@ const configValidation = {
   comment: "See https://lingui.js.org/ref/conf.html for a list of valid options"
 }
 
-function configFilePathFromArgs() {
-  const configIndex = process.argv.indexOf("--config")
-
-  if (
-    configIndex >= 0 &&
-    process.argv.length > configIndex &&
-    fs.existsSync(process.argv[configIndex + 1])
-  ) {
-    return process.argv[configIndex + 1]
-  }
-
-  return null
+function configExists(path) {
+  return path && fs.existsSync(path)
 }
 
-export function getConfig({ cwd } = {}) {
+export function getConfig({ cwd, configPath } = {}) {
   const configExplorer = cosmiconfig("lingui")
   const defaultRootDir = cwd || process.cwd()
-  const configPath = configFilePathFromArgs()
 
-  const result =
-    configPath == null
-      ? configExplorer.searchSync(defaultRootDir)
-      : configExplorer.loadSync(configPath)
+  const result = configExists(configPath)
+    ? configExplorer.loadSync(configPath)
+    : configExplorer.searchSync(defaultRootDir)
 
   const raw = { ...defaultConfig, ...(result ? result.config : {}) }
 

--- a/packages/conf/src/index.test.js
+++ b/packages/conf/src/index.test.js
@@ -58,18 +58,9 @@ describe("lingui-conf", function() {
     expect(cosmiconfig().searchSync).toHaveBeenCalled()
   })
 
-  describe("with --config command line argument", function() {
-    beforeEach(function() {
-      process.argv.push("--config")
-      process.argv.push("./lingui/myconfig")
-    })
-
-    afterEach(function() {
-      process.argv.splice(process.argv.length - 2, 2)
-    })
-
+  describe("with configPath parameter", function() {
     it("allows specific config file to be loaded", function() {
-      getConfig()
+      getConfig({ configPath: "./lingui/myconfig" })
       expect(cosmiconfig().searchSync).not.toHaveBeenCalled()
       expect(cosmiconfig().loadSync).toHaveBeenCalledWith("./lingui/myconfig")
     })

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -32,6 +32,7 @@
     "@lingui/cli": "0.0.0-managed-by-release-script",
     "@lingui/conf": "0.0.0-managed-by-release-script",
     "babel-runtime": "^6.26.0",
-    "ramda": "^0.26.1"
+    "ramda": "^0.26.1",
+    "loader-utils": "^1.1.0"
   }
 }

--- a/packages/loader/test/compiler.js
+++ b/packages/loader/test/compiler.js
@@ -15,7 +15,8 @@ export default (fixture, options = {}) => {
         {
           test: /\.json$/,
           use: {
-            loader: path.resolve(__dirname, "../src/index.js")
+            loader: path.resolve(__dirname, "../src/index.js"),
+            options
           }
         }
       ]

--- a/packages/loader/test/customconfig
+++ b/packages/loader/test/customconfig
@@ -1,0 +1,4 @@
+{
+  "localeDir": "<rootDir>/locale",
+  "compileNamespace": "window.really_long_namespace"
+}

--- a/packages/loader/test/loader.test.js
+++ b/packages/loader/test/loader.test.js
@@ -20,4 +20,16 @@ describe("lingui-loader", function() {
     expect(output.errors).toEqual([])
     expect(output.modules[0].source).toMatchSnapshot()
   })
+
+  skipOnWindows("should allow config option", async () => {
+    const stats = await compiler(
+      path.join(".", "locale", "en", "messages.json"),
+      { config: `${path.dirname(module.filename)}/customconfig` }
+    )
+
+    const output = stats.toJson()
+
+    // customconfig contains this namespace
+    expect(output.modules[0].source).toMatch(/window\.really_long_namespace=/)
+  })
 })


### PR DESCRIPTION
### Overview

Processing process.argv inside getConfig can cause problems when used in conjunction with @lingui/loader since the --config arg is also used by webpack

Instead of processing process.argv, getConfig now accepts the path to a custom config file. Each command now passes the config option from commander into getConfig. Webpack loader now accepts an option "config" that can be used to specify a config file.

### Notes

Should all lingui options be allowed via webpack loader options? loader could be modified to assign all options to getConfig output.

I think I fixed an unrelated bug with lingui/loader. compileNamespace and pseudoLocale config options  were not being passed to createCompiledCatalog, so I assume that all loader compiled output was being exported as cjs.

### Testing

I smoke tested the fix by implementing lingui/loader with a config option while simultaneously using the --config option with webpack. I also verified that `lingui extract --config` continued to function as expected.