### PR TITLE
Fix import of setupI18n in @next React docs.

### DIFF
--- a/docs/tutorials/react.rst
+++ b/docs/tutorials/react.rst
@@ -84,7 +84,8 @@ Let's add all required imports and wrap our app inside :component:`I18nProvider`
    import { render } from 'react-dom'
    import Inbox from './Inbox.js'
 
-   import { setupI18n, I18nProvider } from '@lingui/react'
+   import { I18nProvider } from '@lingui/react'
+   import { setupI18n } from '@lingui/core'
 
    const i18n = setupI18n()
    i18n.load('en', catalogEn)


### PR DESCRIPTION
`setupI18n` isn't exported by the react module, so it has to be imported from core. I'm not sure if this is an issue with the lib or with the docs, though.