### PR TITLE
Feature: add csv support

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -56,6 +56,7 @@
     "mkdirp": "^1.0.4",
     "normalize-path": "^3.0.0",
     "ora": "^4.0.3",
+    "papaparse": "^5.2.0",
     "pofile": "^1.0.11",
     "pseudolocale": "^1.1.0",
     "ramda": "^0.27.0"
@@ -63,6 +64,7 @@
   "devDependencies": {
     "@types/micromatch": "^4.0.1",
     "@types/normalize-path": "^3.0.0",
+    "@types/papaparse": "^5.0.3",
     "mockdate": "^2.0.2",
     "typescript": "^3.8.3"
   },

--- a/packages/cli/src/api/formats/__snapshots__/csv.test.ts.snap
+++ b/packages/cli/src/api/formats/__snapshots__/csv.test.ts.snap
@@ -25,6 +25,6 @@ Object {
 
 exports[`csv format should write catalog in csv format 1`] = `
 static,Static message
-stringWithUnpairedDoubleQuote,"Camecho 9"""" LCD Monitor HD TFT Color Screen, 2 Video Input/HDMI/VGA, Support Car Backup"
+stringWithUnpairedDoubleQuote,"Camecho 9"" LCD Monitor HD TFT Color Screen, 2 Video Input/HDMI/VGA, Support Car Backup"
 veryLongString,"One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections. The bedding was hardly able to cover it and seemed ready to slide off any moment. His many legs, pitifully thin compared with the size of the rest of him, waved about helplessly as he looked. """"What's happened to me?"""" he thought. It wasn't a dream. His room, a proper human"
 `;

--- a/packages/cli/src/api/formats/__snapshots__/csv.test.ts.snap
+++ b/packages/cli/src/api/formats/__snapshots__/csv.test.ts.snap
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`csv format should read catalog in csv format 1`] = `
+Object {
+  static: Object {
+    message: null,
+    obsolete: false,
+    origin: Array [],
+    translation: Static message,
+  },
+  stringWithUnpairedDoubleQuote: Object {
+    message: null,
+    obsolete: false,
+    origin: Array [],
+    translation: Camecho 9" LCD Monitor HD TFT Color Screen, 2 Video Input/HDMI/VGA, Support Car Backup,
+  },
+  veryLongString: Object {
+    message: null,
+    obsolete: false,
+    origin: Array [],
+    translation: One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections. The bedding was hardly able to cover it and seemed ready to slide off any moment. His many legs, pitifully thin compared with the size of the rest of him, waved about helplessly as he looked. "What's happened to me?" he thought. It wasn't a dream. His room, a proper human,
+  },
+}
+`;
+
+exports[`csv format should write catalog in csv format 1`] = `
+static,Static message
+stringWithUnpairedDoubleQuote,"Camecho 9"""" LCD Monitor HD TFT Color Screen, 2 Video Input/HDMI/VGA, Support Car Backup"
+veryLongString,"One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections. The bedding was hardly able to cover it and seemed ready to slide off any moment. His many legs, pitifully thin compared with the size of the rest of him, waved about helplessly as he looked. """"What's happened to me?"""" he thought. It wasn't a dream. His room, a proper human"
+`;

