### PR TITLE
chore: update typescript to 3.7.2

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -58,14 +58,15 @@
     "ora": "^3.4.0",
     "pofile": "^1.0.11",
     "pseudolocale": "^1.1.0",
-    "ramda": "^0.26.1",
-    "typescript": "^2.9.2"
+    "ramda": "^0.26.1"
   },
   "devDependencies": {
-    "mockdate": "^2.0.2"
+    "mockdate": "^2.0.2",
+    "typescript": "^3.7.2"
   },
   "peerDependencies": {
     "babel-core": "6.x || ^7.0.0-bridge.0",
-    "babel-plugin-macros": "^2.4.2"
+    "babel-plugin-macros": "^2.4.2",
+    "typescript": "2.9.x || 3.x"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7139,10 +7139,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^2.9.2:
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
-  integrity sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==
+typescript@^3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.2.tgz#27e489b95fa5909445e9fef5ee48d81697ad18fb"
+  integrity sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==
 
 uglify-js@^3.1.4:
   version "3.4.9"


### PR DESCRIPTION
This PR updates `@lingui/cli` to use TypeScript 3.7 and be able to parse code containing the new optional chaining and nullish coalescing syntaxes.