### PR TITLE
#587: Optional line numbers for lingui format

### DIFF
--- a/docs/ref/conf.rst
+++ b/docs/ref/conf.rst
@@ -128,6 +128,8 @@ Each message is an object composed in the following format:
 
 Origin is filename and line number from where the message was extracted.
 
+Note that origins may produce a large amount of merge conflicts. Origins can be disabled by setting ``origins: false`` in :conf:`formatOptions`.
+
 minimal
 ^^^^^^^
 
@@ -149,6 +151,15 @@ Gettext PO file:
    #: src/App.js:4, src/Component.js:2
    msgid "MessageID"
    msgstr "Translated Message"
+
+.. config:: formatOptions
+
+formatOptions
+-------------
+
+Default: ``{ origins: true }``
+
+Object for configuring message catalog output. See individual formats for options.
 
 .. config:: sourceLocale
 

--- a/packages/cli/src/api/catalog.js
+++ b/packages/cli/src/api/catalog.js
@@ -30,7 +30,10 @@ export default (config: LinguiConfig): CatalogApi => {
       )
 
       const created = !fs.existsSync(filename)
-      format.write(filename, messages, { language: locale })
+      format.write(filename, messages, {
+        language: locale,
+        ...config.formatOptions
+      })
       return [created, filename]
     },
 

--- a/packages/cli/src/api/formats/lingui.js
+++ b/packages/cli/src/api/formats/lingui.js
@@ -1,13 +1,20 @@
 // @flow
 import fs from "fs"
+import * as R from "ramda"
 
 import type { TranslationsFormat } from "../types"
+
+const removeOrigins = R.map(({ origin, ...message }) => message)
 
 const format: TranslationsFormat = {
   filename: "messages.json",
 
-  write(filename, catalog) {
-    fs.writeFileSync(filename, JSON.stringify(catalog, null, 2))
+  write(filename, catalog, options = {}) {
+    let outputCatalog = catalog
+    if (options.origins === false) {
+      outputCatalog = removeOrigins(catalog)
+    }
+    fs.writeFileSync(filename, JSON.stringify(outputCatalog, null, 2))
   },
 
   read(filename) {

--- a/packages/cli/src/api/types.js
+++ b/packages/cli/src/api/types.js
@@ -6,11 +6,16 @@ export type LinguiConfig = {|
   sourceLocale: string,
   fallbackLocale: string,
   pseudoLocale: string,
+  formatOptions: ?FormatOptions,
   srcPathDirs: Array<string>,
   srcPathIgnorePatterns: Array<string>,
   format: "lingui" | "minimal" | "po",
   sorting: Sorting
 |}
+
+export type FormatOptions = {
+  origins: ?boolean
+}
 
 export type Sorting = "messageId" | "origin"
 

--- a/packages/conf/src/index.js
+++ b/packages/conf/src/index.js
@@ -35,6 +35,9 @@ export const defaultConfig = {
   srcPathIgnorePatterns: [NODE_MODULES],
   sorting: "messageId",
   format: "lingui",
+  formatOptions: {
+    origins: true
+  },
   rootDir: ".",
   extractBabelOptions: {
     plugins: [],

--- a/scripts/build/results.json
+++ b/scripts/build/results.json
@@ -2,7 +2,7 @@
   "bundleSizes": {
     "@lingui/core.development.js (NODE_DEV)": {
       "size": 14825,
-      "gzip": 3861
+      "gzip": 3860
     },
     "@lingui/core.production.min.js (NODE_PROD)": {
       "size": 4286,
@@ -18,7 +18,7 @@
     },
     "dev.development.js (NODE_DEV)": {
       "size": 14825,
-      "gzip": 3861
+      "gzip": 3860
     },
     "dev.production.min.js (NODE_PROD)": {
       "size": 4286,


### PR DESCRIPTION
Adds configuration object `formatOptions` with key `origins`. The object is passed to the format's `write()` in the third param.

To turn off line numbers in catalogue files, configure `.linguirc` as follows:
```
"formatOptions": {
  "origins": false
}
```