### PR TITLE
Fix issues with Flow type checking

### DIFF
--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -1,1 +1,2 @@
+// @flow
 export * from "./src"

--- a/packages/react/src/I18nProvider.js
+++ b/packages/react/src/I18nProvider.js
@@ -27,7 +27,7 @@ type LinguiPublisher = {|
 
   unsubscribe(callback: Function): void,
 
-  update(?{ catalogs?: Catalogs, language?: string, locales?: string }): void
+  update(?{ catalogs?: Catalogs, language?: string, locales?: Locales }): void
 |}
 
 /*
@@ -54,7 +54,11 @@ export function makeLinguiPublisher(i18n: I18n): LinguiPublisher {
     },
 
     update(
-      params: ?{ catalogs?: Catalogs, language?: string, locales?: string } = {}
+      params: ?{
+        catalogs?: Catalogs,
+        language?: string,
+        locales?: Locales
+      } = {}
     ) {
       if (!params) return
       const { catalogs, language, locales } = params

--- a/packages/react/src/I18nProvider.test.js
+++ b/packages/react/src/I18nProvider.test.js
@@ -165,14 +165,14 @@ describe("I18nPublisher", function() {
     })
     expect(linguiPublisher.i18n.language).toEqual("fr")
     expect(linguiPublisher.i18n.messages).toEqual({ msg: "salut!" })
-    expect(linguiPublisher.i18n.languageData.plurals()).toEqual("Function")
+    expect(typeof linguiPublisher.i18n.languageData.plurals).toEqual("function")
   })
 
   it("should subscribe/unsubscribe listeners for context changes", function() {
     const linguiPublisher = makeLinguiPublisher(
       setupI18n({
         language: "en",
-        catalogs: { en: {} }
+        catalogs: { en: { messages: {} } }
       })
     )
     const listener = jest.fn()
@@ -191,7 +191,7 @@ describe("I18nPublisher", function() {
     const linguiPublisher = makeLinguiPublisher(
       setupI18n({
         language: "en",
-        catalogs: { en: {}, fr: {} }
+        catalogs: { en: { messages: {} }, fr: { messages: {} } }
       })
     )
     linguiPublisher.subscribe(listener)

--- a/packages/react/src/Select.js
+++ b/packages/react/src/Select.js
@@ -48,7 +48,6 @@ const Select = withI18n()(
 
 const PluralFactory = (ordinal = false) => {
   const displayName = !ordinal ? "Plural" : "SelectOrdinal"
-  const pluralType = !ordinal ? "plural" : "selectOrdinal"
 
   return class extends React.Component<*, PluralProps> {
     displayName = displayName
@@ -61,6 +60,7 @@ const PluralFactory = (ordinal = false) => {
 
     render() {
       const { className, render, i18n, value, offset, ...props } = this.props
+      const getPluralValue = !ordinal ? i18n.plural : i18n.selectOrdinal
 
       // i18n.selectOrdinal/plural uses numbers for exact matches (1, 2),
       // while SelectOrdinal/Plural has to use strings (_1, _2).
@@ -80,7 +80,7 @@ const PluralFactory = (ordinal = false) => {
         <Render
           className={className}
           render={render}
-          value={i18n[pluralType](pluralProps)}
+          value={getPluralValue(pluralProps)}
         />
       )
     }

--- a/packages/react/src/Select.test.js
+++ b/packages/react/src/Select.test.js
@@ -9,7 +9,7 @@ describe("Categories", function() {
     setupI18n({
       language: language,
       locales: locales,
-      catalogs: { [language]: {} }
+      catalogs: { [language]: { messages: {} } }
     })
   const languageContext = (language, locales) => ({
     context: { linguiPublisher: { i18n: i18n(language, locales) } }


### PR DESCRIPTION
Currently, `Flow` isn't actually checking any type imported from `core` due to its root-level `index.js` file missing a `@flow` header. Fixing this revealed a few more errors which I also included fixes for in this branch.

Not all tests are passing in this branch; however all failing tests also fail on `master`, so I'm just ignoring them for now.