### PR TITLE
[cli] Move typescript dependency to peer

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -58,14 +58,15 @@
     "ora": "^3.4.0",
     "pofile": "^1.0.11",
     "pseudolocale": "^1.1.0",
-    "ramda": "^0.26.1",
-    "typescript": "^2.9.2"
+    "ramda": "^0.26.1"
   },
   "devDependencies": {
-    "mockdate": "^2.0.2"
+    "mockdate": "^2.0.2",
+    "typescript": "^2.9.2"
   },
   "peerDependencies": {
     "babel-core": "6.x || ^7.0.0-bridge.0",
-    "babel-plugin-macros": "^2.4.2"
+    "babel-plugin-macros": "^2.4.2",
+    "typescript": "2 || 3"
   }
 }


### PR DESCRIPTION
With TS 3.7 the new syntax for optional chaining and nullish coalescing is added. Because cli depends on TS 2.9.2, it's not able to parse it. I think that moving TS as peer dependency is a safe option here. I did not dare to update in devDependencies, but it's unlikely it would break anything.