### PR TITLE
Feature: set "msgctxt" though macro props

### DIFF
--- a/packages/babel-plugin-extract-messages/src/index.js
+++ b/packages/babel-plugin-extract-messages/src/index.js
@@ -12,7 +12,7 @@ const MESSAGES = Symbol("I18nMessages")
 // Then, i18n._ methods are visited multiple times for each parent CallExpression.
 const VISITED = Symbol("I18nVisited")
 
-function addMessage(path, messages, { id, defaults, origin, ...props }) {
+function addMessage(path, messages, { id, defaults, origin, context, ...props }) {
   if (messages.has(id)) {
     const message = messages.get(id)
 
@@ -27,9 +27,10 @@ function addMessage(path, messages, { id, defaults, origin, ...props }) {
       }
 
       ;[].push.apply(message.origin, origin)
+      message.context = context || message.context;
     }
   } else {
-    messages.set(id, { ...props, defaults, origin })
+    messages.set(id, { ...props, defaults, origin, context })
   }
 }
 
@@ -113,7 +114,7 @@ export default function({ types: t }) {
 
         const props = attrs.reduce((acc, item) => {
           const key = item.name.name
-          if (key === "id" || key === "defaults" || key === "description") {
+          if (key === "id" || key === "defaults" || key === "description" || key === "context") {
             if (item.value.value) {
               acc[key] = item.value.value
             } else if (
@@ -184,6 +185,7 @@ export default function({ types: t }) {
           (acc, item) => {
             const key = item.key.name
             if (key === "defaults") acc[key] = item.value.value
+            if (key === "context") acc[key] = item.value.value
             return acc
           },
           { id }
@@ -218,7 +220,7 @@ export default function({ types: t }) {
         const description = comment.value.replace(/\s*i18n:?\s*/, "").trim()
         if (description) props.description = description
 
-        const copyProps = ["id", "defaults"]
+        const copyProps = ["id", "defaults", "context"]
         path.node.properties
           .filter(({ key }) => copyProps.indexOf(key.name) !== -1)
           .forEach(({ key, value }) => {

--- a/packages/babel-plugin-extract-messages/test/__snapshots__/index.js.snap
+++ b/packages/babel-plugin-extract-messages/test/__snapshots__/index.js.snap
@@ -28,6 +28,25 @@ Object {
 
 exports[`babel-plugin-lingui-extract-messages should extract all messages from JS files (integration) 1`] = `
 Object {
+  Hello World: Object {
+    context: Context without id,
+    origin: Array [
+      Array [
+        packages/babel-plugin-extract-messages/test/fixtures/js/integration.js,
+        6,
+      ],
+    ],
+  },
+  customId: Object {
+    context: customContext,
+    defaults: Hello World,
+    origin: Array [
+      Array [
+        packages/babel-plugin-extract-messages/test/fixtures/js/integration.js,
+        5,
+      ],
+    ],
+  },
   msg.hello: Object {
     origin: Array [
       Array [
@@ -102,6 +121,15 @@ multiline,
       ],
     ],
   },
+  Message with context: Object {
+    context: context,
+    origin: Array [
+      Array [
+        packages/babel-plugin-extract-messages/test/fixtures/js/macro.js,
+        40,
+      ],
+    ],
+  },
   msg.id: Object {
     defaults: Message With Description,
     origin: Array [
@@ -116,6 +144,16 @@ multiline,
 
 exports[`babel-plugin-lingui-extract-messages should extract all messages from JS files 1`] = `
 Object {
+  msg.context: Object {
+    context: context,
+    defaults: Hello World,
+    origin: Array [
+      Array [
+        packages/babel-plugin-extract-messages/test/fixtures/js/all.js,
+        11,
+      ],
+    ],
+  },
   msg.default: Object {
     defaults: Hello World,
     origin: Array [
@@ -150,6 +188,15 @@ Object {
 
 exports[`babel-plugin-lingui-extract-messages should extract all messages from JSX files (integration) 1`] = `
 Object {
+  Hello world: Object {
+    context: context,
+    origin: Array [
+      Array [
+        packages/babel-plugin-extract-messages/test/fixtures/jsx/integration.js,
+        4,
+      ],
+    ],
+  },
   Hi, my name is {name}: Object {
     origin: Array [
       Array [
@@ -162,15 +209,15 @@ Object {
     origin: Array [
       Array [
         packages/babel-plugin-extract-messages/test/fixtures/jsx/integration.js,
-        4,
-      ],
-      Array [
-        packages/babel-plugin-extract-messages/test/fixtures/jsx/integration.js,
-        13,
+        5,
       ],
       Array [
         packages/babel-plugin-extract-messages/test/fixtures/jsx/integration.js,
         14,
+      ],
+      Array [
+        packages/babel-plugin-extract-messages/test/fixtures/jsx/integration.js,
+        15,
       ],
     ],
   },
@@ -178,15 +225,15 @@ Object {
     origin: Array [
       Array [
         packages/babel-plugin-extract-messages/test/fixtures/jsx/integration.js,
-        6,
+        7,
       ],
       Array [
         packages/babel-plugin-extract-messages/test/fixtures/jsx/integration.js,
-        16,
+        17,
       ],
       Array [
         packages/babel-plugin-extract-messages/test/fixtures/jsx/integration.js,
-        21,
+        22,
       ],
     ],
   },
@@ -200,6 +247,15 @@ Object {
       Array [
         packages/babel-plugin-extract-messages/test/fixtures/jsx/all.js,
         9,
+      ],
+    ],
+  },
+  msg.context: Object {
+    context: context,
+    origin: Array [
+      Array [
+        packages/babel-plugin-extract-messages/test/fixtures/jsx/all.js,
+        16,
       ],
     ],
   },

--- a/packages/babel-plugin-extract-messages/test/fixtures/js/all.js
+++ b/packages/babel-plugin-extract-messages/test/fixtures/js/all.js
@@ -8,3 +8,4 @@ i18n._("{count, plural, one {# book} other {# books}}", {
   count: count
 })
 i18n._(message)
+i18n._("msg.context", null, { defaults: "Hello World", context: "context"})

--- a/packages/babel-plugin-extract-messages/test/fixtures/js/integration.js
+++ b/packages/babel-plugin-extract-messages/test/fixtures/js/integration.js
@@ -2,3 +2,5 @@ import { t } from "@lingui/macro"
 
 const a = i18n._(t`msg.hello`)
 i18n._(t`msg.hello`)
+i18n._(t({id: 'customId', context: 'customContext'})`Hello World`)
+i18n._(t({context: "Context without id"})`Hello World`)

--- a/packages/babel-plugin-extract-messages/test/fixtures/js/macro.js
+++ b/packages/babel-plugin-extract-messages/test/fixtures/js/macro.js
@@ -36,3 +36,8 @@ const withValues = /*i18n*/{
 i18n._(/*i18n*/{
   id: 'Message With Description'
 })
+
+i18n._(/*i18n*/{
+  id: 'Message with context',
+  context: 'context'
+})

--- a/packages/babel-plugin-extract-messages/test/fixtures/jsx/all.js
+++ b/packages/babel-plugin-extract-messages/test/fixtures/jsx/all.js
@@ -13,3 +13,4 @@ i18n._("{count, plural, one {# book} other {# books}}", {
   }
 })
 ;<Trans id={message} />
+;<Trans id="msg.context" context="context" />

--- a/packages/babel-plugin-extract-messages/test/fixtures/jsx/integration.js
+++ b/packages/babel-plugin-extract-messages/test/fixtures/jsx/integration.js
@@ -1,6 +1,7 @@
 import { t, plural, Trans } from "@lingui/macro"
 
 ;<Trans>Hi, my name is {name}</Trans>
+;<Trans context="context">Hello world</Trans>
 ;<span title={i18n._(t`Title`)} />
 ;<span
   title={i18n._(plural({

--- a/packages/babel-plugin-transform-js/test/fixtures/t/actual.js
+++ b/packages/babel-plugin-transform-js/test/fixtures/t/actual.js
@@ -17,3 +17,4 @@ i18n.t`
 `
 i18n.t('id')`Hello World`
 i18n.t('id')`Hello ${name}`
+i18n.t({id: 'id', context: 'context'})`Hello World`

--- a/packages/babel-plugin-transform-js/test/fixtures/t/expected.js
+++ b/packages/babel-plugin-transform-js/test/fixtures/t/expected.js
@@ -23,3 +23,7 @@ i18n._('id', {
 }, {
   defaults: 'Hello {name}'
 });
+i18n._('id', {}, {
+  defaults: 'Hello World',
+  context: 'context'
+});

--- a/packages/cli/src/api/formats/__snapshots__/po.test.js.snap
+++ b/packages/cli/src/api/formats/__snapshots__/po.test.js.snap
@@ -1,0 +1,206 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`pofile format should correct badly used comments 1`] = `
+Object {
+  withDescriptionAndComments: Object {
+    comments: Array [
+      Translator comment,
+      Second description?,
+    ],
+    context: undefined,
+    description: Single description only,
+    flags: Array [],
+    obsolete: false,
+    origin: Array [],
+    translation: Second description joins translator comments,
+  },
+  withMultipleDescriptions: Object {
+    comments: Array [
+      Second comment,
+      Third comment,
+    ],
+    context: undefined,
+    description: First description,
+    flags: Array [],
+    obsolete: false,
+    origin: Array [],
+    translation: Extra comments are separated from the first description line,
+  },
+}
+`;
+
+exports[`pofile format should read catalog in pofile format 1`] = `
+Object {
+  obsolete: Object {
+    comments: Array [],
+    context: undefined,
+    description: undefined,
+    flags: Array [],
+    obsolete: true,
+    origin: Array [],
+    translation: Is marked as obsolete,
+  },
+  static: Object {
+    comments: Array [],
+    context: undefined,
+    description: undefined,
+    flags: Array [],
+    obsolete: false,
+    origin: Array [],
+    translation: Static message,
+  },
+  veryLongString: Object {
+    comments: Array [],
+    context: undefined,
+    description: undefined,
+    flags: Array [],
+    obsolete: false,
+    origin: Array [],
+    translation: One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections. The bedding was hardly able to cover it and seemed ready to slide off any moment. His many legs, pitifully thin compared with the size of the rest of him, waved about helplessly as he looked. "What's happened to me?" he thought. It wasn't a dream. His room, a proper human,
+  },
+  withComments: Object {
+    comments: Array [
+      Translator comment,
+      This one might come from developer,
+    ],
+    context: undefined,
+    description: undefined,
+    flags: Array [],
+    obsolete: false,
+    origin: Array [],
+    translation: Support translator comments separately,
+  },
+  withContext: Object {
+    comments: Array [],
+    context: Description of the context,
+    description: undefined,
+    flags: Array [],
+    obsolete: false,
+    origin: Array [],
+    translation: Context can be used to group related items together,
+  },
+  withDescription: Object {
+    comments: Array [],
+    context: undefined,
+    description: Description is comment from developers to translators,
+    flags: Array [],
+    obsolete: false,
+    origin: Array [],
+    translation: Message with description,
+  },
+  withFlags: Object {
+    comments: Array [],
+    context: undefined,
+    description: undefined,
+    flags: Array [
+      fuzzy,
+      otherFlag,
+    ],
+    obsolete: false,
+    origin: Array [],
+    translation: Keeps any flags that are defined,
+  },
+  withMultipleOrigins: Object {
+    comments: Array [],
+    context: undefined,
+    description: undefined,
+    flags: Array [],
+    obsolete: false,
+    origin: Array [
+      Array [
+        src/App.js,
+        4,
+      ],
+      Array [
+        src/Component.js,
+        2,
+      ],
+    ],
+    translation: Message with multiple origin,
+  },
+  withOrigin: Object {
+    comments: Array [],
+    context: undefined,
+    description: undefined,
+    flags: Array [],
+    obsolete: false,
+    origin: Array [
+      Array [
+        src/App.js,
+        4,
+      ],
+    ],
+    translation: Message with origin,
+  },
+}
+`;
+
+exports[`pofile format should throw away additional msgstr if present 1`] = `
+Object {
+  withMultipleTranslation: Object {
+    comments: Array [],
+    context: undefined,
+    description: undefined,
+    flags: Array [],
+    obsolete: false,
+    origin: Array [],
+    translation: This is just fine,
+  },
+}
+`;
+
+exports[`pofile format should write catalog in pofile format 1`] = `
+Array [
+  Array [
+    locale\\en\\messages.po,
+    msgid ""
+msgstr ""
+"Project-Id-Version: \\n"
+"Report-Msgid-Bugs-To: \\n"
+"POT-Creation-Date: \\n"
+"PO-Revision-Date: \\n"
+"Last-Translator: \\n"
+"Language: \\n"
+"Language-Team: \\n"
+"Content-Type: \\n"
+"Content-Transfer-Encoding: \\n"
+"Plural-Forms: \\n"
+
+msgid "static"
+msgstr "Static message"
+
+#: src/App.js:4
+msgid "withOrigin"
+msgstr "Message with origin"
+
+#: src/App.js:4
+#: src/Component.js:2
+msgid "withMultipleOrigins"
+msgstr "Message with multiple origin"
+
+#. Description is comment from developers to translators
+msgid "withDescription"
+msgstr "Message with description"
+
+# Translator comment
+# This one might come from developer
+msgid "withComments"
+msgstr "Support translator comments separately"
+
+msgctxt "Description of the context"
+msgid "withContext"
+msgstr "Context can be used to group related items together"
+
+#~ msgid "obsolete"
+#~ msgstr "Obsolete message"
+
+#, fuzzy,otherFlag
+msgid "withFlags"
+msgstr "Keeps any flags that are defined"
+
+msgid "veryLongString"
+msgstr "One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections. The bedding was hardly able to cover it and seemed ready to slide off any moment. His many legs, pitifully thin compared with the size of the rest of him, waved about helplessly as he looked. \\"What's happened to me?\\" he thought. It wasn't a dream. His room, a proper human"
+,
+  ],
+]
+`;

--- a/packages/cli/src/api/formats/fixtures/messages.po
+++ b/packages/cli/src/api/formats/fixtures/messages.po
@@ -34,6 +34,10 @@ msgstr "Message with description"
 msgid "withComments"
 msgstr "Support translator comments separately"
 
+msgctxt "Description of the context"
+msgid "withContext"
+msgstr "Context can be used to group related items together"
+
 msgid "veryLongString"
 msgstr "One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections. The bedding was hardly able to cover it and seemed ready to slide off any moment. His many legs, pitifully thin compared with the size of the rest of him, waved about helplessly as he looked. \"What's happened to me?\" he thought. It wasn't a dream. His room, a proper human"
 

--- a/packages/cli/src/api/formats/po.js
+++ b/packages/cli/src/api/formats/po.js
@@ -22,6 +22,7 @@ const serialize = R.compose(
     const item = new PO.Item()
     item.msgid = key
     item.msgstr = message.translation
+    item.msgctxt = message.context
     item.comments = message.comments || []
     item.extractedComments = message.description ? [message.description] : []
     item.references = message.origin ? message.origin.map(joinOrigin) : []
@@ -35,6 +36,7 @@ const serialize = R.compose(
 
 const getMessageKey = R.prop("msgid")
 const getTranslations = R.prop("msgstr")
+const getContext = R.prop("msgctxt")
 const getExtractedComments = R.prop("extractedComments")
 const getTranslatorComments = R.prop("comments")
 const getOrigins = R.prop("references")
@@ -52,6 +54,10 @@ const deserialize = R.map(
       R.head,
       R.defaultTo([]),
       getTranslations
+    ),
+    context: R.compose(
+      R.defaultTo(undefined),
+      getContext
     ),
     description: R.compose(
       R.head,

--- a/packages/cli/src/api/types.js
+++ b/packages/cli/src/api/types.js
@@ -22,6 +22,7 @@ export type MessageType = {
   origin: Array<[number, string]>,
   description: ?string,
   comments: ?Array<string>,
+  context: ?string,
   obsolete: boolean,
   flags: ?Array<string>
 }

--- a/packages/core/src/i18n.js
+++ b/packages/core/src/i18n.js
@@ -10,7 +10,8 @@ import * as dev from "./dev"
 
 type MessageOptions = {|
   defaults?: string,
-  formats?: Object
+  formats?: Object,
+  context?: string
 |}
 
 type Locales = string | string[]
@@ -183,7 +184,7 @@ class I18n {
   _(
     id: string | Object,
     values: Object = {},
-    { defaults, formats = {} }: MessageOptions = {}
+    { defaults, formats = {}, context }: MessageOptions = {}
   ) {
     // Expand message descriptor
     if (id && typeof id === "object") {
@@ -191,6 +192,7 @@ class I18n {
       defaults = id.defaults
       formats = id.formats
       id = id.id
+      context = id.context
     }
 
     let translation = this.messages[id] || defaults || id


### PR DESCRIPTION
This PR allows the `msgctxt` property to be set though the `Trans` and `t` macros

## Changes 

```jsx
<Trans context="Currency selector options">USD</Trans>
```

becomes

```po
msgctxt "Currency selector options"
msgid "USD"
msgstr ""
```

Likewise
```js
i18n._(t({context: "Modal controls"})`Close`)
```

becomes 

```po
msgctxt "Modal controls"
msgid "Close"
msgstr ""
```

## Motivation

PO editors (e.g. [Poedit](https://poedit.net/)) use `msgctxt` to group translations, which is helpful for translators' workflows - especially for lists of translations such as `<select>` options.