### PR TITLE
Fixes maybeNodeValue

### DIFF
--- a/packages/macro/src/macroJsx.ts
+++ b/packages/macro/src/macroJsx.ts
@@ -173,7 +173,9 @@ export default class MacroJSX {
       ]
     }
 
-    const maybeNodeValue = (node) => (node != null ? node.value.value : null)
+    const maybeNodeValue = (node) => {
+      return node != null ? node.value.expression.value : null
+    }
 
     return {
       id: maybeNodeValue(id),

--- a/packages/macro/src/macroJsx.ts
+++ b/packages/macro/src/macroJsx.ts
@@ -15,6 +15,20 @@ const keepSpaceRe = /\s*(?:\r\n|\r|\n)+\s*/g
 // remove whitespace before/after tag or expression
 const stripAroundTagsRe = /(?:([>}])(?:\r\n|\r|\n)+\s*|(?:\r\n|\r|\n)+\s*(?=[<{]))/g
 
+function maybeNodeValue(node) {
+  if (!node)
+    return null
+  if (node.type === "StringLiteral")
+    return node.value
+  if (node.type === "JSXAttribute")
+    return maybeNodeValue(node.value)
+  if (node.type === "JSXExpressionContainer")
+    return maybeNodeValue(node.expression)
+  if (node.type === "TemplateLiteral" && node.expressions.length === 0)
+    return node.quasis[0].value.raw
+  return null
+}
+
 function normalizeWhitespace(text) {
   return (
     text
@@ -171,10 +185,6 @@ export default class MacroJSX {
         "value",
         "offset",
       ]
-    }
-
-    const maybeNodeValue = (node) => {
-      return node != null ? node.value.expression.value : null
     }
 
     return {

--- a/packages/macro/test/jsx-trans.ts
+++ b/packages/macro/test/jsx-trans.ts
@@ -15,17 +15,39 @@ export default [
     input: `
         import { Trans } from '@lingui/macro';
         <Trans id="Hello World">Hello World</Trans>;
-          `,
+      `,
     expected: `
         import { Trans } from "@lingui/react";
         <Trans id="Hello World" />;
       `,
   },
   {
-    name: "Macro with custom ID",
+    name: "Macro with custom ID (string literal)",
     input: `
         import { Trans } from '@lingui/macro';
         <Trans id="msg.hello">Hello World</Trans>;
+      `,
+    expected: `
+        import { Trans } from "@lingui/react";
+        <Trans id="msg.hello" message="Hello World" />;
+      `,
+  },
+  {
+    name: "Macro with custom ID (literal expression)",
+    input: `
+        import { Trans } from '@lingui/macro';
+        <Trans id={"msg.hello"}>Hello World</Trans>;
+      `,
+    expected: `
+        import { Trans } from "@lingui/react";
+        <Trans id="msg.hello" message="Hello World" />;
+      `,
+  },
+  {
+    name: "Macro with custom ID (template expression)",
+    input: `
+        import { Trans } from '@lingui/macro';
+        <Trans id={\`msg.hello\`}>Hello World</Trans>;
       `,
     expected: `
         import { Trans } from "@lingui/react";


### PR DESCRIPTION
The JSX attributes contain expressions which contain literals. The current accessor is missing the expression dereference,

Fixes #604 