### PR TITLE
Log a helpful warning if we're returning a string from render() in React 15

### DIFF
--- a/packages/react/src/Render.js
+++ b/packages/react/src/Render.js
@@ -23,6 +23,17 @@ export default class Render extends React.Component<RenderComponentProps> {
     let render = this.props.render || this.context.linguiDefaultRender
 
     if (render === null || render === undefined) {
+      if (process.env.NODE_ENV === "production" && typeof value === "string") {
+        if (/^15\./.test(React.version)) {
+          console.warn(
+            "lingui is about to return a string from render() in React 15.x, " +
+              "which will likely raise an Uncaught Invariant Violation error. " +
+              "to resolve this, please provide a custom defaultRender function " +
+              "that wraps the string in a component of your choice, or upgrade " +
+              "to React 16."
+          )
+        }
+      }
       return value || null
     } else if (typeof render === "string") {
       // Built-in element: h1, p

--- a/packages/react/src/Render.js
+++ b/packages/react/src/Render.js
@@ -23,7 +23,7 @@ export default class Render extends React.Component<RenderComponentProps> {
     let render = this.props.render || this.context.linguiDefaultRender
 
     if (render === null || render === undefined) {
-      if (process.env.NODE_ENV === "production" && typeof value === "string") {
+      if (process.env.NODE_ENV !== "production" && typeof value === "string") {
         if (/^15\./.test(React.version)) {
           console.warn(
             "lingui is about to return a string from render() in React 15.x, " +

--- a/packages/react/src/Render.js
+++ b/packages/react/src/Render.js
@@ -2,8 +2,6 @@
 import * as React from "react"
 import PropTypes from "prop-types"
 
-const REACT_VERSION = React.version
-
 export type RenderProps = {
   render?: any,
   className?: string
@@ -26,7 +24,7 @@ export default class Render extends React.Component<RenderComponentProps> {
 
     if (render === null || render === undefined) {
       if (process.env.NODE_ENV !== "production" && typeof value === "string") {
-        if (/^15\./.test(REACT_VERSION)) {
+        if (/^15\./.test(React.version)) {
           console.warn(
             "lingui is about to return a string from render() in React 15.x, " +
               "which will likely raise an Uncaught Invariant Violation error. " +

--- a/packages/react/src/Render.js
+++ b/packages/react/src/Render.js
@@ -2,6 +2,8 @@
 import * as React from "react"
 import PropTypes from "prop-types"
 
+const REACT_VERSION = React.version
+
 export type RenderProps = {
   render?: any,
   className?: string
@@ -24,7 +26,7 @@ export default class Render extends React.Component<RenderComponentProps> {
 
     if (render === null || render === undefined) {
       if (process.env.NODE_ENV !== "production" && typeof value === "string") {
-        if (/^15\./.test(React.version)) {
+        if (/^15\./.test(REACT_VERSION)) {
           console.warn(
             "lingui is about to return a string from render() in React 15.x, " +
               "which will likely raise an Uncaught Invariant Violation error. " +

--- a/scripts/build/modules.js
+++ b/scripts/build/modules.js
@@ -9,6 +9,7 @@ const { UNIVERSAL } = require("./bundles").bundleTypes
 const HAS_NO_SIDE_EFFECTS_ON_IMPORT = false
 
 const importSideEffects = Object.freeze({
+  "react": HAS_NO_SIDE_EFFECTS_ON_IMPORT,
   "babel-runtime/core-js/object/get-own-property-names": HAS_NO_SIDE_EFFECTS_ON_IMPORT,
   "babel-runtime/helpers/slicedToArray": HAS_NO_SIDE_EFFECTS_ON_IMPORT,
   "messageformat-parser": HAS_NO_SIDE_EFFECTS_ON_IMPORT,


### PR DESCRIPTION
This is an alternative to #597 that, instead of dropping support for React 15, logs a helpful warning if `render()` is about to return a string in React 15, to make it easier for developers to debug #592.

@tricoder42 does this kind of fix seem OK?  It doesn't actually update the docs yet, but I wanted to get your feedback on the code change and the text of the warning.

## To do

- [ ] Add docs that mention the workaround for React 15.
 