### PR TITLE
(docs:misc/tooling) Added storybook-addon within docs/misc/tooling.rst

### DIFF
--- a/docs/misc/tooling.rst
+++ b/docs/misc/tooling.rst
@@ -1,0 +1,9 @@
+*******
+Tooling
+*******
+
+.. csv-table::
+   :header: "Tool", "Type", "Description"
+   :widths: 15, 10, 30
+
+   "`storybook-addon-linguijs <https://www.npmjs.com/package/storybook-addon-linguijs>`_", storybook, "Storybook addon to provide language and locale switcher in storybook"


### PR DESCRIPTION
## Storybook addon for LinguiJS  🎉

A few days ago I published a storybook addon for lingui to support the dev experience 

And as requested from https://github.com/lingui/js-lingui/issues/413

[storybook-addon-linguijs](https://www.npmjs.com/package/storybook-addon-linguijs) in now listed under`docs/misc/tooling.rst`.

i hope it helps
