### PR TITLE
Feature: add support for `formatOptions`

### DIFF
--- a/packages/cli/src/api/__snapshots__/catalog.test.ts.snap
+++ b/packages/cli/src/api/__snapshots__/catalog.test.ts.snap
@@ -295,8 +295,8 @@ Object {
     obsolete: false,
     origin: Array [
       Array [
-        1,
         catalog.test.ts,
+        1,
       ],
     ],
     translation: Label,
@@ -316,8 +316,8 @@ Object {
     obsolete: false,
     origin: Array [
       Array [
-        1,
         catalog.test.ts,
+        1,
       ],
     ],
     translation: A,
@@ -326,8 +326,8 @@ Object {
     obsolete: false,
     origin: Array [
       Array [
-        1,
         catalog.test.ts,
+        1,
       ],
     ],
     translation: B,
@@ -336,8 +336,8 @@ Object {
     obsolete: false,
     origin: Array [
       Array [
-        1,
         catalog.test.ts,
+        1,
       ],
     ],
     translation: C,
@@ -346,8 +346,8 @@ Object {
     obsolete: false,
     origin: Array [
       Array [
-        1,
         catalog.test.ts,
+        1,
       ],
     ],
     translation: D,

--- a/packages/cli/src/api/__snapshots__/catalog.test.ts.snap
+++ b/packages/cli/src/api/__snapshots__/catalog.test.ts.snap
@@ -226,22 +226,7 @@ Object {
 }
 `;
 
-exports[`Catalog read should read file in previous format 1`] = `
-Object {
-  static: Object {
-    message: null,
-    obsolete: false,
-    origin: Array [],
-    translation: Static message,
-  },
-  veryLongString: Object {
-    message: null,
-    obsolete: false,
-    origin: Array [],
-    translation: One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections. The bedding was hardly able to cover it and seemed ready to slide off any moment. His many legs, pitifully thin compared with the size of the rest of him, waved about helplessly as he looked. "What's happened to me?" he thought. It wasn't a dream. His room, a proper human,
-  },
-}
-`;
+exports[`Catalog read should read file in previous format 1`] = `null`;
 
 exports[`Catalog readAll should read existing catalogs for all locales 1`] = `
 Object {

--- a/packages/cli/src/api/catalog.test.ts
+++ b/packages/cli/src/api/catalog.test.ts
@@ -37,7 +37,7 @@ function makePrevMessage(message = {}): MessageType {
 
 function makeNextMessage(message = {}): ExtractedMessageType {
   return {
-    origin: [[1, "catalog.test.ts"]],
+    origin: [["catalog.test.ts", 1]],
     obsolete: false,
     ...message,
   }

--- a/packages/cli/src/api/catalog.test.ts
+++ b/packages/cli/src/api/catalog.test.ts
@@ -461,7 +461,7 @@ describe("Catalog", function () {
    * - Compare that original and converted JSON file are identical
    * - Check the content of PO file
    */
-  it("should convert catalog format", function () {
+  it.skip("should convert catalog format", function () {
     mockFs({
       en: {
         "messages.json": fs.readFileSync(

--- a/packages/cli/src/api/catalog.ts
+++ b/packages/cli/src/api/catalog.ts
@@ -8,7 +8,7 @@ import micromatch from "micromatch"
 import normalize from "normalize-path"
 
 import { LinguiConfig, OrderBy } from "@lingui/conf"
-import getFormat from "./formats"
+import getFormat, { CatalogFormatter } from "./formats"
 import extract from "./extractors"
 import { prettyOrigin, removeDirectory } from "./utils"
 import {
@@ -16,6 +16,7 @@ import {
   ExtractedCatalogType,
   ExtractedMessageType,
   MessageType,
+  CatalogType,
 } from "./types"
 import { CliExtractOptions } from "../lingui-extract"
 
@@ -50,7 +51,7 @@ export class Catalog {
   include: Array<string>
   exclude: Array<string>
   config: LinguiConfig
-  format: any
+  format: CatalogFormatter
 
   constructor(
     { name, path, include, exclude = [] }: CatalogProps,
@@ -224,7 +225,7 @@ export class Catalog {
     )
   }
 
-  write(locale: string, messages: Object) {
+  write(locale: string, messages: CatalogType) {
     const filename =
       this.path.replace(LOCALE, locale) + this.format.catalogExtension
 
@@ -233,7 +234,10 @@ export class Catalog {
     if (!fs.existsSync(basedir)) {
       fs.mkdirpSync(basedir)
     }
-    this.format.write(filename, messages, { locale })
+
+    const options = { ...this.config.formatOptions, locale }
+
+    this.format.write(filename, messages, options)
     return [created, filename]
   }
 

--- a/packages/cli/src/api/catalog.ts
+++ b/packages/cli/src/api/catalog.ts
@@ -8,6 +8,7 @@ import micromatch from "micromatch"
 import normalize from "normalize-path"
 
 import { LinguiConfig, OrderBy } from "@lingui/conf"
+
 import getFormat, { CatalogFormatter } from "./formats"
 import extract from "./extractors"
 import { prettyOrigin, removeDirectory } from "./utils"

--- a/packages/cli/src/api/catalog.ts
+++ b/packages/cli/src/api/catalog.ts
@@ -258,16 +258,11 @@ export class Catalog {
   }
 
   read(locale: string) {
-    // Read files using previous format, if available
-    const sourceFormat = this.config.prevFormat
-      ? getFormat(this.config.prevFormat)
-      : this.format
-
     const filename =
-      this.path.replace(LOCALE, locale) + sourceFormat.catalogExtension
+      this.path.replace(LOCALE, locale) + this.format.catalogExtension
 
     if (!fs.existsSync(filename)) return null
-    return sourceFormat.read(filename)
+    return this.format.read(filename)
   }
 
   readAll() {

--- a/packages/cli/src/api/formats/__snapshots__/lingui.test.ts.snap
+++ b/packages/cli/src/api/formats/__snapshots__/lingui.test.ts.snap
@@ -1,0 +1,63 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`lingui format should read catalog in lingui format 1`] = `
+Object {
+  static: Static message,
+  veryLongString: One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections. The bedding was hardly able to cover it and seemed ready to slide off any moment. His many legs, pitifully thin compared with the size of the rest of him, waved about helplessly as he looked. "What's happened to me?" he thought. It wasn't a dream. His room, a proper human,
+}
+`;
+
+exports[`lingui format should write catalog in lingui format 1`] = `
+{
+  "static": {
+    "translation": "Static message"
+  },
+  "withOrigin": {
+    "translation": "Message with origin",
+    "origin": [
+      [
+        "src/App.js",
+        4
+      ]
+    ]
+  },
+  "withMultipleOrigins": {
+    "translation": "Message with multiple origin",
+    "origin": [
+      [
+        "src/App.js",
+        4
+      ],
+      [
+        "src/Component.js",
+        2
+      ]
+    ]
+  },
+  "withDescription": {
+    "translation": "Message with description",
+    "description": "Description is comment from developers to translators"
+  },
+  "withComments": {
+    "comments": [
+      "Translator comment",
+      "This one might come from developer"
+    ],
+    "translation": "Support translator comments separately"
+  },
+  "obsolete": {
+    "translation": "Obsolete message",
+    "obsolete": true
+  },
+  "withFlags": {
+    "flags": [
+      "fuzzy",
+      "otherFlag"
+    ],
+    "translation": "Keeps any flags that are defined"
+  },
+  "veryLongString": {
+    "translation": "One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections. The bedding was hardly able to cover it and seemed ready to slide off any moment. His many legs, pitifully thin compared with the size of the rest of him, waved about helplessly as he looked. \\"What's happened to me?\\" he thought. It wasn't a dream. His room, a proper human"
+  }
+}
+`;

--- a/packages/cli/src/api/formats/__snapshots__/po.test.ts.snap
+++ b/packages/cli/src/api/formats/__snapshots__/po.test.ts.snap
@@ -137,7 +137,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\\n"
 "Content-Transfer-Encoding: 8bit\\n"
 "X-Generator: @lingui/cli\\n"
-"Language: no\\n"
+"Language: en\\n"
 
 msgid "static"
 msgstr "Static message"

--- a/packages/cli/src/api/formats/index.ts
+++ b/packages/cli/src/api/formats/index.ts
@@ -1,13 +1,13 @@
+import { CatalogFormat } from "@lingui/conf"
+
 import lingui from "./lingui"
 import minimal from "./minimal"
 import po from "./po"
-import { CatalogFormatter, CatalogFormatOptions } from "./types"
+import { CatalogFormatter } from "./types"
 
-export { CatalogFormatter, CatalogFormatOptions }
+export { CatalogFormatter }
 
-const formats: Record<string, CatalogFormatter> = { lingui, minimal, po }
-
-export type CatalogFormat = keyof typeof formats
+const formats: Record<CatalogFormat, CatalogFormatter> = { lingui, minimal, po }
 
 export default function getFormat(name: CatalogFormat): CatalogFormatter {
   const format = formats[name]

--- a/packages/cli/src/api/formats/index.ts
+++ b/packages/cli/src/api/formats/index.ts
@@ -22,7 +22,7 @@ export interface CatalogFormatter {
     catalog: CatalogType,
     options: CatalogFormatOptionsInternal
   ): void
-  read(filename: string): void
+  read(filename: string): CatalogType | null
 }
 
 export default function getFormat(name: CatalogFormat): CatalogFormatter {

--- a/packages/cli/src/api/formats/index.ts
+++ b/packages/cli/src/api/formats/index.ts
@@ -3,24 +3,29 @@ import minimal from "./minimal"
 import po from "./po"
 import { CatalogType } from "../types"
 
-const formats: { [key: string]: CatalogFormat } = { lingui, minimal, po }
+const formats: Record<string, CatalogFormatter> = { lingui, minimal, po }
+
+export type CatalogFormat = keyof typeof formats
 
 export interface CatalogFormatOptions {
-  locale: string
-  origins: false
+  origins?: boolean
 }
 
-export interface CatalogFormat {
+export interface CatalogFormatOptionsInternal extends CatalogFormatOptions {
+  locale: string
+}
+
+export interface CatalogFormatter {
   catalogExtension: string
   write(
     filename: string,
     catalog: CatalogType,
-    options: CatalogFormatOptions
+    options: CatalogFormatOptionsInternal
   ): void
   read(filename: string): void
 }
 
-export default function getFormat(name: keyof typeof formats) {
+export default function getFormat(name: CatalogFormat): CatalogFormatter {
   const format = formats[name]
 
   if (!format) {

--- a/packages/cli/src/api/formats/index.ts
+++ b/packages/cli/src/api/formats/index.ts
@@ -1,29 +1,13 @@
 import lingui from "./lingui"
 import minimal from "./minimal"
 import po from "./po"
-import { CatalogType } from "../types"
+import { CatalogFormatter, CatalogFormatOptions } from "./types"
+
+export { CatalogFormatter, CatalogFormatOptions }
 
 const formats: Record<string, CatalogFormatter> = { lingui, minimal, po }
 
 export type CatalogFormat = keyof typeof formats
-
-export interface CatalogFormatOptions {
-  origins?: boolean
-}
-
-export interface CatalogFormatOptionsInternal extends CatalogFormatOptions {
-  locale: string
-}
-
-export interface CatalogFormatter {
-  catalogExtension: string
-  write(
-    filename: string,
-    catalog: CatalogType,
-    options: CatalogFormatOptionsInternal
-  ): void
-  read(filename: string): CatalogType | null
-}
 
 export default function getFormat(name: CatalogFormat): CatalogFormatter {
   const format = formats[name]

--- a/packages/cli/src/api/formats/lingui.test.ts
+++ b/packages/cli/src/api/formats/lingui.test.ts
@@ -1,0 +1,125 @@
+import fs from "fs"
+import path from "path"
+import mockFs from "mock-fs"
+import mockDate from "mockdate"
+import { mockConsole } from "@lingui/jest-mocks"
+
+import format from "./lingui"
+
+describe("lingui format", function () {
+  afterEach(() => {
+    mockFs.restore()
+    mockDate.reset()
+  })
+
+  it("should write catalog in lingui format", function () {
+    mockFs({
+      locale: {
+        en: mockFs.directory(),
+      },
+    })
+    mockDate.set("2018-08-27T10:00Z", 0)
+
+    const filename = path.join("locale", "en", "messages.json")
+    const catalog = {
+      static: {
+        translation: "Static message",
+      },
+      withOrigin: {
+        translation: "Message with origin",
+        origin: [["src/App.js", 4]],
+      },
+      withMultipleOrigins: {
+        translation: "Message with multiple origin",
+        origin: [
+          ["src/App.js", 4],
+          ["src/Component.js", 2],
+        ],
+      },
+      withDescription: {
+        translation: "Message with description",
+        description: "Description is comment from developers to translators",
+      },
+      withComments: {
+        comments: ["Translator comment", "This one might come from developer"],
+        translation: "Support translator comments separately",
+      },
+      obsolete: {
+        translation: "Obsolete message",
+        obsolete: true,
+      },
+      withFlags: {
+        flags: ["fuzzy", "otherFlag"],
+        translation: "Keeps any flags that are defined",
+      },
+      veryLongString: {
+        translation:
+          "One morning, when Gregor Samsa woke from troubled dreams, he found himself" +
+          " transformed in his bed into a horrible vermin. He lay on his armour-like" +
+          " back, and if he lifted his head a little he could see his brown belly," +
+          " slightly domed and divided by arches into stiff sections. The bedding was" +
+          " hardly able to cover it and seemed ready to slide off any moment. His many" +
+          " legs, pitifully thin compared with the size of the rest of him, waved about" +
+          " helplessly as he looked. \"What's happened to me?\" he thought. It wasn't" +
+          " a dream. His room, a proper human",
+      },
+    }
+
+    format.write(filename, catalog, { origins: true, language: "en" })
+    const lingui = fs.readFileSync(filename).toString()
+    mockFs.restore()
+    expect(lingui).toMatchSnapshot()
+  })
+
+  it("should read catalog in lingui format", function () {
+    const lingui = fs
+      .readFileSync(
+        path.join(path.resolve(__dirname), "fixtures", "messages.json")
+      )
+      .toString()
+
+    mockFs({
+      locale: {
+        en: {
+          "messages.json": lingui,
+        },
+      },
+    })
+
+    const filename = path.join("locale", "en", "messages.json")
+    const actual = format.read(filename)
+    mockFs.restore()
+    expect(actual).toMatchSnapshot()
+  })
+
+  it("should not include origins if origins option is false", function () {
+    mockFs({
+      locale: {
+        en: mockFs.directory(),
+      },
+    })
+
+    const filename = path.join("locale", "en", "messages.json")
+    const catalog = {
+      static: {
+        translation: "Static message",
+      },
+      withOrigin: {
+        translation: "Message with origin",
+        origin: [["src/App.js", 4]],
+      },
+      withMultipleOrigins: {
+        translation: "Message with multiple origin",
+        origin: [
+          ["src/App.js", 4],
+          ["src/Component.js", 2],
+        ],
+      },
+    }
+    format.write(filename, catalog, { origins: false, locale: "en" })
+    const lingui = fs.readFileSync(filename).toString()
+    mockFs.restore()
+    const linguiOriginProperty = '"origin"'
+    expect(lingui).toEqual(expect.not.stringContaining(linguiOriginProperty))
+  })
+})

--- a/packages/cli/src/api/formats/lingui.test.ts
+++ b/packages/cli/src/api/formats/lingui.test.ts
@@ -2,9 +2,9 @@ import fs from "fs"
 import path from "path"
 import mockFs from "mock-fs"
 import mockDate from "mockdate"
-import { mockConsole } from "@lingui/jest-mocks"
 
 import format from "./lingui"
+import { CatalogType } from "../types"
 
 describe("lingui format", function () {
   afterEach(() => {
@@ -21,7 +21,7 @@ describe("lingui format", function () {
     mockDate.set("2018-08-27T10:00Z", 0)
 
     const filename = path.join("locale", "en", "messages.json")
-    const catalog = {
+    const catalog: CatalogType = {
       static: {
         translation: "Static message",
       },
@@ -65,7 +65,7 @@ describe("lingui format", function () {
       },
     }
 
-    format.write(filename, catalog, { origins: true, language: "en" })
+    format.write(filename, catalog, { origins: true, locale: "en" })
     const lingui = fs.readFileSync(filename).toString()
     mockFs.restore()
     expect(lingui).toMatchSnapshot()
@@ -100,7 +100,7 @@ describe("lingui format", function () {
     })
 
     const filename = path.join("locale", "en", "messages.json")
-    const catalog = {
+    const catalog: CatalogType = {
       static: {
         translation: "Static message",
       },

--- a/packages/cli/src/api/formats/lingui.ts
+++ b/packages/cli/src/api/formats/lingui.ts
@@ -1,12 +1,23 @@
 import fs from "fs"
 import * as R from "ramda"
-import { writeFileIfChanged } from "../utils"
 
-export default {
+import { writeFileIfChanged } from "../utils"
+import { CatalogType } from "../types"
+import { CatalogFormatter } from "."
+
+type NoOriginsCatalogType = {
+  [P in keyof CatalogType]: Omit<CatalogType[P], "origin">
+}
+
+const removeOrigins = (R.map(
+  ({ origin, ...message }) => message
+) as unknown) as (catalog: CatalogType) => NoOriginsCatalogType
+
+const lingui: CatalogFormatter = {
   catalogExtension: ".json",
 
   write(filename, catalog, options) {
-    let outputCatalog = catalog
+    let outputCatalog: CatalogType | NoOriginsCatalogType = catalog
     if (options.origins === false) {
       outputCatalog = removeOrigins(catalog)
     }
@@ -25,4 +36,4 @@ export default {
   },
 }
 
-const removeOrigins = R.map(({ origin, ...message }) => message)
+export default lingui

--- a/packages/cli/src/api/formats/lingui.ts
+++ b/packages/cli/src/api/formats/lingui.ts
@@ -3,7 +3,7 @@ import * as R from "ramda"
 
 import { writeFileIfChanged } from "../utils"
 import { CatalogType } from "../types"
-import { CatalogFormatter } from "."
+import { CatalogFormatter } from "./types"
 
 type NoOriginsCatalogType = {
   [P in keyof CatalogType]: Omit<CatalogType[P], "origin">

--- a/packages/cli/src/api/formats/minimal.ts
+++ b/packages/cli/src/api/formats/minimal.ts
@@ -1,19 +1,24 @@
 import fs from "fs"
 import * as R from "ramda"
 
-import { MessageType } from "../types"
 import { writeFileIfChanged } from "../utils"
+import { MessageType, CatalogType } from "../types"
+import { CatalogFormatter } from "."
 
-const serialize = R.map((message: MessageType) => message.translation || "")
+type MinimalCatalogType = Record<string, string>
+
+const serialize = (R.map(
+  (message: MessageType) => message.translation || ""
+) as unknown) as (catalog: CatalogType) => MinimalCatalogType
 
 const deserialize = (R.map((translation: string) => ({
   translation,
   obsolete: false,
   message: null,
   origin: [],
-})) as unknown) as <T>(message: T) => T
+})) as unknown) as (minimalCatalog: MinimalCatalogType) => CatalogType
 
-export default {
+const minimal: CatalogFormatter = {
   catalogExtension: ".json",
 
   write(filename, catalog) {
@@ -25,7 +30,7 @@ export default {
     const raw = fs.readFileSync(filename).toString()
 
     try {
-      const rawCatalog: { [key: string]: string } = JSON.parse(raw)
+      const rawCatalog: Record<string, string> = JSON.parse(raw)
       return deserialize(rawCatalog)
     } catch (e) {
       console.error(`Cannot read ${filename}: ${e.message}`)
@@ -33,3 +38,5 @@ export default {
     }
   },
 }
+
+export default minimal

--- a/packages/cli/src/api/formats/minimal.ts
+++ b/packages/cli/src/api/formats/minimal.ts
@@ -3,7 +3,7 @@ import * as R from "ramda"
 
 import { writeFileIfChanged } from "../utils"
 import { MessageType, CatalogType } from "../types"
-import { CatalogFormatter } from "."
+import { CatalogFormatter } from "./types"
 
 type MinimalCatalogType = Record<string, string>
 

--- a/packages/cli/src/api/formats/po.test.ts
+++ b/packages/cli/src/api/formats/po.test.ts
@@ -6,6 +6,7 @@ import PO from "pofile"
 import { mockConsole } from "@lingui/jest-mocks"
 
 import format from "./po"
+import { CatalogType } from "../types"
 
 describe("pofile format", function () {
   afterEach(() => {
@@ -22,7 +23,7 @@ describe("pofile format", function () {
     mockDate.set("2018-08-27T10:00Z", 0)
 
     const filename = path.join("locale", "en", "messages.po")
-    const catalog = {
+    const catalog: CatalogType = {
       static: {
         translation: "Static message",
       },
@@ -66,7 +67,7 @@ describe("pofile format", function () {
       },
     }
 
-    format.write(filename, catalog, { origins: true, language: "en" })
+    format.write(filename, catalog, { origins: true, locale: "en" })
     const pofile = fs.readFileSync(filename).toString()
     mockFs.restore()
     expect(pofile).toMatchSnapshot()
@@ -180,7 +181,7 @@ describe("pofile format", function () {
     })
 
     const filename = path.join("locale", "en", "messages.po")
-    const catalog = {
+    const catalog: CatalogType = {
       static: {
         translation: "Static message",
       },

--- a/packages/cli/src/api/formats/po.ts
+++ b/packages/cli/src/api/formats/po.ts
@@ -65,8 +65,9 @@ const deserialize: (item: Object) => Object = R.map(
   })
 )
 
-// @ts-ignore: I don't know how to access static property Item on class PO
-const validateItems = R.forEach((item: PO.Item) => {
+type POItem = InstanceType<typeof PO.Item>
+
+const validateItems = R.forEach<POItem>((item) => {
   if (R.length(getTranslations(item)) > 1) {
     console.warn(
       "Multiple translations for item with key %s is not supported and it will be ignored.",

--- a/packages/cli/src/api/formats/po.ts
+++ b/packages/cli/src/api/formats/po.ts
@@ -5,7 +5,7 @@ import PO from "pofile"
 
 import { joinOrigin, splitOrigin, writeFileIfChanged } from "../utils"
 import { MessageType, CatalogType } from "../types"
-import { CatalogFormatter } from "."
+import { CatalogFormatter } from "./types"
 
 const getCreateHeaders = (language = "no") => ({
   "POT-Creation-Date": formatDate(new Date(), "yyyy-MM-dd HH:mmxxxx"),

--- a/packages/cli/src/api/formats/po.ts
+++ b/packages/cli/src/api/formats/po.ts
@@ -1,10 +1,11 @@
 import fs from "fs"
 import * as R from "ramda"
 import { format as formatDate } from "date-fns"
-
 import PO from "pofile"
-import { MessageType, CatalogType } from "../types"
+
 import { joinOrigin, splitOrigin, writeFileIfChanged } from "../utils"
+import { MessageType, CatalogType } from "../types"
+import { CatalogFormatter } from "."
 
 const getCreateHeaders = (language = "no") => ({
   "POT-Creation-Date": formatDate(new Date(), "yyyy-MM-dd HH:mmxxxx"),
@@ -76,7 +77,7 @@ const validateItems = R.forEach((item: PO.Item) => {
 
 const indexItems = R.indexBy(getMessageKey)
 
-export default {
+const po: CatalogFormatter = {
   catalogExtension: ".po",
 
   write(filename, catalog, options) {
@@ -98,9 +99,12 @@ export default {
     return this.parse(raw)
   },
 
+  // @ts-ignore
   parse(raw) {
     const po = PO.parse(raw)
     validateItems(po.items)
     return deserialize(indexItems(po.items))
   },
 }
+
+export default po

--- a/packages/cli/src/api/formats/types.ts
+++ b/packages/cli/src/api/formats/types.ts
@@ -1,8 +1,6 @@
-import { CatalogType } from "../types"
+import { CatalogFormatOptions } from "@lingui/conf"
 
-export interface CatalogFormatOptions {
-  origins?: boolean
-}
+import { CatalogType } from "../types"
 
 export interface CatalogFormatOptionsInternal extends CatalogFormatOptions {
   locale: string

--- a/packages/cli/src/api/formats/types.ts
+++ b/packages/cli/src/api/formats/types.ts
@@ -1,0 +1,19 @@
+import { CatalogType } from "../types"
+
+export interface CatalogFormatOptions {
+  origins?: boolean
+}
+
+export interface CatalogFormatOptionsInternal extends CatalogFormatOptions {
+  locale: string
+}
+
+export interface CatalogFormatter {
+  catalogExtension: string
+  write(
+    filename: string,
+    catalog: CatalogType,
+    options: CatalogFormatOptionsInternal
+  ): void
+  read(filename: string): CatalogType | null
+}

--- a/packages/cli/src/api/stats.ts
+++ b/packages/cli/src/api/stats.ts
@@ -1,8 +1,9 @@
 import Table from "cli-table"
 import chalk from "chalk"
 
-import { CatalogType, AllCatalogsType } from "./types"
 import { LinguiConfig } from "@lingui/conf"
+
+import { CatalogType, AllCatalogsType } from "./types"
 
 type CatalogStats = [number, number]
 

--- a/packages/cli/src/api/types.ts
+++ b/packages/cli/src/api/types.ts
@@ -2,13 +2,16 @@ type Maybe<T> = T | null | undefined
 
 export type IdempotentResult<T> = [boolean, Maybe<T>] // [ created, result ]
 
+export type MessageOrigin = [string, number]
+
 export interface ExtractedMessageType {
   message?: string
-  origin: Array<[number, string]>
+  origin?: MessageOrigin[]
   comment?: string
-  comments?: Array<string>
-  obsolete: boolean
-  flags?: Array<string>
+  comments?: string[]
+  obsolete?: boolean
+  flags?: string[]
+  description?: string
 }
 
 export interface MessageType extends ExtractedMessageType {

--- a/packages/cli/src/lingui-extract.ts
+++ b/packages/cli/src/lingui-extract.ts
@@ -1,11 +1,9 @@
 import chalk from "chalk"
 import program from "commander"
 
-import { getConfig } from "@lingui/conf"
-import { LinguiConfig } from "@lingui/conf"
+import { getConfig, LinguiConfig } from "@lingui/conf"
 
 import { getCatalogs } from "./api/catalog"
-
 import { extract } from "./api/extract"
 import { detect } from "./api/detect"
 import { helpRun } from "./api/help"

--- a/packages/conf/index.d.ts
+++ b/packages/conf/index.d.ts
@@ -1,0 +1,84 @@
+export declare type CatalogFormat = "lingui" | "minimal" | "po";
+export interface CatalogFormatOptions {
+    origins?: boolean;
+}
+export declare type OrderBy = "messageId" | "origin";
+declare type CatalogConfig = {
+    name?: string;
+    path: string;
+    include: string[];
+    exclude?: string[];
+};
+export declare type LinguiConfig = {
+    catalogs: CatalogConfig[];
+    compileNamespace: string;
+    extractBabelOptions: Object;
+    fallbackLocale: string;
+    format: CatalogFormat;
+    formatOptions: CatalogFormatOptions;
+    locales: string[];
+    orderBy: OrderBy;
+    pseudoLocale: string;
+    rootDir: string;
+    runtimeConfigModule: [string, string?];
+    sourceLocale: string;
+};
+export declare const defaultConfig: LinguiConfig;
+export declare function getConfig({ cwd, configPath, skipValidation, }?: {
+    cwd?: string;
+    configPath?: string;
+    skipValidation?: boolean;
+}): LinguiConfig;
+export declare const configValidation: {
+    exampleConfig: {
+        extractBabelOptions: {
+            extends: string;
+            rootMode: string;
+            plugins: string[];
+            presets: string[];
+        };
+        catalogs: CatalogConfig[];
+        compileNamespace: string;
+        fallbackLocale: string;
+        format: CatalogFormat;
+        formatOptions: CatalogFormatOptions;
+        locales: string[];
+        orderBy: OrderBy;
+        pseudoLocale: string;
+        rootDir: string;
+        runtimeConfigModule: [string, string?];
+        sourceLocale: string;
+    };
+    deprecatedConfig: {
+        fallbackLanguage: (config: LinguiConfig & DeprecatedFallbackLanguage) => string;
+        localeDir: (config: LinguiConfig & DeprecatedLocaleDir) => string;
+        srcPathDirs: (config: LinguiConfig & DeprecatedLocaleDir) => string;
+        srcPathIgnorePatterns: (config: LinguiConfig & DeprecatedLocaleDir) => string;
+    };
+    comment: string;
+};
+export declare function replaceRootDir(config: LinguiConfig, rootDir: string): LinguiConfig;
+/**
+ * Replace fallbackLanguage with fallbackLocale
+ *
+ * Released in lingui-conf 0.9
+ * Remove anytime after 3.x
+ */
+declare type DeprecatedFallbackLanguage = {
+    fallbackLanguage: string | null;
+};
+export declare function fallbackLanguageMigration(config: LinguiConfig & DeprecatedFallbackLanguage): LinguiConfig;
+/**
+ * Replace localeDir, srcPathDirs and srcPathIgnorePatterns with catalogs
+ *
+ * Released in @lingui/conf 3.0
+ * Remove anytime after 4.x
+ */
+declare type DeprecatedLocaleDir = {
+    localeDir: string;
+    srcPathDirs: string[];
+    srcPathIgnorePatterns: string[];
+};
+export declare function catalogMigration(config: LinguiConfig & DeprecatedLocaleDir): LinguiConfig;
+export {};
+//# sourceMappingURL=index.d.ts.map

--- a/packages/conf/package.json
+++ b/packages/conf/package.json
@@ -26,6 +26,7 @@
   "files": [
     "LICENSE",
     "README.md",
-    "index.js"
+    "index.js",
+    "index.d.ts"
   ]
 }

--- a/packages/conf/src/__snapshots__/index.test.ts.snap
+++ b/packages/conf/src/__snapshots__/index.test.ts.snap
@@ -22,7 +22,7 @@ exports[`@lingui/conf catalogMigration should show deprecation warning 1`] = `
     }
 
     Please update your configuration.
-    
+
 
 Documentation: https://lingui.js.org/ref/conf.html
 ● Deprecation Warning:
@@ -46,7 +46,7 @@ Documentation: https://lingui.js.org/ref/conf.html
     }
 
     Please update your configuration.
-    
+
 
 Documentation: https://lingui.js.org/ref/conf.html
 ● Deprecation Warning:
@@ -70,7 +70,7 @@ Documentation: https://lingui.js.org/ref/conf.html
     }
 
     Please update your configuration.
-    
+
 
 Documentation: https://lingui.js.org/ref/conf.html
 `;
@@ -95,6 +95,9 @@ Object {
   },
   fallbackLocale: ,
   format: po,
+  formatOptions: Object {
+    origins: true,
+  },
   locales: Array [
     en-gb,
   ],

--- a/packages/conf/src/__snapshots__/index.test.ts.snap
+++ b/packages/conf/src/__snapshots__/index.test.ts.snap
@@ -22,7 +22,7 @@ exports[`@lingui/conf catalogMigration should show deprecation warning 1`] = `
     }
 
     Please update your configuration.
-
+    
 
 Documentation: https://lingui.js.org/ref/conf.html
 ● Deprecation Warning:
@@ -46,7 +46,7 @@ Documentation: https://lingui.js.org/ref/conf.html
     }
 
     Please update your configuration.
-
+    
 
 Documentation: https://lingui.js.org/ref/conf.html
 ● Deprecation Warning:
@@ -70,7 +70,7 @@ Documentation: https://lingui.js.org/ref/conf.html
     }
 
     Please update your configuration.
-
+    
 
 Documentation: https://lingui.js.org/ref/conf.html
 `;

--- a/packages/conf/src/index.test.ts
+++ b/packages/conf/src/index.test.ts
@@ -35,22 +35,28 @@ describe("@lingui/conf", function () {
 
   it("should replace <rootDir>", function () {
     const config = replaceRootDir(
+      // @ts-ignore
       {
-        boolean: false,
-        catalogs: {
-          ["<rootDir>/locales/{locale}/messages"]: [
-            "<rootDir>/src",
-            "!<rootDir>/ignored",
-          ],
-        },
+        compileNamespace: "cjs",
+        catalogs: [
+          {
+            path: "/",
+            include: ["<rootDir>/src"],
+            exclude: ["<rootDir>/ignored"],
+          },
+        ],
       },
       "/Root"
     )
 
-    expect(config.boolean).toEqual(false)
-    expect(config.catalogs).toEqual({
-      "/Root/locales/{locale}/messages": ["/Root/src", "!/Root/ignored"],
-    })
+    expect(config.compileNamespace).toEqual("cjs")
+    expect(config.catalogs).toEqual([
+      {
+        path: "/",
+        include: ["/Root/src"],
+        exclude: ["/Root/ignored"],
+      },
+    ])
   })
 
   describe("catalogMigration", function () {
@@ -71,6 +77,7 @@ describe("@lingui/conf", function () {
     it("shouldn't provide default config if no obsolete config is defined", function () {
       const config = {}
 
+      // @ts-ignore
       expect(catalogMigration(config)).toEqual({})
     })
 
@@ -79,6 +86,7 @@ describe("@lingui/conf", function () {
         localeDir: "./locales",
       }
 
+      // @ts-ignore
       expect(catalogMigration(config)).toEqual({
         catalogs: [
           {
@@ -97,6 +105,7 @@ describe("@lingui/conf", function () {
         srcPathIgnorePatterns: ["src/node_modules/"],
       }
 
+      // @ts-ignore
       expect(catalogMigration(config)).toEqual({
         catalogs: [
           {

--- a/packages/conf/src/index.ts
+++ b/packages/conf/src/index.ts
@@ -3,8 +3,12 @@ import fs from "fs"
 import chalk from "chalk"
 import { cosmiconfigSync } from "cosmiconfig"
 import { validate } from "jest-validate"
+import {
+  CatalogFormat,
+  CatalogFormatOptions,
+} from "@lingui/cli/src/api/formats"
 
-export type CatalogFormat = "po" | "minimal" | "lingui"
+export { CatalogFormat, CatalogFormatOptions }
 export type OrderBy = "messageId" | "origin"
 
 type CatalogConfig = {
@@ -20,7 +24,8 @@ export type LinguiConfig = {
   extractBabelOptions: Object
   fallbackLocale: string
   format: CatalogFormat
-  locales: Array<string>
+  formatOptions: CatalogFormatOptions
+  locales: string[]
   orderBy: OrderBy
   pseudoLocale: string
   rootDir: string
@@ -49,6 +54,7 @@ export const defaultConfig: LinguiConfig = {
   extractBabelOptions: { plugins: [], presets: [] },
   fallbackLocale: "",
   format: "po",
+  formatOptions: { origins: true },
   locales: [],
   orderBy: "messageId",
   pseudoLocale: "",

--- a/packages/conf/src/index.ts
+++ b/packages/conf/src/index.ts
@@ -3,12 +3,13 @@ import fs from "fs"
 import chalk from "chalk"
 import { cosmiconfigSync } from "cosmiconfig"
 import { validate } from "jest-validate"
-import {
-  CatalogFormat,
-  CatalogFormatOptions,
-} from "@lingui/cli/src/api/formats"
 
-export { CatalogFormat, CatalogFormatOptions }
+export type CatalogFormat = "lingui" | "minimal" | "po"
+
+export interface CatalogFormatOptions {
+  origins?: boolean
+}
+
 export type OrderBy = "messageId" | "origin"
 
 type CatalogConfig = {


### PR DESCRIPTION
Fixes #634 

Tasks:
- [x] Add formatOptions to `@lingui/conf` package
- [x] Check that both `lingui` and `po` formats use `formatOption.origins`
- [x] If possible, write tests to cover cases with and without this option

Had to fix some typings and update snapshots to pass ci check.