### PR TITLE
Add optional sort by origin/filename

### DIFF
--- a/docs/ref/conf.rst
+++ b/docs/ref/conf.rst
@@ -193,3 +193,21 @@ localeDir
 Default: ``<rootDir>/locale``
 
 Directory where message catalogs should be saved.
+
+
+sorting
+---------
+
+Default: ``messageId``
+
+Sorting order for catalog files. Possible values are:
+
+messageId
+^^^^^^
+
+Sort by the message ID.
+
+origin
+^^^^^^^
+
+Sort by file origin of the message.

--- a/packages/cli/src/api/__snapshots__/extract.test.js.snap
+++ b/packages/cli/src/api/__snapshots__/extract.test.js.snap
@@ -124,3 +124,61 @@ Object {
   ],
 }
 `;
+
+exports[`order should order messages by origin 1`] = `
+Object {
+  en: Object {
+    LabelA: Object {
+      origin: Array [
+        Array [
+          file2.js,
+          3,
+        ],
+      ],
+      translation: A,
+    },
+    LabelB: Object {
+      origin: Array [
+        Array [
+          file1.js,
+          2,
+        ],
+        Array [
+          file2.js,
+          2,
+        ],
+      ],
+      translation: B,
+    },
+    LabelC: Object {
+      origin: Array [
+        Array [
+          file1.js,
+          1,
+        ],
+      ],
+      translation: C,
+    },
+    LabelD: Object {
+      origin: Array [
+        Array [
+          file2.js,
+          100,
+        ],
+      ],
+      translation: D,
+    },
+  },
+}
+`;
+
+exports[`order should order messages by origin 2`] = `
+Object {
+  en: Array [
+    LabelC,
+    LabelB,
+    LabelA,
+    LabelD,
+  ],
+}
+`;

--- a/packages/cli/src/api/extract.test.js
+++ b/packages/cli/src/api/extract.test.js
@@ -249,7 +249,7 @@ describe("order", function() {
       }
     }
 
-    const orderedCatalogs = order(catalogs)
+    const orderedCatalogs = order(catalogs, "messageId")
 
     // Test that the message content is the same as before
     expect(orderedCatalogs).toMatchSnapshot()
@@ -258,6 +258,41 @@ describe("order", function() {
     expect({
       en: Object.keys(orderedCatalogs.en),
       fr: Object.keys(orderedCatalogs.fr)
+    }).toMatchSnapshot()
+  })
+
+  it("should order messages by origin", function() {
+    const { order } = require("./extract")
+
+    const catalogs = {
+      en: {
+        LabelB: {
+          translation: "B",
+          origin: [["file2.js", 2], ["file1.js", 2]]
+        },
+        LabelA: {
+          translation: "A",
+          origin: [["file2.js", 3]]
+        },
+        LabelD: {
+          translation: "D",
+          origin: [["file2.js", 100]]
+        },
+        LabelC: {
+          translation: "C",
+          origin: [["file1.js", 1]]
+        }
+      }
+    }
+
+    const orderedCatalogs = order(catalogs, "origin")
+
+    // Test that the message content is the same as before
+    expect(orderedCatalogs).toMatchSnapshot()
+
+    // Jest snapshot order the keys automatically, so test that the key order explicitly
+    expect({
+      en: Object.keys(orderedCatalogs.en)
     }).toMatchSnapshot()
   })
 })

--- a/packages/cli/src/api/types.js
+++ b/packages/cli/src/api/types.js
@@ -8,8 +8,11 @@ export type LinguiConfig = {|
   pseudoLocale: string,
   srcPathDirs: Array<string>,
   srcPathIgnorePatterns: Array<string>,
-  format: "lingui" | "minimal" | "po"
+  format: "lingui" | "minimal" | "po",
+  sorting: Sorting
 |}
+
+export type Sorting = "messageId" | "origin"
 
 export type IdempotentResult<T> = [boolean, ?T] // [ created, result ]
 

--- a/packages/cli/src/lingui-extract.js
+++ b/packages/cli/src/lingui-extract.js
@@ -91,7 +91,8 @@ export default function command(
       catalog.merge(prevCatalogs, nextCatalog, {
         overwrite: options.overwrite
       })
-    )
+    ),
+    config.sorting
   )
   options.verbose && console.log()
 

--- a/packages/conf/src/index.js
+++ b/packages/conf/src/index.js
@@ -33,6 +33,7 @@ export const defaultConfig = {
   pseudoLocale: "",
   srcPathDirs: ["<rootDir>"],
   srcPathIgnorePatterns: [NODE_MODULES],
+  sorting: "messageId",
   format: "lingui",
   rootDir: ".",
   extractBabelOptions: {
@@ -57,14 +58,14 @@ const deprecatedConfig = {
     ` Option ${chalk.bold("fallbackLanguage")} was replaced by ${chalk.bold(
       "fallbackLocale"
     )}
-    
+
     @lingui/cli now treats your current configuration as:
     {
       ${chalk.bold('"fallbackLocale"')}: ${chalk.bold(
       `"${config.fallbackLanguage}"`
     )}
     }
-    
+
     Please update your configuration.
     `
 }


### PR DESCRIPTION
This is a proposal to add a config option `sorting` to expose a new sort by origin feature.

Unfortunately, `master` is in a rather bad state with a bunch of failing tests. Let me know what I can do to help.

Context https://github.com/lingui/js-lingui/issues/562