### PR TITLE
[next] Add support for FLUENT format

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -47,6 +47,7 @@
     "cli-table": "^0.3.1",
     "commander": "^2.20.0",
     "date-fns": "^1.29.0",
+    "fluent-syntax": "^0.13.0",
     "fuzzaldrin": "^2.1.0",
     "glob": "^7.1.4",
     "inquirer": "^6.3.1",

--- a/packages/cli/src/api/formats/__snapshots__/fluent.test.ts.snap
+++ b/packages/cli/src/api/formats/__snapshots__/fluent.test.ts.snap
@@ -1,0 +1,146 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`fluent format should read catalog in fluent format 1`] = `
+Object {
+  multilineString: Object {
+    comments: undefined,
+    defaults: undefined,
+    description: undefined,
+    flags: undefined,
+    obsolete: false,
+    origin: Array [],
+    translation: One morning, when Gregor Samsa woke from troubled dreams, he found himself
+transformed in his bed into a horrible vermin. He lay on his armour-like
+back, and if he lifted his head a little he could see his brown belly,
+slightly domed and divided by arches into stiff sections. The bedding was
+hardly able to cover it and seemed ready to slide off any moment. His many
+legs, pitifully thin compared with the size of the rest of him, waved about
+helplessly as he looked. "What's happened to me?" he thought. It wasn't
+a dream. His room, a proper human
+  Two spaces before
+     Four spaces before,
+  },
+  obsolete: Object {
+    comments: Array [
+      Old message,
+    ],
+    defaults: undefined,
+    description: undefined,
+    flags: undefined,
+    obsolete: true,
+    origin: Array [],
+    translation: Obsolete message,
+  },
+  static: Object {
+    comments: undefined,
+    defaults: undefined,
+    description: undefined,
+    flags: undefined,
+    obsolete: false,
+    origin: Array [],
+    translation: Static message,
+  },
+  withComments: Object {
+    comments: Array [
+      Translator comment,
+      This one might come from developer,
+    ],
+    defaults: undefined,
+    description: undefined,
+    flags: undefined,
+    obsolete: false,
+    origin: Array [],
+    translation: Support translator comments separately,
+  },
+  withDescription: Object {
+    comments: undefined,
+    defaults: undefined,
+    description: Description is comment from developers to translators,
+    flags: undefined,
+    obsolete: false,
+    origin: Array [],
+    translation: Message with description,
+  },
+  withFlags: Object {
+    comments: undefined,
+    defaults: undefined,
+    description: undefined,
+    flags: Array [
+      fuzzy,
+      otherFlag,
+    ],
+    obsolete: false,
+    origin: Array [],
+    translation: Keeps any flags that are defined,
+  },
+  withMultipleOrigins: Object {
+    comments: undefined,
+    defaults: undefined,
+    description: undefined,
+    flags: undefined,
+    obsolete: false,
+    origin: Array [
+      Array [
+        src/App.js,
+        4,
+      ],
+      Array [
+        src/Component.js,
+        2,
+      ],
+    ],
+    translation: Message with multiple origin,
+  },
+  withOrigin: Object {
+    comments: undefined,
+    defaults: undefined,
+    description: undefined,
+    flags: undefined,
+    obsolete: false,
+    origin: Array [
+      Array [
+        src/App.js,
+        4,
+      ],
+    ],
+    translation: Message with origin,
+  },
+}
+`;
+
+exports[`fluent format should write catalog in fluent format 1`] = `
+static = Static message
+
+# #: src/App.js:4
+withOrigin = Message with origin
+
+# #: src/App.js:4
+# #: src/Component.js:2
+withMultipleOrigins = Message with multiple origin
+
+# Description is comment from developers to translators
+withDescription = Message with description
+
+# #. Translator comment
+# #. This one might come from developer
+withComments = Support translator comments separately
+
+# #~ # #. Old message
+# #~ obsolete = Obsolete message
+
+# #, fuzzy,otherFlag
+withFlags = Keeps any flags that are defined
+
+multilineString =
+    One morning, when Gregor Samsa woke from troubled dreams, he found himself
+    transformed in his bed into a horrible vermin. He lay on his armour-like
+    back, and if he lifted his head a little he could see his brown belly,
+    slightly domed and divided by arches into stiff sections. The bedding was
+    hardly able to cover it and seemed ready to slide off any moment. His many
+    legs, pitifully thin compared with the size of the rest of him, waved about
+    helplessly as he looked. "What's happened to me?" he thought. It wasn't
+    a dream. His room, a proper human
+      Two spaces before
+         Four spaces before
+
+`;

