### PR TITLE
Add fs-extra to package.json for CLI which is using it.

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -46,6 +46,7 @@
     "cli-table": "^0.3.1",
     "commander": "^5.0.0",
     "date-fns": "^2.12.0",
+    "fs-extra": "^9.0.0",
     "fuzzaldrin": "^2.1.0",
     "glob": "^7.1.4",
     "inquirer": "^7.1.0",


### PR DESCRIPTION
Currently when using `next`, the user has to add `fs-extra` to their package.json since the CLI is using it (in `catalog.ts`), but it's not listed as a dependency.