### PR TITLE
fix(compile): fallback gracefully when source translation is missing

### DIFF
--- a/packages/cli/src/api/catalog.js
+++ b/packages/cli/src/api/catalog.js
@@ -104,7 +104,10 @@ export default (config: LinguiConfig): CatalogApi => {
     },
 
     getTranslation(catalogs, locale, key, { fallbackLocale, sourceLocale }) {
-      const getTranslation = locale => catalogs[locale][key].translation
+      const getTranslation = anotherLocale =>
+        (catalogs[anotherLocale][key] &&
+          catalogs[anotherLocale][key].translation) ||
+        undefined
 
       return (
         // Get translation in target locale
@@ -112,7 +115,7 @@ export default (config: LinguiConfig): CatalogApi => {
         // Get translation in fallbackLocale (if any)
         (fallbackLocale && getTranslation(fallbackLocale)) ||
         // Get message default
-        catalogs[locale][key].defaults ||
+        (catalogs[locale][key] && catalogs[locale][key].defaults) ||
         // If sourceLocale is either target locale of fallback one, use key
         (sourceLocale && sourceLocale === locale && key) ||
         (sourceLocale &&


### PR DESCRIPTION
- lingui version: `2.8.3`
# Goal of this PR
- This PR fixes `lingui compile` failing whan a locale has a string that the source locale doesn't.

```
(ko/messages.po, downloaded from translation platform)
...
msgid "Hello"
msgstr "안녕"
...
```
 
```
(en/messages.po, extracted from latest source)
...
#~ msgid "Hello" (now removed)
...
``` 

# Expected
- `lingui compile` should compile both `ko`, `en` without problem
# Actual
- `lingui compile` errors with following error:
```
/Users/.../node_modules/@lingui/cli/api/catalog.js:131
        return catalogs[locale][key].translation;
                                     ^

TypeError: Cannot read property 'translation' of undefined
    at getTranslation (/Users/.../node_modules/@lingui/cli/api/catalog.js:131:38)
```