### PR TITLE
fix: windows compatibility in catalogs (#643)

### DIFF
--- a/packages/cli/src/api/catalog.test.ts
+++ b/packages/cli/src/api/catalog.test.ts
@@ -724,7 +724,7 @@ describe("getCatalogForFile", function () {
     )
     const catalogs = [catalog]
 
-    expect(getCatalogForFile(".\\src\\locales\\en.po", catalogs)).toEqual({
+    expect(getCatalogForFile("src\\locales\\en.po", catalogs)).toEqual({
       locale: "en",
       catalog,
     })

--- a/packages/cli/src/api/catalog.ts
+++ b/packages/cli/src/api/catalog.ts
@@ -447,7 +447,7 @@ function normalizeRelativePath(sourcePath: string): string {
   // preserve trailing slash for directories
   const isDir = normalize(sourcePath, false).endsWith(PATHSEP)
   return (
-    path.relative(process.cwd(), path.resolve(sourcePathPosix)) +
+    normalize(path.relative(process.cwd(), path.resolve(sourcePathPosix))) +
     (isDir ? PATHSEP : "")
   )
 }


### PR DESCRIPTION
Small oversight for paths not starting with `.\`

cc @tricoder42 