### PR TITLE
fix: Support comments inside JSX macros by ignoring empty jsx expressions

### DIFF
--- a/packages/macro/src/icu.ts
+++ b/packages/macro/src/icu.ts
@@ -7,6 +7,7 @@ export default function ICUMessageFormat() {}
 ICUMessageFormat.prototype.fromTokens = function (tokens) {
   return (Array.isArray(tokens) ? tokens : [tokens])
     .map((token) => this.processToken(token))
+    .filter(Boolean)
     .reduce(
       (props, message) => ({
         ...message,
@@ -30,6 +31,9 @@ ICUMessageFormat.prototype.processToken = function (token) {
       message: token.value,
     }
   } else if (token.type === "arg") {
+    if (token.value !== undefined && token.value.type === 'JSXEmptyExpression') {
+      return null;
+    }
     const values =
       token.value !== undefined
         ? {

--- a/packages/macro/test/jsx-trans.ts
+++ b/packages/macro/test/jsx-trans.ts
@@ -311,4 +311,15 @@ export default [
         }>About</a>;
       `,
   },
+  {
+    name: "Ignore JSXEmptyExpression",
+    input: `
+        import { Trans } from '@lingui/macro';
+        <Trans>Hello {/* and I cannot stress this enough */} World</Trans>;
+      `,
+    expected: `
+        import { Trans } from "@lingui/react";
+        <Trans id="Hello  World" />;
+      `,
+  },
 ]


### PR DESCRIPTION
- this adds explicit handling of JSXEmptyExpression within
  packages/macro/src/icu.ts, where the token is skipped over entirely
- Fixes #684