### PR TITLE
import setupI18n from core

### DIFF
--- a/docs/ref/react.rst
+++ b/docs/ref/react.rst
@@ -94,7 +94,7 @@ variables and components inside messages. Usage of this component depends on
 whether or not you're using LinguiJS Babel plugins.
 
 Each message is identified by **message ID**.
-``babel-plugin-lingui-transform-react`` automatically generates message ID from
+``@lingui/babel-plugin-transform-react`` automatically generates message ID from
 contents of :component:`Trans` component, but it's possible to provide custom
 message ID by setting the `id` prop.
 

--- a/docs/releases/migration-3.rst
+++ b/docs/releases/migration-3.rst
@@ -40,8 +40,8 @@ is simplified and accepts ``i18n`` manager, which must be created manually:
 
 .. code-block:: diff
 
-   - import { I18nProvider } from '@lingui/react'
-   + import { setupI18n, I18nProvider } from '@lingui/react'
+     import { I18nProvider } from '@lingui/react'
+   + import { setupI18n } from '@lingui/core'
      import catalogEn from './locale/en/messages.js'
 
    + const i18n = setupI18n()

--- a/packages/cli/src/api/extract.js
+++ b/packages/cli/src/api/extract.js
@@ -55,6 +55,7 @@ export function extract(
     if (fs.statSync(srcFilename).isDirectory()) {
       const subdirs = fs
         .readdirSync(srcFilename)
+        .sort()
         .map(filename => path.join(srcFilename, filename))
 
       extract(subdirs, targetPath, options)
@@ -78,6 +79,7 @@ export function extract(
 export function collect(buildDir: string) {
   return fs
     .readdirSync(buildDir)
+    .sort()
     .map(filename => {
       const filepath = path.join(buildDir, filename)
 


### PR DESCRIPTION
import `setupI18n` from `@lingui/core` instead of `@lingui/react`

(`setupI18n` not found in `@lingui/react`)