--- a/packages/cli/src/api/formats/__snapshots__/fluent.test.ts.snap
+++ b/packages/cli/src/api/formats/__snapshots__/fluent.test.ts.snap
@@ -3,9 +3,8 @@
 exports[`fluent format should read catalog in fluent format 1`] = `
 Object {
   multilineString: Object {
+    comment: undefined,
     comments: undefined,
-    defaults: undefined,
-    description: undefined,
     flags: undefined,
     obsolete: false,
     origin: Array [],
@@ -21,50 +20,45 @@ a dream. His room, a proper human
      Four spaces before,
   },
   obsolete: Object {
+    comment: undefined,
     comments: Array [
       Old message,
     ],
-    defaults: undefined,
-    description: undefined,
     flags: undefined,
     obsolete: true,
     origin: Array [],
     translation: Obsolete message,
   },
   static: Object {
+    comment: undefined,
     comments: undefined,
-    defaults: undefined,
-    description: undefined,
     flags: undefined,
     obsolete: false,
     origin: Array [],
     translation: Static message,
   },
   withComments: Object {
+    comment: undefined,
     comments: Array [
       Translator comment,
       This one might come from developer,
     ],
-    defaults: undefined,
-    description: undefined,
     flags: undefined,
     obsolete: false,
     origin: Array [],
     translation: Support translator comments separately,
   },
   withDescription: Object {
+    comment: Description is comment from developers to translators,
     comments: undefined,
-    defaults: undefined,
-    description: Description is comment from developers to translators,
     flags: undefined,
     obsolete: false,
     origin: Array [],
     translation: Message with description,
   },
   withFlags: Object {
+    comment: undefined,
     comments: undefined,
-    defaults: undefined,
-    description: undefined,
     flags: Array [
       fuzzy,
       otherFlag,
@@ -74,9 +68,8 @@ a dream. His room, a proper human
     translation: Keeps any flags that are defined,
   },
   withMultipleOrigins: Object {
+    comment: undefined,
     comments: undefined,
-    defaults: undefined,
-    description: undefined,
     flags: undefined,
     obsolete: false,
     origin: Array [
@@ -92,9 +85,8 @@ a dream. His room, a proper human
     translation: Message with multiple origin,
   },
   withOrigin: Object {
+    comment: undefined,
     comments: undefined,
-    defaults: undefined,
-    description: undefined,
     flags: undefined,
     obsolete: false,
     origin: Array [
@@ -118,7 +110,6 @@ withOrigin = Message with origin
 # #: src/Component.js:2
 withMultipleOrigins = Message with multiple origin
 
-# Description is comment from developers to translators
 withDescription = Message with description
 
 # #. Translator comment

--- a/packages/cli/src/api/formats/fixtures/messages.flt
+++ b/packages/cli/src/api/formats/fixtures/messages.flt
@@ -1,0 +1,33 @@
+static = Static message
+
+# #: src/App.js:4
+withOrigin = Message with origin
+
+# #: src/App.js:4
+# #: src/Component.js:2
+withMultipleOrigins = Message with multiple origin
+
+# Description is comment from developers to translators
+withDescription = Message with description
+
+# #. Translator comment
+# #. This one might come from developer
+withComments = Support translator comments separately
+
+# #~ # #. Old message
+# #~ obsolete = Obsolete message
+
+# #, fuzzy,otherFlag
+withFlags = Keeps any flags that are defined
+
+multilineString =
+    One morning, when Gregor Samsa woke from troubled dreams, he found himself
+    transformed in his bed into a horrible vermin. He lay on his armour-like
+    back, and if he lifted his head a little he could see his brown belly,
+    slightly domed and divided by arches into stiff sections. The bedding was
+    hardly able to cover it and seemed ready to slide off any moment. His many
+    legs, pitifully thin compared with the size of the rest of him, waved about
+    helplessly as he looked. "What's happened to me?" he thought. It wasn't
+    a dream. His room, a proper human
+      Two spaces before
+         Four spaces before

--- a/packages/cli/src/api/formats/fluent.test.ts
+++ b/packages/cli/src/api/formats/fluent.test.ts
@@ -62,7 +62,7 @@ describe("fluent format", function() {
       }
     }
 
-    format.write(filename, catalog, { language: "en" })
+    format.write(filename, catalog)
     const fltfile = fs.readFileSync(filename).toString()
     expect(fltfile).toMatchSnapshot()
   })

--- a/packages/cli/src/api/formats/fluent.test.ts
+++ b/packages/cli/src/api/formats/fluent.test.ts
@@ -1,0 +1,111 @@
+import fs from "fs"
+import path from "path"
+import mockFs from "mock-fs"
+import { mockConsole } from "@lingui/jest-mocks"
+
+import format from "./fluent"
+
+describe("fluent format", function() {
+  afterEach(() => {
+    mockFs.restore()
+  })
+
+  it("should write catalog in fluent format", function() {
+    mockFs({
+      locale: {
+        en: mockFs.directory()
+      }
+    })
+
+    const filename = path.join("locale", "en", "messages.flt")
+    const catalog = {
+      static: {
+        translation: "Static message"
+      },
+      withOrigin: {
+        translation: "Message with origin",
+        origin: [["src/App.js", 4]]
+      },
+      withMultipleOrigins: {
+        translation: "Message with multiple origin",
+        origin: [["src/App.js", 4], ["src/Component.js", 2]]
+      },
+      withDescription: {
+        translation: "Message with description",
+        description: "Description is comment from developers to translators"
+      },
+      withComments: {
+        comments: ["Translator comment", "This one might come from developer"],
+        translation: "Support translator comments separately"
+      },
+      obsolete: {
+        translation: "Obsolete message",
+        comments: ["Old message"],
+        obsolete: true
+      },
+      withFlags: {
+        flags: ["fuzzy", "otherFlag"],
+        translation: "Keeps any flags that are defined"
+      },
+      multilineString: {
+        translation:
+          "One morning, when Gregor Samsa woke from troubled dreams, he found himself" +
+          "\ntransformed in his bed into a horrible vermin. He lay on his armour-like" +
+          "\nback, and if he lifted his head a little he could see his brown belly," +
+          "\nslightly domed and divided by arches into stiff sections. The bedding was" +
+          "\nhardly able to cover it and seemed ready to slide off any moment. His many" +
+          "\nlegs, pitifully thin compared with the size of the rest of him, waved about" +
+          "\nhelplessly as he looked. \"What's happened to me?\" he thought. It wasn't" +
+          "\na dream. His room, a proper human" +
+          "\n  Two spaces before" +
+          "\n     Four spaces before"
+      }
+    }
+
+    format.write(filename, catalog, { language: "en" })
+    const fltfile = fs.readFileSync(filename).toString()
+    expect(fltfile).toMatchSnapshot()
+  })
+
+  it("should read catalog in fluent format", function() {
+    const flt = fs
+      .readFileSync(
+        path.join(path.resolve(__dirname), "fixtures", "messages.flt")
+      )
+      .toString()
+
+    mockFs({
+      locale: {
+        en: {
+          "messages.flt": flt
+        }
+      }
+    })
+
+    const filename = path.join("locale", "en", "messages.flt")
+    const actual = format.read(filename)
+    expect(actual).toMatchSnapshot()
+  })
+
+  it("should write the same catalog as it was read", function() {
+    const flt = fs
+      .readFileSync(
+        path.join(path.resolve(__dirname), "fixtures", "messages.flt")
+      )
+      .toString()
+
+    mockFs({
+      locale: {
+        en: {
+          "messages.flt": flt
+        }
+      }
+    })
+
+    const filename = path.join("locale", "en", "messages.flt")
+    const catalog = format.read(filename)
+    format.write(filename, catalog)
+    const actual = fs.readFileSync(filename).toString()
+    expect(actual).toEqual(flt)
+  })
+})

--- a/packages/cli/src/api/formats/fluent.ts
+++ b/packages/cli/src/api/formats/fluent.ts
@@ -1,8 +1,7 @@
-// @flow
 import fs from "fs"
 import { parse, serializeExpression } from "fluent-syntax"
 
-import { TranslationsFormat, MessageType } from "../types"
+import { MessageType } from "../types"
 import { joinOrigin, splitOrigin } from "../utils"
 
 // Most methods was adopted from
@@ -18,14 +17,10 @@ function indent(content, ind = "    ") {
 }
 
 function serializePattern(content) {
-  // TODO: check selector
-  const startOnNewLine =
-    /* content.some(isSelectExpr) || */ content.indexOf("\n") >= 0
-
+  const startOnNewLine = content.indexOf("\n") >= 0
   if (startOnNewLine) {
     return `\n    ${indent(content, "    ")}`
   }
-
   return ` ${content}`
 }
 
@@ -52,8 +47,8 @@ function serializeMessage(message, key) {
 
   const parts = []
 
-  if (message.description) {
-    parts.push(serializeComment(message.description, "#"))
+  if (message.comment) {
+    parts.push(serializeComment(message.comment, "#"))
   }
 
   if (message.comments) {
@@ -131,9 +126,8 @@ function deserializeMessageAST(entry) {
 
   const message: MessageType = {
     translation: deserializeMessagePatternAST(entry.value), // string,
-    defaults: undefined,
     origin: [], // Array<[number, string]>,
-    description: undefined, // ?string,
+    comment: undefined, // ?string,
     comments: undefined,
     obsolete: false, // boolean,
     flags: undefined // ?Array<string>
@@ -153,10 +147,10 @@ function deserializeMessageAST(entry) {
         if (!message.flags) message.flags = []
         message.flags.push(...line.substr(PREFIX_FLAGS.length + 1).split(","))
       } else {
-        if (!message.description) {
-          message.description = line
+        if (!message.comment) {
+          message.comment = line
         } else {
-          message.description += `\n${line}`
+          message.comment += `\n${line}`
         }
       }
     })
@@ -221,8 +215,8 @@ function deserialize(raw: string) {
   return catalog
 }
 
-const format: TranslationsFormat = {
-  filename: "messages.flt",
+export default {
+  catalogExtension: ".flt",
 
   write(filename, catalog) {
     fs.writeFileSync(filename, serialize(catalog))
@@ -238,5 +232,3 @@ const format: TranslationsFormat = {
     }
   }
 }
-
-export default format

--- a/packages/cli/src/api/formats/fluent.ts
+++ b/packages/cli/src/api/formats/fluent.ts
@@ -1,0 +1,242 @@
+// @flow
+import fs from "fs"
+import { parse, serializeExpression } from "fluent-syntax"
+
+import { TranslationsFormat, MessageType } from "../types"
+import { joinOrigin, splitOrigin } from "../utils"
+
+// Most methods was adopted from
+// https://github.com/projectfluent/fluent.js/blob/master/fluent-syntax/src/serializer.js
+
+const PREFIX_COMMENTS = "#."
+const PREFIX_ORIGIN = "#:"
+const PREFIX_FLAGS = "#,"
+const PREFIX_OBSOLETE = "#~"
+
+function indent(content, ind = "    ") {
+  return content.split("\n").join(`\n${ind}`)
+}
+
+function serializePattern(content) {
+  // TODO: check selector
+  const startOnNewLine =
+    /* content.some(isSelectExpr) || */ content.indexOf("\n") >= 0
+
+  if (startOnNewLine) {
+    return `\n    ${indent(content, "    ")}`
+  }
+
+  return ` ${content}`
+}
+
+function serializeComment(comment, prefix = "#") {
+  const prefixed = comment
+    .split("\n")
+    .map(line => (line.length ? `${prefix} ${line}` : prefix))
+    .join("\n")
+  // Add the trailing newline.
+  return `${prefixed}\n`
+}
+
+/**
+ * Fluent format can be found here:
+ * https://github.com/projectfluent/fluent/blob/master/spec/fluent.ebnf
+ */
+function serializeMessage(message, key) {
+  if (!/^[a-zA-Z][a-zA-Z0-9_-]*$/.test(key)) {
+    console.warn(
+      `Fluent Message with wrong key '${key}' was skipped. Valid key mask is /^[a-zA-Z][a-zA-Z0-9_-]*$/`
+    )
+    return ""
+  }
+
+  const parts = []
+
+  if (message.description) {
+    parts.push(serializeComment(message.description, "#"))
+  }
+
+  if (message.comments) {
+    message.comments.forEach(o => {
+      // Fluent 1.0 does not support translater comments
+      // Differs from po file! Cause by Fluent spec `description` should be as regular comment.
+      parts.push(serializeComment(o, `# ${PREFIX_COMMENTS}`))
+    })
+  }
+
+  if (message.origin) {
+    message.origin.forEach(o => {
+      // Fluent 1.0 does not support sources
+      parts.push(serializeComment(joinOrigin(o), `# ${PREFIX_ORIGIN}`))
+    })
+  }
+
+  if (message.flags && message.flags.length > 0) {
+    // Fluent 1.0 does not support flags
+    // So as fallback use `#,` comment like in po files
+    parts.push(serializeComment(message.flags.join(","), `# ${PREFIX_FLAGS}`))
+  }
+
+  parts.push(`${key} =`)
+
+  if (message.translation) {
+    parts.push(serializePattern(message.translation))
+  }
+
+  if (message.obsolete) {
+    // Comment obsolete messages like in po files
+    return serializeComment(parts.join(""), `# ${PREFIX_OBSOLETE}`)
+  }
+
+  parts.push("\n")
+  return parts.join("")
+}
+
+function serialize(catalog) {
+  return Object.keys(catalog)
+    .map(key => serializeMessage(catalog[key], key))
+    .join("\n")
+}
+
+function deserializeElementAst(element) {
+  switch (element.type) {
+    case "TextElement":
+      return element.value
+    case "Placeable":
+      return deserializePlaceableAST(element)
+  }
+}
+
+function deserializePlaceableAST(placeable) {
+  const expr = placeable.expression
+  switch (expr.type) {
+    case "Placeable":
+      return `{${deserializePlaceableAST(expr)}}`
+    case "SelectExpression":
+      // Special-case select expression to control the whitespace around the
+      // opening and the closing brace.
+      return `{ ${serializeExpression(expr)}}`
+    default:
+      return `{ ${serializeExpression(expr)} }`
+  }
+}
+
+function deserializeMessagePatternAST(value) {
+  return value.elements.map(deserializeElementAst).join("\n")
+}
+
+function deserializeMessageAST(entry) {
+  const key = entry && entry.id ? entry.id.name : null
+  if (!key) return
+
+  const message: MessageType = {
+    translation: deserializeMessagePatternAST(entry.value), // string,
+    defaults: undefined,
+    origin: [], // Array<[number, string]>,
+    description: undefined, // ?string,
+    comments: undefined,
+    obsolete: false, // boolean,
+    flags: undefined // ?Array<string>
+  }
+
+  if (entry.comment && entry.comment.content) {
+    const rawComment = entry.comment.content
+    const lines = rawComment.split("\n")
+    lines.forEach(line => {
+      if (line.startsWith(PREFIX_COMMENTS)) {
+        if (!message.comments) message.comments = []
+        message.comments.push(line.substr(PREFIX_COMMENTS.length + 1))
+      } else if (line.startsWith(PREFIX_ORIGIN)) {
+        if (!message.origin) message.origin = []
+        message.origin.push(splitOrigin(line.substr(PREFIX_ORIGIN.length + 1)))
+      } else if (line.startsWith(PREFIX_FLAGS)) {
+        if (!message.flags) message.flags = []
+        message.flags.push(...line.substr(PREFIX_FLAGS.length + 1).split(","))
+      } else {
+        if (!message.description) {
+          message.description = line
+        } else {
+          message.description += `\n${line}`
+        }
+      }
+    })
+  }
+
+  return [key, message]
+}
+
+function deserializeCommentAST(entry) {
+  const content = entry.content
+
+  let obsoleteFLT = []
+  const lines = content.split("\n")
+  lines.forEach(line => {
+    if (line.startsWith(PREFIX_OBSOLETE)) {
+      obsoleteFLT.push(line.substr(PREFIX_OBSOLETE.length + 1))
+    }
+  })
+
+  if (obsoleteFLT.length > 0) {
+    const flt = obsoleteFLT.join("\n")
+    const ast = parse(flt)
+    if (ast && ast.body && ast.body[0]) {
+      const data = deserializeEntry(ast.body[0])
+      if (data && data[1]) data[1].obsolete = true
+      return data
+    }
+  }
+}
+
+function deserializeEntry(entry) {
+  switch (entry.type) {
+    case "Message":
+      return deserializeMessageAST(entry)
+    case "Comment":
+      return deserializeCommentAST(entry)
+    // case "Term": // -term
+    // case "GroupComment": // ##
+    // case "ResourceComment": // ###
+    // case "Junk": // something wrong
+  }
+}
+
+function deserialize(raw: string) {
+  const ast = parse(raw)
+
+  if (ast.type !== "Resource") {
+    console.error(
+      `Fluent format parser error - Unknown resource type: ${ast.type}`
+    )
+  }
+
+  const catalog = {}
+  for (const entry of ast.body) {
+    const data = deserializeEntry(entry)
+    if (data) {
+      const [key, message] = data
+      if (key) catalog[key] = message
+    }
+  }
+
+  return catalog
+}
+
+const format: TranslationsFormat = {
+  filename: "messages.flt",
+
+  write(filename, catalog) {
+    fs.writeFileSync(filename, serialize(catalog))
+  },
+
+  read(filename) {
+    try {
+      const raw = fs.readFileSync(filename).toString()
+      return deserialize(raw)
+    } catch (e) {
+      console.error(`Cannot read ${filename}: ${e.message}`)
+      return {}
+    }
+  }
+}
+
+export default format

