### PR TITLE
Enable add-locale with deprecation message

### DIFF
--- a/docs/ref/cli.rst
+++ b/docs/ref/cli.rst
@@ -24,7 +24,6 @@ Install
 
       {
          "scripts": {
-            "add-locale": "lingui add-locale",
             "extract": "lingui extract",
             "compile": "lingui compile",
          }
@@ -40,22 +39,6 @@ is loaded as described in :doc:`LinguiJS configuration </ref/conf>` reference.
 
 Commands
 ========
-
-``add-locale``
---------------
-
-.. lingui-cli:: add-locale [locales...] [--format <format>]
-
-This command creates a new directory for each locale in :conf:`localeDir`.
-
-.. code-block:: shell
-
-   # Add English, French and Spanish locales
-   lingui add-locale en fr es
-
-.. lingui-cli-option:: --format <format>
-
-Format of message catalog (see :conf:`format` option).
 
 ``extract``
 -----------

--- a/docs/tutorials/cli.rst
+++ b/docs/tutorials/cli.rst
@@ -14,22 +14,6 @@ packages.
    This tutorial assumes you use `yarn` to run commands. If you use `npm`,
    type `npm run <command>` instead of `yarn <command>`.
 
-Add a new locale
-================
-
-First, we need to add all the locales we want to translate our application into.
-:cli:`add-locale` command checks if such locale exists and creates a new directory in
-the ``locale`` directory::
-
-   yarn add-locale en cs
-
-Example output::
-
-   Added locale en.
-   Added locale cs.
-
-   (use "yarn extract" to extract messages)
-
 Extracting messages
 ===================
 
@@ -53,7 +37,6 @@ command looks for messages in the source files and extracts them::
    │ en       │     40      │   40    │
    └──────────┴─────────────┴─────────┘
 
-   (use "yarn add-locale <locale>" to add more locales)
    (use "yarn extract" to update catalogs with new messages)
    (use "yarn compile" to compile catalogs for production)
 

--- a/packages/cli/src/lingui.ts
+++ b/packages/cli/src/lingui.ts
@@ -13,7 +13,7 @@ try {
 
 program
   .version(version)
-  .command("init", "Install all required packages")
+  .command("add-locale", "Deprecated, run it for instructions")
   .command("extract [files...]", "Extracts messages from source files")
   .command("compile", "Compile message catalogs")
   .parse(process.argv)


### PR DESCRIPTION
Even though `add-locale` is deprecated, it's probably better to keep in the CLI so it can show deprecation message. I was fairly confused myself when I tried to run it and it was giving me rather cryptic error messages.

Also `init` command is some thing of the past, so I removed it from there.