### PR TITLE
Drop support for React 15.

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -37,7 +37,7 @@
     "cjs/"
   ],
   "peerDependencies": {
-    "react": "^15.0.0 || ^16.0.0"
+    "react": "^16.0.0"
   },
   "dependencies": {
     "@lingui/core": "0.0.0-managed-by-release-script",


### PR DESCRIPTION
Some components in `@lingui/react` return strings from their `render()` methods, which is a convention introduced in React 16 (see the first entry under "New Features" in the [v16.0.0 release notes](https://github.com/facebook/react/releases/tag/v16.0.0)).

This just updates the `peerDependencies` entry of `package.json` to clarify this fact. (See #592 for more details.)