### PR TITLE
Export MessageDescriptor interface in core package

### DIFF
--- a/packages/core/src/i18n.ts
+++ b/packages/core/src/i18n.ts
@@ -1,5 +1,5 @@
 import { interpolate } from "./context"
-import { isString, isFunction, isEmpty } from "./essentials"
+import { isString, isFunction } from "./essentials"
 import { date, number } from "./formats"
 import * as icu from "./dev"
 import { EventEmitter } from "./eventEmitter"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,7 @@ export {
   setupI18n,
   I18n,
   AllMessages,
+  MessageDescriptor,
   Messages,
   AllLocaleData,
   LocaleData,


### PR DESCRIPTION
This is required because we are [importing it in `@lingui/macro`](https://github.com/lingui/js-lingui/blob/next/packages/macro/index.d.ts#L2) but it wasn't exported in the `@lingui/core` package, causing it to be treated as `any` and forcing users to use the `skipLibCheck` compiler option in their `tsconfig.json`.