### PR TITLE
don't write unchanged extract files

### DIFF
--- a/packages/cli/src/api/formats/lingui.js
+++ b/packages/cli/src/api/formats/lingui.js
@@ -2,12 +2,13 @@
 import fs from "fs"
 
 import type { TranslationsFormat } from "../types"
+import { writeFileIfChanged } from "../utils"
 
 const format: TranslationsFormat = {
   filename: "messages.json",
 
   write(filename, catalog) {
-    fs.writeFileSync(filename, JSON.stringify(catalog, null, 2))
+    writeFileIfChanged(filename, JSON.stringify(catalog, null, 2))
   },
 
   read(filename) {

--- a/packages/cli/src/api/formats/minimal.js
+++ b/packages/cli/src/api/formats/minimal.js
@@ -3,6 +3,7 @@ import fs from "fs"
 import * as R from "ramda"
 
 import type { TranslationsFormat } from "../types"
+import { writeFileIfChanged } from "../utils"
 
 const serialize = R.map(message => message.translation || "")
 
@@ -16,7 +17,7 @@ const format: TranslationsFormat = {
   filename: "messages.json",
   write(filename, catalog) {
     const messages = serialize(catalog)
-    fs.writeFileSync(filename, JSON.stringify(messages, null, 2))
+    writeFileIfChanged(filename, JSON.stringify(messages, null, 2))
   },
 
   read(filename) {

--- a/packages/cli/src/api/formats/po.js
+++ b/packages/cli/src/api/formats/po.js
@@ -4,7 +4,7 @@ import * as R from "ramda"
 import { format as formatDate } from "date-fns"
 
 import PO from "pofile"
-import { joinOrigin, splitOrigin } from "../utils"
+import { joinOrigin, splitOrigin, writeFileIfChanged } from "../utils"
 import type { TranslationsFormat } from "../types"
 
 const getCreateHeaders = (language = "no") => ({
@@ -86,7 +86,6 @@ const format: TranslationsFormat = {
 
   write(filename, catalog, options = {}) {
     let po
-    let indexedItems = {}
     if (fs.existsSync(filename)) {
       const raw = fs.readFileSync(filename).toString()
       po = PO.parse(raw)
@@ -96,7 +95,7 @@ const format: TranslationsFormat = {
       po.headerOrder = R.keys(po.headers)
     }
     po.items = serialize(catalog)
-    fs.writeFileSync(filename, po.toString())
+    writeFileIfChanged(filename, po.toString())
   },
 
   read(filename) {

--- a/packages/cli/src/api/utils.js
+++ b/packages/cli/src/api/utils.js
@@ -74,3 +74,14 @@ export function helpMisspelledCommand(command, availableCommands = []) {
 export const splitOrigin = origin => origin.split(":")
 
 export const joinOrigin = origin => origin.join(":")
+
+export function writeFileIfChanged(filename, newContent) {
+  if (fs.existsSync(filename)) {
+    const raw = fs.readFileSync(filename).toString()
+    if (newContent !== raw) {
+      fs.writeFileSync(filename, newContent)
+    }
+  } else {
+    fs.writeFileSync(filename, newContent)
+  }
+}


### PR DESCRIPTION
Hi,

I want to create a pre-push hook to prevent untranslated strings by running `yarn extract`, then check if there is any uncommited changes (e. g. locale files). I'm using this command:

`yarn extract && git diff-index HEAD`

The problem is that extract always writes the locale files so they show up in `git diff` if I'm running the command above. This PR changes this behaviour and solves my problem.

