### PR TITLE
test: Add tests to check for escape apostrophes

### DIFF
--- a/packages/cli/src/api/compile.test.ts
+++ b/packages/cli/src/api/compile.test.ts
@@ -12,6 +12,11 @@ describe("compile", function() {
     expect(getSource("Hello World")).toEqual('"Hello World"')
   })
 
+  it("should allow escaping syntax characters", () => {
+    expect(getSource("'{name}'")).toEqual('"{name}"')
+    expect(getSource("''")).toEqual('"\'"')
+  })
+
   it("should compile arguments", function() {
     expect(getSource("{name}")).toEqual('function(a){return[a("name")]}')
 

--- a/packages/core/src/i18n.test.ts
+++ b/packages/core/src/i18n.test.ts
@@ -159,6 +159,19 @@ describe("I18n", function() {
     expect(i18n._(hello)).toEqual("Salut")
   })
 
+  it("._ allow escaping syntax characters", () => {
+    const messages = {
+      "My ''name'' is '{name}'": "Mi ''nombre'' es '{name}'"
+    }
+
+    const i18n = setupI18n({
+      locale: "es",
+      catalogs: { es: { messages } }
+    })
+
+    expect(i18n._("My ''name'' is '{name}'")).toEqual("Mi 'nombre' es {name}")
+  })
+
   it("._ shouldn't compile messages in production", function() {
     const messages = {
       Hello: "Salut",


### PR DESCRIPTION
Syntax escaping is supported by ICU MessageFormat by using apostrophes http://userguide.icu-project.org/formatparse/messages#TOC-Quoting-Escaping

The bug that caused #457 has already been fixed in the `next` branch.

This PR adds some tests to prevent regressions.