### PR TITLE
Export PureI18nProvider without side-effects for testing purposes

### DIFF
--- a/docs/ref/react.rst
+++ b/docs/ref/react.rst
@@ -290,77 +290,28 @@ I18nProvider
 
 .. component:: I18nProvider
 
-   :prop string language: Active language
-   :prop string|string[] locales: List of locales used for date/number formatting. Defaults to active language.
-   :prop object catalogs: Message catalogs
+   :prop I18n i18n: Instance of i18n to use
    :prop React.Element|React.Class|string defaultRender: Default element to render translation
-   :prop string|Function missing: Custom message to be returned when translation is missing
+   :prop boolean optOutFromChanges: Stop updating Provider value with locale changes
 
 ``defaultRender`` has the same meaning as ``render`` in other i18n
 components. :ref:`Rendering of translations <rendering-translations>` is explained
 at the beginning of this document.
 
-``language`` sets the active language and loads corresponding message catalog.
-``locales`` are used for date/number formatting for countries or regions which use
-different formats for the same language (e.g. arabic numerals have several
-representations).
-
-``missing`` is used as a default translation when translation is missing. It might
-be also a function, which is called with language and message ID. This is useful
-for debugging:
+``optOutFromChanges`` is useful if you don't need components to re-render when any locale data
+changes.
 
 .. code-block:: jsx
 
    import React from 'react';
    import { I18nProvider } from '@lingui/react';
+   import { setupI18n } from '@lingui/core';
 
