### PR TITLE
CLI: Explicitly sort directory listings

### DIFF
--- a/packages/cli/src/api/extract.ts
+++ b/packages/cli/src/api/extract.ts
@@ -56,6 +56,7 @@ export function extract(
     if (fs.statSync(srcFilename).isDirectory()) {
       const subdirs = fs
         .readdirSync(srcFilename)
+        .sort()
         .map((filename) => path.join(srcFilename, filename))
 
       extract(subdirs, targetPath, options)
@@ -79,6 +80,7 @@ export function extract(
 export function collect(buildDir: string) {
   return fs
     .readdirSync(buildDir)
+    .sort()
     .map((filename) => {
       const filepath = path.join(buildDir, filename)
 


### PR DESCRIPTION
When reading the files in a directory in order to extract translation strings, the order in which the files are returned varies based on OS, sometimes resulting in unnecessary diffs when extraction is performed on different operating systems.

(Basically the same thing as pull request #694 but for the `next` branch)