### PR TITLE
fix: allow imports from @lingui/macro to be in any order

### DIFF
--- a/packages/macro/src/index.js
+++ b/packages/macro/src/index.js
@@ -10,8 +10,11 @@ function macro({ references, state, babel }) {
   const reactImportsToCarryOver = ["DateFormat", "NumberFormat"]
   const reactImports = []
 
-  Object.keys(references).forEach(tagName => {
+  PROCESSING_ORDER.forEach(tagName => {
     const tags = references[tagName]
+    if (!tags) {
+      return
+    }
     const macroType = getMacroType(tagName)
 
     if (macroType === "jsx") {
@@ -128,6 +131,21 @@ const select = () => {}
 const selectOrdinal = () => {}
 const date = () => {}
 const number = () => {}
+
+const PROCESSING_ORDER = [
+  "t",
+  "plural",
+  "select",
+  "selectOrdinal",
+  "date",
+  "number",
+  "Trans",
+  "Plural",
+  "Select",
+  "SelectOrdinal",
+  "DateFormat",
+  "NumberFormat"
+]
 
 export { Trans, Plural, Select, SelectOrdinal, DateFormat, NumberFormat }
 export { t, plural, select, selectOrdinal, date, number }

--- a/packages/macro/test/fixtures/t-plural/actual.js
+++ b/packages/macro/test/fixtures/t-plural/actual.js
@@ -1,0 +1,8 @@
+// `plural` can be imported before `t` without issue
+import { plural, t } from '@lingui/macro'
+
+t`There ${plural({
+  value: 4,
+  one: 'is one light',
+  other: 'are # lights'
+})}!`

--- a/packages/macro/test/fixtures/t-plural/expected.js
+++ b/packages/macro/test/fixtures/t-plural/expected.js
@@ -1,0 +1,6 @@
+( /*i18n*/{
+  id: 'There {0, plural, one {is one light} other {are # lights}}!',
+  values: {
+    0: 4
+  }
+}); // `plural` can be imported before `t` without issue


### PR DESCRIPTION
previously, the references were processed in the order that they were
imported, leading to troubling results if one attempted to import
`plural` before `t` and use them together.

This transforms each reference in a deterministic order, regardless of
the order of import.