### PR TITLE
Fix flow types on withI18n

### DIFF
--- a/packages/react/src/withI18n.js
+++ b/packages/react/src/withI18n.js
@@ -19,7 +19,7 @@ type withI18nProps = {
 const withI18n = (options: withI18nOptions = {}) =>
   function<P, C: React.ComponentType<P>>(
     WrappedComponent: C
-  ): C & React.ComponentType<$Diff<P, withI18nProps>> {
+  ): React.ComponentType<$Diff<P, withI18nProps>> {
     if (process.env.NODE_ENV !== "production") {
       if (typeof options === "function" || React.isValidElement(options)) {
         console.warn(


### PR DESCRIPTION
Hello guys,

I don't know how that works for others, but the existing flow types in withI18n throw a lot of errors in our project.
I figured out that the proposed change fixes this.

As far as I understand flowtype and the withI18n component, the return type is indeed `React.ComponentType<$Diff<P, withI18nProps>>` and not an intersection of `C` and the above.

Please take a look if it makes sense for you too.