--- a/packages/cli/src/api/formats/csv.test.ts
+++ b/packages/cli/src/api/formats/csv.test.ts
@@ -21,7 +21,7 @@ describe("csv format", function () {
         translation: "Static message",
       },
       stringWithUnpairedDoubleQuote: {
-        translation: `Camecho 9"" LCD Monitor HD TFT Color Screen, 2 Video Input/HDMI/VGA, Support Car Backup`,
+        translation: `Camecho 9" LCD Monitor HD TFT Color Screen, 2 Video Input/HDMI/VGA, Support Car Backup`,
       },
       veryLongString: {
         translation: `One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections. The bedding was hardly able to cover it and seemed ready to slide off any moment. His many legs, pitifully thin compared with the size of the rest of him, waved about helplessly as he looked. ""What's happened to me?"" he thought. It wasn't a dream. His room, a proper human`,

--- a/packages/cli/src/api/formats/csv.test.ts
+++ b/packages/cli/src/api/formats/csv.test.ts
@@ -1,0 +1,82 @@
+import fs from "fs"
+import path from "path"
+import mockFs from "mock-fs"
+
+import format from "./csv"
+
+describe("csv format", function () {
+  afterEach(() => {
+    mockFs.restore()
+  })
+
+  it("should write catalog in csv format", function () {
+    mockFs({
+      locale: {
+        en: mockFs.directory(),
+      },
+    })
+    const filename = path.join("locale", "en", "messages.csv")
+    const catalog = {
+      static: {
+        translation: "Static message",
+      },
+      stringWithUnpairedDoubleQuote: {
+        translation: `Camecho 9"" LCD Monitor HD TFT Color Screen, 2 Video Input/HDMI/VGA, Support Car Backup`,
+      },
+      veryLongString: {
+        translation: `One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections. The bedding was hardly able to cover it and seemed ready to slide off any moment. His many legs, pitifully thin compared with the size of the rest of him, waved about helplessly as he looked. ""What's happened to me?"" he thought. It wasn't a dream. His room, a proper human`,
+      },
+    }
+
+    format.write(filename, catalog)
+    const csv = fs.readFileSync(filename).toString()
+    mockFs.restore()
+    expect(csv).toMatchSnapshot()
+  })
+
+  it("should read catalog in csv format", function () {
+    const csv = fs
+      .readFileSync(
+        path.join(path.resolve(__dirname), "fixtures", "messages.csv")
+      )
+      .toString()
+
+    mockFs({
+      locale: {
+        en: {
+          "messages.csv": csv,
+        },
+      },
+    })
+
+    const filename = path.join("locale", "en", "messages.csv")
+    const actual = format.read(filename)
+    mockFs.restore()
+    expect(actual).toMatchSnapshot()
+  })
+
+  it("should write the same catalog as it was read", function () {
+    const csv = fs
+      .readFileSync(
+        path.join(path.resolve(__dirname), "fixtures", "messages.csv")
+      )
+      .toString()
+
+    mockFs({
+      locale: {
+        en: {
+          "messages.csv": csv,
+        },
+      },
+    })
+
+    const filename = path.join("locale", "en", "messages.csv")
+    const catalog = format.read(filename)
+    format.write(filename, catalog)
+    const actual = fs.readFileSync(filename).toString()
+    mockFs.restore()
+    expect(actual.replace(/(\r\n|\n|\r)/gm, "")).toEqual(
+      csv.replace(/(\r\n|\n|\r)/gm, "")
+    )
+  })
+})

--- a/packages/cli/src/api/formats/csv.ts
+++ b/packages/cli/src/api/formats/csv.ts
@@ -1,0 +1,52 @@
+import fs from "fs"
+
+import { writeFileIfChanged } from "../utils"
+import { MessageType } from "../types"
+
+const serialize = (catalog) => {
+  var row = ""
+  for (const key of Object.keys(catalog)) {
+    var cur = catalog[key]
+    row += `\"${key}\"`
+    row += `,\"${cur.translation}\"` || ""
+    row += "\n"
+  }
+  return row
+}
+
+const deserialize = (raw: string): { [key: string]: MessageType } => {
+  const rows = raw.split("\n")
+  var rawCatalog = {}
+  rows.forEach((row) => {
+    for (let i = 0; i < row.length; i++) {
+      if (row[i] === "," && row[i - 1] === '"' && row[i + 1] === '"') {
+        rawCatalog[row.substring(1, i - 1)] = {
+          translation: row.substring(i + 2, row.length - 1),
+          obsolete: false,
+          message: null,
+          origin: [],
+        }
+      }
+    }
+  })
+  return rawCatalog
+}
+
+export default {
+  catalogExtension: ".csv",
+
+  write(filename, catalog) {
+    const messages = serialize(catalog)
+    writeFileIfChanged(filename, messages)
+  },
+
+  read(filename) {
+    const raw = fs.readFileSync(filename).toString()
+    try {
+      return deserialize(raw)
+    } catch (e) {
+      console.error(`Cannot read ${filename}: ${e.message}`)
+      return null
+    }
+  },
+}

--- a/packages/cli/src/api/formats/csv.ts
+++ b/packages/cli/src/api/formats/csv.ts
@@ -8,7 +8,7 @@ const serialize = (catalog) => {
   for (const key of Object.keys(catalog)) {
     var cur = catalog[key]
     row += `\"${key}\"`
-    row += `,\"${cur.translation}\"` || ""
+    row += `,\"${cur.translation}\"`
     row += "\n"
   }
   return row

--- a/packages/cli/src/api/formats/fixtures/messages.csv
+++ b/packages/cli/src/api/formats/fixtures/messages.csv
@@ -1,0 +1,3 @@
+static,Static message
+stringWithUnpairedDoubleQuote,"Camecho 9"" LCD Monitor HD TFT Color Screen, 2 Video Input/HDMI/VGA, Support Car Backup"
+veryLongString,"One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections. The bedding was hardly able to cover it and seemed ready to slide off any moment. His many legs, pitifully thin compared with the size of the rest of him, waved about helplessly as he looked. ""What's happened to me?"" he thought. It wasn't a dream. His room, a proper human"

--- a/packages/cli/src/api/formats/index.ts
+++ b/packages/cli/src/api/formats/index.ts
@@ -1,9 +1,10 @@
 import lingui from "./lingui"
 import minimal from "./minimal"
 import po from "./po"
+import csv from "./csv"
 import { CatalogType } from "../types"
 
-const formats: { [key: string]: CatalogFormat } = { lingui, minimal, po }
+const formats: { [key: string]: CatalogFormat } = { lingui, minimal, po, csv }
 
 export interface CatalogFormatOptions {
   locale: string

--- a/yarn.lock
+++ b/yarn.lock
@@ -1425,6 +1425,13 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-path/-/normalize-path-3.0.0.tgz#bb5c46cab77b93350b4cf8d7ff1153f47189ae31"
   integrity sha512-Nd8y/5t/7CRakPYiyPzr/IAfYusy1FkcZYFEAcoMZkwpJv2n4Wm+olW+e7xBdHEXhOnWdG9ddbar0gqZWS4x5Q==
 
+"@types/papaparse@^5.0.3":
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/@types/papaparse/-/papaparse-5.0.3.tgz#7cedc1ebc9484819af8306a8b42f9f08ca9bdb44"
+  integrity sha512-SgWGWnBGxl6XgjKDM2eoDg163ZFQtH6m6C2aOuaAf1T2gUB3rjaiPDDARbY9WlacRgZqieRG9imAfJaJ+5ouDA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/parse-json@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
@@ -6866,6 +6873,11 @@ pako@~1.0.2, pako@~1.0.5:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
   integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
+
+papaparse@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/papaparse/-/papaparse-5.2.0.tgz#97976a1b135c46612773029153dc64995caa3b7b"
+  integrity sha512-ylq1wgUSnagU+MKQtNeVqrPhZuMYBvOSL00DHycFTCxownF95gpLAk1HiHdUW77N8yxRq1qHXLdlIPyBSG9NSA==
 
 parallel-transform@^1.1.0:
   version "1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1103,7 +1103,7 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@jest/types@^25.3.0", "@jest/types@^25.4.0":
+"@jest/types@^25.4.0":
   version "25.4.0"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-25.4.0.tgz#5afeb8f7e1cba153a28e5ac3c9fe3eede7206d59"
   integrity sha512-XBeaWNzw2PPnGW5aXvZt3+VO60M+34RY3XDsCK5tW7kyj3RK0XClRutCfjqcBuaR2aBQTbluEDME9b5MB9UAPw==
@@ -5539,18 +5539,6 @@ jest-validate@^24.9.0:
     leven "^3.1.0"
     pretty-format "^24.9.0"
 
-jest-validate@^25.3.0, jest-validate@^25.4.0:
-  version "25.4.0"
-  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-25.4.0.tgz#2e177a93b716a137110eaf2768f3d9095abd3f38"
-  integrity sha512-hvjmes/EFVJSoeP1yOl8qR8mAtMR3ToBkZeXrD/ZS9VxRyWDqQ/E1C5ucMTeSmEOGLipvdlyipiGbHJ+R1MQ0g==
-  dependencies:
-    "@jest/types" "^25.4.0"
-    camelcase "^5.3.1"
-    chalk "^3.0.0"
-    jest-get-type "^25.2.6"
-    leven "^3.1.0"
-    pretty-format "^25.4.0"
-
 jest-validate@^25.4.0:
   version "25.4.0"
   resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-25.4.0.tgz#2e177a93b716a137110eaf2768f3d9095abd3f38"
@@ -7143,16 +7131,6 @@ pretty-format@^24.9.0:
     react-is "^16.8.4"
 
 pretty-format@^25.1.0, pretty-format@^25.2.1, pretty-format@^25.3.0, pretty-format@^25.4.0:
-  version "25.4.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-25.4.0.tgz#c58801bb5c4926ff4a677fe43f9b8b99812c7830"
-  integrity sha512-PI/2dpGjXK5HyXexLPZU/jw5T9Q6S1YVXxxVxco+LIqzUFHXIbKZKdUVt7GcX7QUCr31+3fzhi4gN4/wUYPVxQ==
-  dependencies:
-    "@jest/types" "^25.4.0"
-    ansi-regex "^5.0.0"
-    ansi-styles "^4.0.0"
-    react-is "^16.12.0"
-
-pretty-format@^25.4.0:
   version "25.4.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-25.4.0.tgz#c58801bb5c4926ff4a677fe43f9b8b99812c7830"
   integrity sha512-PI/2dpGjXK5HyXexLPZU/jw5T9Q6S1YVXxxVxco+LIqzUFHXIbKZKdUVt7GcX7QUCr31+3fzhi4gN4/wUYPVxQ==


### PR DESCRIPTION
I don't actually like the csv format, however in my current situation, the translators only accept csv files for convenience, and I have to convert the po file into csv and convert it back when the translation is ready. I'm not familiar with ramda, not sure if some of the code can be replaced by using ramda. 