### PR TITLE
#593: lazily split messages by value tags

### DIFF
--- a/packages/react/src/format.js
+++ b/packages/react/src/format.js
@@ -2,7 +2,7 @@
 import { cloneElement } from "react"
 
 // match <0>paired</0> and <1/> unpaired tags
-const tagRe = /<(\d+)>(.*)<\/\1>|<(\d+)\/>/
+const tagRe = /<(\d+)>(.*?)<\/\1>|<(\d+)\/>/
 const nlRe = /(?:\r\n|\r|\n)/g
 
 /**

--- a/packages/react/src/format.test.js
+++ b/packages/react/src/format.test.js
@@ -53,4 +53,16 @@ describe("formatElements", function() {
       )
     )
   })
+
+  it("should format multiple usages of same element in the same scope", function() {
+    expect(
+      html(
+        formatElements("<0>First</0> second <0>third</0> <0>fourth</0>", [
+          <sup />
+        ])
+      )
+    ).toEqual(
+      wrap("<sup>First</sup> second <sup>third</sup> <sup>fourth</sup>")
+    )
+  })
 })


### PR DESCRIPTION
#593 Adds support for reusing the same tag multiple times in the same line in the same scope.
Given a message: `"msg": "<0>first</0> second <0>third</0>"`, used with `<Trans id="msg" components=[{<sup />}] />`
We expect: `<sup>first</sup> second <sup>third</sup>`

In practice we get: `<sup>first&lt;/0&gt; second &lt;0&gt;third</sup>`

Current: https://regex101.com/r/LHoVEP/2
New: https://regex101.com/r/LHoVEP/1