### PR TITLE
Update react-int's rich text formatting example

### DIFF
--- a/docs/misc/react-intl.rst
+++ b/docs/misc/react-intl.rst
@@ -50,39 +50,11 @@ In `react-intl`_, this would be translated as:
 
    <FormattedMessage
        id='msg.docs'
-       defaultMessage='Read the {link}.'
+       defaultMessage='Read the <link>documentation</link>.'
        values={{
-           link: <a href="/docs">documentation</a>
+           link: (...chunks) => <a href="/docs">{chunks}</a>
        }}
    />
-
-which isn't enough, because word ``documentation`` is left untranslated.
-The correct solution would be:
-
-.. code-block:: jsx
-
-   <FormattedMessage
-       id='msg.docs'
-       defaultMessage='Read the {link}.'
-       values={{
-           link: (
-            <a href="/docs">
-               <FormattedMessage id="msg.docs.link" defaultMessage="documentation" />
-            </a>
-           )
-       }}
-   />
-
-but even this solution is sub-optimal, because the translator has to translate two separate messages:
-
-.. code-block:: json
-
-   {
-      "msg.docs": "Read the {link}.",
-      "msg.docs.link": "documentation"
-   }
-
-This is very fragile and error prone because phrases usually can't be translated word by word.
 
 `LinguiJS`_ extends ICU MessageFormat with tags. The example above would be:
 
@@ -135,13 +107,9 @@ Let's compare it with `react-intl`_ solution to see the difference:
    <p>
       <FormattedMessage
           id='msg.docs'
-          defaultMessage='Read the {link}.'
+          defaultMessage='Read the <link>documentation</link>.'
           values={{
-              name: (
-               <a href="/docs">
-                  <FormattedMessage id="msg.docs.link" defaultMessage="documentation" />
-               </a>
-              )
+              link: (...chunks) => <a href="/docs">{chunks}</a>
           }}
       />
    </p>


### PR DESCRIPTION
`react-intl` supports [rich text formatting](https://formatjs.io/docs/react-intl/components#rich-text-formatting) that is very similar to the way `LinguiJS` does. This updates the doc's to correctly show that.