--- a/packages/cli/src/api/formats/index.ts
+++ b/packages/cli/src/api/formats/index.ts
@@ -1,9 +1,15 @@
 import lingui from "./lingui"
 import minimal from "./minimal"
 import po from "./po"
+import fluent from "./fluent"
 import { CatalogType } from "../types"
 
-const formats: {[key: string]: CatalogFormat} = { lingui, minimal, po }
+const formats: { [key: string]: CatalogFormat } = {
+  lingui,
+  minimal,
+  po,
+  fluent
+}
 
 export interface CatalogFormatOptions {
   locale: string
@@ -11,7 +17,11 @@ export interface CatalogFormatOptions {
 
 export interface CatalogFormat {
   catalogExtension: string
-  write(filename: string, catalog: CatalogType, options: CatalogFormatOptions): void
+  write(
+    filename: string,
+    catalog: CatalogType,
+    options: CatalogFormatOptions
+  ): void
   read(filename: string): void
 }
 

--- a/packages/conf/src/index.ts
+++ b/packages/conf/src/index.ts
@@ -4,7 +4,7 @@ import chalk from "chalk"
 import cosmiconfig from "cosmiconfig"
 import { validate } from "jest-validate"
 
-export type CatalogFormat = "po" | "minimal" | "lingui"
+export type CatalogFormat = "po" | "minimal" | "lingui" | "fluent"
 
 type CatalogConfig = {
   name?: string

--- a/packages/macro/src/fluent.test.ts
+++ b/packages/macro/src/fluent.test.ts
@@ -1,8 +1,8 @@
-import ICUMessageFormat from "./icu"
+import FluentMessageFormat from "./fluent"
 
 describe("ICU MessageFormat", function() {
   it("should collect text message", function() {
-    const messageFormat = new ICUMessageFormat()
+    const messageFormat = new FluentMessageFormat()
     const tokens = [
       {
         type: "text",
@@ -18,7 +18,7 @@ describe("ICU MessageFormat", function() {
   })
 
   it("should collect text message with arguments", function() {
-    const messageFormat = new ICUMessageFormat()
+    const messageFormat = new FluentMessageFormat()
     const tokens = [
       {
         type: "text",
@@ -32,7 +32,7 @@ describe("ICU MessageFormat", function() {
     ]
     expect(messageFormat.fromTokens(tokens)).toEqual(
       expect.objectContaining({
-        message: "Hello {name}",
+        message: "Hello {$name}",
         values: {
           name: "Joe"
         }
@@ -41,12 +41,8 @@ describe("ICU MessageFormat", function() {
   })
 
   it("should collect text message for plural", function() {
-    const messageFormat = new ICUMessageFormat()
+    const messageFormat = new FluentMessageFormat()
     const tokens = [
-      {
-        type: "text",
-        value: "Get "
-      },
       {
         type: "arg",
         name: "count",
@@ -54,7 +50,7 @@ describe("ICU MessageFormat", function() {
         format: "plural",
         options: {
           one: [
-            { type: "text", value: "# glass of " },
+            { type: "text", value: "Get one glass of " },
             {
               type: "arg",
               name: "drink",
@@ -62,7 +58,13 @@ describe("ICU MessageFormat", function() {
             }
           ],
           other: [
-            { type: "text", value: "# glasses of " },
+            { type: "text", value: "Get " },
+            {
+              type: "arg",
+              name: "count",
+              value: "5"
+            },
+            { type: "text", value: " glasses of " },
             {
               type: "arg",
               name: "drink",
@@ -75,7 +77,10 @@ describe("ICU MessageFormat", function() {
     expect(messageFormat.fromTokens(tokens)).toEqual(
       expect.objectContaining({
         message:
-          "Get {count, plural, one {# glass of {drink}} other {# glasses of {drink}}}",
+          "{ PLURAL($count) ->\n" +
+          "    [one] Get one glass of {$drink}\n" +
+          "    [other] Get {$count} glasses of {$drink}\n" +
+          "}",
         values: {
           count: "5",
           drink: "Beer"

--- a/packages/macro/src/fluent.ts
+++ b/packages/macro/src/fluent.ts
@@ -1,0 +1,111 @@
+const metaOptions = ["id", "comment", "props"]
+
+const escapedMetaOptionsRe = new RegExp(`^_(${metaOptions.join("|")})$`)
+
+export default function FluentMessageFormat() {}
+
+FluentMessageFormat.prototype.fromTokens = function(tokens) {
+  return (Array.isArray(tokens) ? tokens : [tokens])
+    .map(token => this.processToken(token))
+    .reduce(
+      (props, message) => ({
+        ...message,
+        message: props.message + message.message,
+        values: { ...props.values, ...message.values },
+        jsxElements: { ...props.jsxElements, ...message.jsxElements }
+      }),
+      {
+        message: "",
+        values: {},
+        jsxElements: {}
+      }
+    )
+}
+
+FluentMessageFormat.prototype.processToken = function(token) {
+  const jsxElements = {}
+
+  if (token.type === "text") {
+    return {
+      message: token.value
+    }
+  } else if (token.type === "arg") {
+    const values =
+      token.value !== undefined
+        ? {
+            [token.name]: token.value
+          }
+        : {}
+
+    switch (token.format) {
+      case "plural":
+      case "select":
+      case "selectordinal":
+        const formatOptions = Object.keys(token.options)
+          .filter(key => token.options[key] != null)
+          .map(key => {
+            let value = token.options[key]
+            key = key.replace(escapedMetaOptionsRe, "$1")
+
+            // if (key === "offset") {
+            //   // TODO: find how it implemented in fluent
+            //   // offset has special syntax `offset:number`
+            //   return `offset:${value}`
+            // }
+
+            if (typeof value !== "string") {
+              // process tokens from nested formatters
+              const {
+                message,
+                values: childValues,
+                jsxElements: childJsxElements
+              } = this.fromTokens(value)
+
+              Object.assign(values, childValues)
+              Object.assign(jsxElements, childJsxElements)
+              value = message
+            }
+
+            return `    [${key}] ${value}\n`
+          })
+          .join("")
+
+        return {
+          message: `{ ${token.format.toUpperCase()}(\$${
+            token.name
+          }) ->\n${formatOptions}}`,
+          values,
+          jsxElements
+        }
+      default:
+        return {
+          message: `{\$${token.name}}`,
+          values
+        }
+    }
+  } else if (token.type === "element") {
+    let message = ""
+    let elementValues = {}
+    Object.assign(jsxElements, { [token.name]: token.value })
+    token.children.forEach(child => {
+      const {
+        message: childMessage,
+        values: childValues,
+        jsxElements: childJsxElements
+      } = this.fromTokens(child)
+
+      message += childMessage
+      Object.assign(elementValues, childValues)
+      Object.assign(jsxElements, childJsxElements)
+    })
+    return {
+      message: token.children.length
+        ? `<${token.name}>${message}</${token.name}>`
+        : `<${token.name}/>`,
+      values: elementValues,
+      jsxElements
+    }
+  }
+
+  throw new Error(`Unknown token type ${token.type}`)
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3350,6 +3350,11 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.0.tgz#55122b6536ea496b4b44893ee2608141d10d9916"
   integrity sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==
 
+fluent-syntax@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/fluent-syntax/-/fluent-syntax-0.13.0.tgz#417144d99cba94ff474c422b3e6623d5a842855a"
+  integrity sha512-0Bk1AsliuYB550zr4JV9AYhsETsD3ELXUQzdXGJfIc1Ni/ukAfBdQInDhVMYJUaT2QxoamNslwkYF7MlOrPUwg==
+
 flush-write-stream@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/flush-write-stream/-/flush-write-stream-1.0.3.tgz#c5d586ef38af6097650b49bc41b55fabb19f35bd"


### PR DESCRIPTION
According to https://github.com/lingui/js-lingui/issues/489#issuecomment-497781933 needs to implement:
- [x] format in `cli`
- [x] processToken in `macro`
- [ ] add config property `parser`
- [ ] check compile
- [ ] polishing & refactoring