### PR TITLE
fix: type of compiled messages

### DIFF
--- a/packages/cli/src/lingui-compile.ts
+++ b/packages/cli/src/lingui-compile.ts
@@ -84,8 +84,8 @@ function command(config, options) {
         const typescriptPath = compiledPath.replace(/\.jsx?$/, "") + ".d.ts"
         fs.writeFileSync(
           typescriptPath,
-          `import { AllMessages } from '@lingui/core';
-declare const messages: AllMessages;
+          `import { Messages } from '@lingui/core';
+declare const messages: Messages;
 export = messages;
 `
         )

--- a/packages/cli/src/lingui-compile.ts
+++ b/packages/cli/src/lingui-compile.ts
@@ -86,7 +86,7 @@ function command(config, options) {
           typescriptPath,
           `import { Messages } from '@lingui/core';
 declare const messages: Messages;
-export = messages;
+export { messages };
 `
         )
       }


### PR DESCRIPTION
`AllMessages` is a map from locale to messages, but this is the type for an individual, compiled locale.