-   const App = ({ language} ) => {
+   const i18n = setupI18n()
+
+   const App = () => {
         return (
-            <I18nProvider language={language} missing="🚨">
-               {/* This will render as 🚨*/}
-               <Trans id="missing translation" />
-            </I18nProvider>
-        );
-   }
-
-``catalogs`` is a type of ``Catalogs``:
-
-.. code-block:: jsx
-
-   // One catalog per language
-   type Catalogs = {
-     [language: string]: Catalog
-   }
-
-   // Catalog contains messages and language data (i.e: plurals)
-   type Catalog = {
-     messages: Messages,
-     languageData?: {
-       plurals: Function
-     }
-   }
-
-   // Message is either function (compiled message) or string
-   type Messages = {
-     [messageId: string]: string | Function
-   }
-
-This component should live above all i18n components. A good place is as a
-top-level application component. However, if the ``language`` is stored in a
-``redux`` store, this component should be inserted below ``react-redux/Provider``:
-
-.. code-block:: jsx
-
-   import React from 'react';
-   import { I18nProvider } from '@lingui/react';
-
-   const App = ({ language} ) => {
-        const catalog = require(`locales/${language}.js`);
-
-        return (
-            <I18nProvider language={language} catalogs={{ [language]: catalog }}>
-               // rest of the app
-            </I18nProvider>
+            <I18nProvider i18n={i18n} />
         );
    }
 

--- a/packages/react/src/I18nProvider.tsx
+++ b/packages/react/src/I18nProvider.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent } from "react"
-import { I18n } from "@lingui/core"
-import { TransRenderType } from "./Trans"
+import type { I18n } from "@lingui/core"
+import type { TransRenderType } from "./Trans"
 
 type I18nContext = {
   i18n: I18n
@@ -9,7 +9,7 @@ type I18nContext = {
 
 export type I18nProviderProps = I18nContext
 
-const LinguiContext = React.createContext<I18nContext>(null)
+export const LinguiContext = React.createContext<I18nContext>(null)
 
 export function useLingui(): I18nContext {
   const context = React.useContext(LinguiContext)
@@ -21,6 +21,10 @@ export function useLingui(): I18nContext {
   }
 
   return context
+}
+
+export function usei18n(): I18n {
+  return useLingui().i18n
 }
 
 export const I18nProvider: FunctionComponent<I18nProviderProps> = (props) => {

--- a/packages/react/src/I18nProvider.tsx
+++ b/packages/react/src/I18nProvider.tsx
@@ -5,9 +5,10 @@ import type { TransRenderType } from "./Trans"
 type I18nContext = {
   i18n: I18n
   defaultRender?: TransRenderType
+  optOutFromChanges?: boolean
 }
 
-export interface I18nProviderProps extends I18nContext {}
+export type I18nProviderProps = {} & I18nContext
 
 const LinguiContext = React.createContext<I18nContext>(null)
 
@@ -34,9 +35,13 @@ export const I18nProvider: FunctionComponent<I18nProviderProps> = (props) => {
    * we need to trigger re-rendering of LinguiContext.Consumers.
    */
   React.useEffect(() => {
-    const unsubscribe = props.i18n.on("change", () => setContext(makeContext()))
-    return () => unsubscribe()
-  }, [])
+    if (props.optOutFromChanges !== true) {
+      const unsubscribe = props.i18n.on("change", () =>
+        setContext(makeContext())
+      )
+      return () => unsubscribe()
+    }
+  }, [props.optOutFromChanges])
 
   /**
    * We can't pass `i18n` object directly through context, because even when locale
@@ -59,21 +64,6 @@ export const I18nProvider: FunctionComponent<I18nProviderProps> = (props) => {
   return (
     <LinguiContext.Provider value={context}>
       {props.children}
-    </LinguiContext.Provider>
-  )
-}
-
-/**
- * I18nProvider variant without side effect of updating when i18n changes eg. locale.
- * Useful for tests which don't such functionality and can cause problems (act warning).
- * Additionally, it doesn't require i18n instance to be passed, global one will be used by default.
- */
-export const PureI18nProvider: FunctionComponent<Partial<
-  I18nProviderProps
->> = ({ i18n = i18nGlobal, defaultRender, children }) => {
-  return (
-    <LinguiContext.Provider value={{ i18n, defaultRender }}>
-      {children}
     </LinguiContext.Provider>
   )
 }

--- a/packages/react/src/I18nProvider.tsx
+++ b/packages/react/src/I18nProvider.tsx
@@ -23,10 +23,6 @@ export function useLingui(): I18nContext {
   return context
 }
 
-export function usei18n(): I18n {
-  return useLingui().i18n
-}
-
 export const I18nProvider: FunctionComponent<I18nProviderProps> = (props) => {
   const [context, setContext] = React.useState<I18nContext>(makeContext())
 

--- a/packages/react/src/I18nProvider.tsx
+++ b/packages/react/src/I18nProvider.tsx
@@ -7,7 +7,7 @@ type I18nContext = {
   defaultRender?: TransRenderType
 }
 
-export type I18nProviderProps = I18nContext
+export interface I18nProviderProps extends I18nContext {}
 
 const LinguiContext = React.createContext<I18nContext>(null)
 

--- a/packages/react/src/I18nProvider.tsx
+++ b/packages/react/src/I18nProvider.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from "react"
-import type { I18n } from "@lingui/core"
+import { i18n as i18nGlobal, I18n } from "@lingui/core"
 import type { TransRenderType } from "./Trans"
 
 type I18nContext = {
@@ -9,7 +9,7 @@ type I18nContext = {
 
 export type I18nProviderProps = I18nContext
 
-export const LinguiContext = React.createContext<I18nContext>(null)
+const LinguiContext = React.createContext<I18nContext>(null)
 
 export function useLingui(): I18nContext {
   const context = React.useContext(LinguiContext)
@@ -63,6 +63,21 @@ export const I18nProvider: FunctionComponent<I18nProviderProps> = (props) => {
   return (
     <LinguiContext.Provider value={context}>
       {props.children}
+    </LinguiContext.Provider>
+  )
+}
+
+/**
+ * I18nProvider variant without side effect of updating when i18n changes eg. locale.
+ * Useful for tests which don't such functionality and can cause problems (act warning).
+ * Additionally, it doesn't require i18n instance to be passed, global one will be used by default.
+ */
+export const PureI18nProvider: FunctionComponent<Partial<
+  I18nProviderProps
+>> = ({ i18n = i18nGlobal, defaultRender, children }) => {
+  return (
+    <LinguiContext.Provider value={{ i18n, defaultRender }}>
+      {children}
     </LinguiContext.Provider>
   )
 }

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,8 +1,3 @@
-export {
-  I18nProvider,
-  I18nProviderProps,
-  PureI18nProvider,
-  useLingui,
-} from "./I18nProvider"
+export { I18nProvider, I18nProviderProps, useLingui } from "./I18nProvider"
 
 export { Trans } from "./Trans"

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,2 +1,9 @@
-export { I18nProvider, useLingui } from "./I18nProvider"
+export {
+  I18nProvider,
+  I18nProviderProps,
+  LinguiContext,
+  useLingui,
+  usei18n,
+} from "./I18nProvider"
+
 export { Trans } from "./Trans"

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,9 +1,8 @@
 export {
   I18nProvider,
   I18nProviderProps,
-  LinguiContext,
+  PureI18nProvider,
   useLingui,
-  usei18n,
 } from "./I18nProvider"
 
 export { Trans } from "./Trans"


### PR DESCRIPTION
I know, it's uncommon to have a whole Context exported but bear with me.

Current `I18nProvider` includes a side effect to provide an update to context when `i18n` changes something. That's cool and even though I know I wouldn't use that, it's not the main reason for this PR.

https://github.com/lingui/js-lingui/blob/f6167e0cff98de6ffd7da2296058b0405af5fbeb/packages/react/src/I18nProvider.tsx#L36-L39

When running tests, this side effect will cause an infamous `act warning` and I haven't found a way on how to prevent that except removing that side effect from the code.

![image](https://user-images.githubusercontent.com/1096340/82113315-68885180-9755-11ea-87f7-c9ab57469af0.png)

With exported Context and I can have my own Provider in tests without that side effect.

An alternative solution would be to introduce a boolean to props that would disable that side effect, but that doesn't sound great.

PR is a draft, for now, I will update documentation when we have agreed on a way to go.

**Bonus**

I have exported `usei18n` hook purely as a shortcut because in most cases users don't care about `defaultRender`.

cc @tricoder42 