### PR TITLE
docs: Fixed typo in CLI example

### DIFF
--- a/docs/tutorials/cli.rst
+++ b/docs/tutorials/cli.rst
@@ -112,7 +112,7 @@ plural rules to a production ready catalog::
 
    yarn compile
 
- .. code-block:: shell
+.. code-block:: shell
 
    Compiling message catalogs…
    Done!


### PR DESCRIPTION
Fixed typo in CLI example.
https://lingui.js.org/tutorials/cli.html