### PR TITLE
Add labeler workflow to mark changed packages in PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,7 @@
+":package: cli": packages/cli/**/*
+":package: conf": packages/conf/**/*
+":package: core": packages/core/**/*
+":package: loader": packages/loader/**/*
+":package: macro": packages/macro/**/*
+":package: plugin-extract": packages/babel-plugin-extract-messages/**/*
+":package: react": packages/react/**/*

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,11 @@
+name: Labeler
+on: [pull_request]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/labeler@v2
+      with:
+        repo_token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Adds the [labeler](https://github.com/actions/labeler) workflow to automatically add the labels for pull-requests (like the ":package: cli", etc)