### PR TITLE
CLI: Explicitly sort directory listings

### DIFF
--- a/packages/cli/src/api/extract.js
+++ b/packages/cli/src/api/extract.js
@@ -55,6 +55,7 @@ export function extract(
     if (fs.statSync(srcFilename).isDirectory()) {
       const subdirs = fs
         .readdirSync(srcFilename)
+        .sort()
         .map(filename => path.join(srcFilename, filename))
 
       extract(subdirs, targetPath, options)
@@ -78,6 +79,7 @@ export function extract(
 export function collect(buildDir: string) {
   return fs
     .readdirSync(buildDir)
+    .sort()
     .map(filename => {
       const filepath = path.join(buildDir, filename)
 


### PR DESCRIPTION
When reading the files in a directory in order to extract translation strings, the order in which the files are returned varies based on OS, sometimes resulting in unnecessary diffs when extraction is performed on different operating systems.

For example, runing `lingui extract` on Windows after a file was previously "extracted" on MacOS would generate a diff similar to this:
```patch
-#: src/components/admin/content/admin-event-page/AdminEventPage.tsx:217
 #: src/components/admin/content/AdminNugget.tsx:411
+#: src/components/admin/content/admin-event-page/AdminEventPage.tsx:217
 msgid "Preview"
 msgstr "Vorschau"
```