### PR TITLE
Correcting bugs in "lazy translations" sample code

### DIFF
--- a/docs/tutorials/react-patterns.rst
+++ b/docs/tutorials/react-patterns.rst
@@ -201,27 +201,32 @@ Lazy translations
 Messages don't have to be declared at the same code location where they're displayed.
 Tag a string with the :jsmacro:`t` macro, and you've created a "message descriptor", which
 can then be passed around as a variable, and can be displayed as a translated string by
-passing it to :jsxmacro:`Trans` as its ``id`` prop:
+passing its ``id`` attribute to :jsxmacro:`Trans` as its ``id`` prop:
 
 .. code-block:: jsx
 
-   import { t, Trans } from "@lingui/macro"
+   import React from 'react';
+   import { t, Trans } from '@lingui/macro';
 
+   // Creates an array of message descriptor objects
    const favoriteColors = [
       t`Red`,
       t`Orange`,
       t`Yellow`,
-      t`Green`,
-   ]
+      t`Green`
+   ];
 
    export default function ColorList() {
       return (
          <ul>
-            {favoriteColors.map(color => (
-               <li><Trans id={color}/></li>
-            }
+            {favoriteColors.map((color) => (
+            <li key={color.id}>
+               {/* Passing the message descriptor's `id` as the `id` prop */}
+               <Trans id={color.id} />
+            </li>
+            ))}
          </ul>
-      )
+      );
    }
 
 Or to render the message descriptor as a string-only translation, just pass it to
@@ -229,6 +234,8 @@ the :js:meth:`I18n._` method as usual:
 
 .. code-block:: jsx
 
+   import React from 'react';
+   import { I18n } from '@lingui/react';
    import { t } from "@lingui/macro"
 
    const favoriteColors = [
@@ -238,9 +245,29 @@ the :js:meth:`I18n._` method as usual:
       t`Green`,
    ]
 
-   const translatedColorNames = favoriteColors.map(
-      color => i18n._(color)
-   )
+   export default function ColorMenu() {
+      // Using the `<I18n>` component to access the `i18n` object.
+      <I18n>
+         {({ i18n }) => {
+            const options = favoriteColors.map((color) => ({
+               value: color.id,
+
+               // Passing the message descriptor directly to i18n._()
+               label: i18n._(color),
+
+            }));
+            return (
+               <select>
+                  {options.map(({ label, value }) => (
+                     <option key={value} value={value}>
+                        {label}
+                     </option>
+                  ))}
+               </select>
+            );
+         }}
+      </I18n>
+   }
 
 Passing messages as props
 -------------------------
@@ -251,6 +278,7 @@ element as the prop:
 
 .. code-block:: jsx
 
+   import React from 'react';
    import { Trans } from "@lingui/macro"
 
    export default function FancyButton(props) {
@@ -259,8 +287,11 @@ element as the prop:
 
    export function LoginLogoutButtons(props) {
       return <div>
+
+         {/* Passing `<Trans>` elements as props */}
          <FancyButton label={<Trans>Log in</Trans>} />
          <FancyButton label={<Trans>Log out</Trans>} />
+
       </div>
    }
 
@@ -270,28 +301,31 @@ render it as a string using lazy translation:
 
 .. code-block:: jsx
 
+   import React from 'react';
    import { t } from "@lingui/macro"
    import { I18n } from "@lingui/react"
 
-   export default function ImageWithCaption(props) {
+   function ImageWithCaption(props) {
       return (
          <I18n>
-            {({ i18n }) => (
-               <img src="..." alt={i18n._(props.caption)} />
-            )}
+            {({ i18n }) => <img
+               src="..."
+               title={i18n._(props.hoverText)}
+            />}
          </I18n>
-      )
+      );
    }
 
    export function HappySad(props) {
-      return <div>
-         <ImageWithCaption
-            hoverText={t`I'm so happy!`}
-         />
-         <ImageWithCaption
-            hoverText={t`I'm so sad.`}
-         />
-      </div>
+      return (
+         <div>
+
+            {/* Passing message descriptors tagged with `t` as props */}
+            <ImageWithCaption hoverText={t`I'm so happy!`} />
+            <ImageWithCaption hoverText={t`I'm so sad.`} />
+
+         </div>
+      );
    }
 
 Picking a message based on a variable
@@ -314,6 +348,8 @@ with lazy translation:
          STATUS_CANCELLED = 4,
          STATUS_COMPLETED = 8
 
+   // A mapping object that provides a message descriptor for each expected
+   // value of the "status" variable
    const statusMessages = {
       [STATUS_OPEN]: t`Open`,
       [STATUS_CLOSED]: t`Closed`,
@@ -321,6 +357,14 @@ with lazy translation:
       [STATUS_COMPLETED]: t`Completed`,
    }
 
-   export default function StatusDisplay(statusCode) {
-      return <div><Trans id={statusMessages[statusCode]} /></div>
+   export default function StatusDisplay(props) {
+      // Locate the correct message descriptor
+      const messageDescriptor = statusMessages[props.statusCode];
+
+      return (
+         <div>
+            {/* Pass the message descriptor's `id` as the `id` prop */}
+            <Trans id={messageDescriptor.id} />
+         </div>
+      );
    }


### PR DESCRIPTION
I've noticed some problems in the updates I pushed for the "lazy translations" section of the docs. :sweat_smile: 

The main thing is, it copied from the previous examples the idea that you could pass a message descriptor object from `t` to `<Trans>`'s `id` prop. That doesn't work. In fact, it causes various errors, because the `id` prop must be a string, but `t` returns an object. I suspect it's probably a holdover from an earlier version of the docs that referenced the `i18nMark()` function, which actually did return a string.

Here's a little example to demonstrate what I'm talking about

```jsx
import React from 'react';
import {Trans, t} from "@lingui/macro";

const msg = t`Hello world`;

// This is what the examples were saying to do, but it causes a type error
const bad = <Trans id={msg} />;

// This causes "lingui extract" to crash due to #368 
const bad2 = <Trans {...msg} />;

// This is what you must do
const good = <Trans id={msg.id} />;
```

So this merge request updates my examples to pass the message descriptor's ID instead of the whole message descriptor object. Which is also what I've been doing in my own project that uses lazy translations, but I'd forgotten about that when writing the examples! I also actually ran and tested the code in each example, and fixed some other unrelated issues in them.

The new examples are still a little bit simple, because they don't address how you need to also pass the `defaults` property if you're using custom message IDs (and other properties if you're trying to use lazy translations for parameterized messages). But I think that would probably be best addressed by fixing #368 so that `<Trans {...msg} />` will just be ignored by "lingui extract" instead of causing it to crash.