### PR TITLE
Improve macro typings

### DIFF
--- a/packages/macro/index.d.ts
+++ b/packages/macro/index.d.ts
@@ -6,10 +6,22 @@ export function t(
   literals: TemplateStringsArray,
   ...placeholders: any[]
 ): string
-export function plural(arg: number | string, options: Object): string
-export function selectOrdinal(arg: number | string, options: Object): string
-export function select(arg: string, choices: { [key: string]: string }): string
-export function defineMessages<M extends { [key: string]: MessageDescriptor }>(
+
+export interface ChoiceOptions<T = string> {
+  offset?: number
+  zero?: T
+  one?: T
+  few?: T
+  many?: T
+  other?: T
+}
+export function plural(arg: number | string, options: ChoiceOptions): string
+export function selectOrdinal(
+  arg: number | string,
+  options: ChoiceOptions
+): string
+export function select(arg: string, choices: Record<string, string>): string
+export function defineMessages<M extends Record<string, MessageDescriptor>>(
   messages: M
 ): M
 export function defineMessage(descriptor: MessageDescriptor): MessageDescriptor
@@ -20,14 +32,8 @@ export interface TransProps {
   render?: TransRenderType
 }
 
-export interface ChoiceProps extends TransProps {
+export interface ChoiceProps extends TransProps, ChoiceOptions<ReactNode> {
   value?: string | number
-  offset?: number
-  zero?: ReactNode
-  one?: ReactNode
-  few?: ReactNode
-  many?: ReactNode
-  other?: ReactNode
 }
 
 export interface SelectProps extends TransProps {


### PR DESCRIPTION
It bugged me that `plural` macro accepts `Object` instead of correct options. And I slightly improved small things around. Also removed `defineMessages` declaration which no longer exists, does it?