### PR TITLE
Add `babel-plugin-macros` to default TypeScript plugins to make message extraction much easier to setup for non-CRA projects

### DIFF
--- a/packages/cli/src/api/extractors/typescript.js
+++ b/packages/cli/src/api/extractors/typescript.js
@@ -47,6 +47,7 @@ const extractor: ExtractorType = {
       linguiTransformJs,
       linguiTransformReact,
       [linguiExtractMessages, { localeDir }],
+      "babel-plugin-macros",
       ...(babelOptions.plugins || [])
     ]
 


### PR DESCRIPTION
Add `babel-plugin-macros` to plugins since it's required for any project type. The plugin is often included by default by presets such as `react-app` and `tsdx`, but since only `react-app` is supported by default, extracting in other libraries (in my case TSDX) is much more time consuming to configure.