### PR TITLE
Prevent trimming defaults for Trans component in Production env

### DIFF
--- a/packages/babel-plugin-transform-react/src/transformer.js
+++ b/packages/babel-plugin-transform-react/src/transformer.js
@@ -425,8 +425,7 @@ export default class Transformer {
 
     if (process.env.NODE_ENV === "production") {
       node.openingElement.attributes = attrs.filter(
-        node =>
-          !this.isDefaultsAttribute(node) && !this.isDescriptionAttribute(node)
+        node => !this.isDescriptionAttribute(node)
       )
     }
   }

--- a/packages/babel-plugin-transform-react/test/fixtures/env-production-remove-defaults/actual.js
+++ b/packages/babel-plugin-transform-react/test/fixtures/env-production-remove-defaults/actual.js
@@ -1,3 +1,0 @@
-import { Trans } from '@lingui/react';
-
-<Trans id="msg.hello" defaults="Hello World" />

--- a/packages/babel-plugin-transform-react/test/fixtures/env-production-remove-defaults/expected.js
+++ b/packages/babel-plugin-transform-react/test/fixtures/env-production-remove-defaults/expected.js
@@ -1,3 +1,0 @@
-import { Trans } from '@lingui/react';
-
-<Trans id="msg.hello" />;

--- a/packages/babel-plugin-transform-react/test/fixtures/env-production-save-defaults/actual.js
+++ b/packages/babel-plugin-transform-react/test/fixtures/env-production-save-defaults/actual.js
@@ -1,4 +1,3 @@
-import { Trans } from "@lingui/react";
-
+import { Trans } from '@lingui/react';
 
 <Trans id="msg.hello" defaults="Hello World" />;

--- a/packages/babel-plugin-transform-react/test/fixtures/env-production-save-defaults/expected.js
+++ b/packages/babel-plugin-transform-react/test/fixtures/env-production-save-defaults/expected.js
@@ -1,4 +1,3 @@
-import { Trans } from "@lingui/react";
-
+import { Trans } from '@lingui/react';
 
 <Trans id="msg.hello" defaults="Hello World" />;


### PR DESCRIPTION
This PR fixes #404 and prevents trimming `defaults` for the Trans component.
So now `t` and `Trans` have similar behavior

```
i18n._(t("component.name")`Your name`)
<Trans id="component.name1">
  Your name
</Trans>
```

After compiling it will be
```
b._({id:"component.name",defaults:"Your name"})
i.a.createElement(m.Trans,{id:"component.name1", defaults:"Your name"}))
```