### PR TITLE
Fail gracefully for wrong use of elements in translation

### DIFF
--- a/packages/react/src/format.test.tsx
+++ b/packages/react/src/format.test.tsx
@@ -51,4 +51,29 @@ describe("formatElements", function () {
       'Before <a href="/about">Inside <strong>Nested</strong> Between <br> After</a>'
     )
   })
+
+  it("should ignore non existing element", function() {
+    expect(html(formatElements("<0>First</0>"))).toEqual("First")
+    expect(html(formatElements("<0>First</0>Second"))).toEqual("FirstSecond")
+    expect(html(formatElements("First<0>Second</0>Third")))
+        .toEqual("FirstSecondThird")
+    expect(html(formatElements("Fir<0/>st"))).toEqual("First")
+  })
+
+  it("should ignore incorrect tags and print them as a text", function() {
+    expect(html(formatElements("text</0>"))).toEqual("text&lt;/0&gt;")
+    expect(html(formatElements("text<0 />"))).toEqual("text&lt;0 /&gt;")
+    expect(html(formatElements("<tag>text</tag>")))
+        .toEqual("&lt;tag&gt;text&lt;/tag&gt;")
+    expect(html(formatElements("text <br/>"))).toEqual("text &lt;br/&gt;")
+  })
+
+  it("should ignore unpaired element used as paired", function() {
+    expect(html(formatElements("<0>text</0>", {0: <br />}))).toEqual("text")
+  })
+
+  it("should ignore paired element used as unpaired", function() {
+    expect(html(formatElements("text<0/>", {0: <span />})))
+        .toEqual("text<span></span>")
+  })
 })


### PR DESCRIPTION
Every few times we pull translation updates it turns out that translators do typo or miss-use either element or ICU formats.
Some of these mistakes can cause severe issues. It happens once that broken translation was released to prod and total break our application for customers.
I heard that there are other teams in my company that face similar issues with js-lingui.

We internally created a translation validator and as discussed in the issue https://github.com/lingui/js-lingui/issues/591 I'll try to rise a PR with that feature to the original library.

However, I still believe that any typo or mistake in the translation should not cause the page to break.

In this PR I tried to address the issue with errors caused by wrong use of react components.
- I introduced tests for the cases I thought could cause the error.
- I fixed the case where a not declared element is used in translation
- I fixed for the case where an unpaired component is used as paired (I couldn't find a nice way to implement it, I ended up coping the list of elements from react source)

All suggestions are welcome :) 
 