### PR TITLE
fix(cli): noMessages is not a function

### DIFF
--- a/packages/cli/src/lingui-compile.ts
+++ b/packages/cli/src/lingui-compile.ts
@@ -10,6 +10,12 @@ import { getCatalogs } from "./api/catalog"
 import { createCompiledCatalog } from "./api/compile"
 import { helpRun } from "./api/help"
 
+const noMessages: (catalogs: Object[]) => boolean = R.pipe(
+  R.map(R.isEmpty),
+  R.values,
+  R.all(R.equals<any>(true))
+)
+
 function command(config, options) {
   const catalogs = getCatalogs(config)
 
@@ -144,9 +150,3 @@ if (require.main === module) {
 
   console.log("Done!")
 }
-
-const noMessages: (catalogs: Object[]) => boolean = R.pipe(
-  R.map(R.isEmpty),
-  R.values,
-  R.all(R.equals<any>(true))
-)


### PR DESCRIPTION
This PR for `next` branch (v3.0.0).

Something strange happens with my setup:

```txt
$ yarn compile                 
yarn run v1.15.2
$ lingui compile
/Users/nodkz/www/_npm/lingui-express-middleware/examples/simple/node_modules/@lingui/cli/lingui-compile.js:30
  if (noMessages(catalogs)) {
      ^

TypeError: noMessages is not a function
    at command (/Users/nodkz/www/_npm/lingui-express-middleware/examples/simple/node_modules/@lingui/cli/lingui-compile.js:30:7)
    at Object.<anonymous> (/Users/nodkz/www/_npm/lingui-express-middleware/examples/simple/node_modules/@lingui/cli/lingui-compile.js:115:17)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
    at Module.load (internal/modules/cjs/loader.js:599:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
    at Function.Module._load (internal/modules/cjs/loader.js:530:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:742:12)
    at startup (internal/bootstrap/node.js:282:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:743:3)
error Command failed with exit code 1.
```

Moving `noMessage` declaration before `command` function resolves the problem.