### PR TITLE
Handle icu errors gracefully

### DIFF
--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -59,6 +59,8 @@ function context({ locale, locales, values, formats, localeData }) {
   const formatters = defaultFormats(locale, locales, localeData, formats)
 
   const ctx = (name: string, type: string, format: any) => {
+    if (!formatters.hasOwnProperty(type)) return null
+
     const value = values[name]
     const formatted = formatters[type](value, format)
     const message = isFunction(formatted) ? formatted(ctx) : formatted

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -24,11 +24,13 @@ const defaultFormats = (
 
   return {
     plural: (value, { offset = 0, ...rules }) => {
+      if (!isFunction(plurals)) return null;
       const message = rules[value] || rules[plurals(value - offset)]
       return replaceOctothorpe(value - offset, message)
     },
 
     selectordinal: (value, { offset = 0, ...rules }) => {
+      if (!isFunction(plurals)) return null;
       const message = rules[value] || rules[plurals(value - offset, true)]
       return replaceOctothorpe(value - offset, message)
     },

--- a/packages/core/src/formats.ts
+++ b/packages/core/src/formats.ts
@@ -7,8 +7,13 @@ export function date(
 ): (value: string | Date) => string {
   const formatter = new Intl.DateTimeFormat(locales, format)
   return (value) => {
-    if (isString(value)) value = new Date(value)
-    return formatter.format(value)
+    try {
+      if (isString(value)) value = new Date(value)
+      return formatter.format(value)
+    } catch (error) {
+      console.error(`Could not format a date: ${value}`, error)
+      return `${value}`;
+    }
   }
 }
 
@@ -16,6 +21,11 @@ export function number(
   locales: Locales,
   format: Intl.NumberFormatOptions = {}
 ): (value: number) => string {
-  const formatter = new Intl.NumberFormat(locales, format)
-  return (value) => formatter.format(value)
+  try {
+    const formatter = new Intl.NumberFormat(locales, format)
+    return (value) => formatter.format(value)
+  } catch (error) {
+    console.error(`Could not create number formatter of style ${format.style}`, error)
+    return (value) => `${value}`;
+  }
 }

--- a/packages/core/src/i18n.test.ts
+++ b/packages/core/src/i18n.test.ts
@@ -1,5 +1,5 @@
-import { setupI18n } from "@lingui/core"
-import { mockConsole, mockEnv } from "@lingui/jest-mocks"
+import {setupI18n} from "@lingui/core"
+import {mockConsole, mockEnv} from "@lingui/jest-mocks"
 
 describe("I18n", function () {
   describe("I18n.load", () => {
@@ -215,6 +215,25 @@ describe("I18n", function () {
       })
       expect(i18n._("missing")).toEqual("gnissim")
       expect(missing).toHaveBeenCalledWith("en", "missing")
+    })
+  })
+
+  describe("handling formatters errors", function () {
+    const setupI18nWithMessage = (message )=> setupI18n({
+      locale: "en",
+      messages: { en: {"message": message} }
+    })
+
+    it("._ should ignore not defined variable", function () {
+      const i18n = setupI18nWithMessage("My name is {name}")
+
+      expect(i18n._("message")).toEqual("My name is")
+    })
+
+    it("._ should ignore not defined custom formatter", function () {
+      const i18n = setupI18nWithMessage("My name is {name, uppercase}")
+
+      expect(i18n._("message", { name: "Fred" })).toEqual("My name is")
     })
   })
 })

--- a/packages/core/src/i18n.test.ts
+++ b/packages/core/src/i18n.test.ts
@@ -321,5 +321,35 @@ describe("I18n", function () {
       // en plurals fallback to other with NaN number
       expect(i18n._("message")).toEqual("Open NaNth message")
     })
+
+    it("._ should ignore number for undefined variable", function () {
+      const i18n = setupI18nWithMessage("{size, number, percent}")
+
+      expect(i18n._("message")).toEqual("NaN%")
+    })
+
+    it("._ should ignore number in wrong type", function () {
+      const i18n = setupI18nWithMessage("{amount, number, currency}")
+
+      expect(i18n._("message", {amount: "data"}, {formats: { currency: "usd"}})).toEqual("NaN")
+    })
+
+    it("._ should ignore number in undefined format", function () {
+      const i18n = setupI18nWithMessage("{size, number, size}")
+
+      expect(i18n._("message", {size: 5})).toEqual("5")
+    })
+
+    it("._ should ignore date in undefined format", function () {
+      const i18n = setupI18nWithMessage("{today, date, tiny}")
+
+      expect(i18n._("message", {today: new Date(1999, 11)})).toEqual("12/1/1999")
+    })
+
+    it("._ should ignore date in a wrong type", function () {
+      const i18n = setupI18nWithMessage("{today, date}")
+
+      expect(i18n._("message", {today: "Monday"})).toEqual("Invalid Date")
+    })
   })
 })


### PR DESCRIPTION
Every few times we pull translation updates it turns out that translators do typo or miss-use either element or ICU formats.
Some of these mistakes can cause severe issues. It happens once that broken translation was released to prod and total break our application for customers.
I heard that there are other teams in my company that face similar issues with js-lingui.

We internally created a translation validator and as discussed in issue #591 I'll try to rise a PR with that feature to the original library.

However, I still believe that any typo or mistake in the translation should not cause the page to break.

In this PR I tried to address the issue with errors caused by a wrong use of ICU formats.
- I introduced tests for the cases I thought could cause the error.
- I fix case where plurals are not declared - I assumed that declaration of them is not mandatory but a translator could still use it
- No more error when custom ICU format is used
- I handle exception from formatters on wrong arguments