### PR TITLE
Fix a code sample

### DIFF
--- a/docs/tutorials/react.rst
+++ b/docs/tutorials/react.rst
@@ -44,8 +44,8 @@ We're going to translate the following app:
            <p>
              {
                messagesCount === 1
-                 ? "There's {messagesCount} message in your inbox."
-                 : "There're {messagesCount} messages in your inbox."
+                 ? `There's ${messagesCount} message in your inbox.`
+                 : `There're ${messagesCount} messages in your inbox.`
              }
            </p>
 


### PR DESCRIPTION
One of the code samples provided in the tutorials looks wrong:

```js
{
  messagesCount === 1
    ? "There's {messagesCount} message in your inbox."
    : "There're {messagesCount} messages in your inbox."
}
```

It seems that the `messageCount` variable was meant to be interpolated:

```patch
{
  messagesCount === 1
-    ? "There's {messagesCount} message in your inbox."
+    ? `There's ${messagesCount} message in your inbox.`
-    : "There're {messagesCount} messages in your inbox."
+    : `There're ${messagesCount} messages in your inbox.`
}
```