### PR TITLE
Add `lingui check` cli

### DIFF
--- a/packages/cli/src/api/__snapshots__/catalog.test.ts.snap
+++ b/packages/cli/src/api/__snapshots__/catalog.test.ts.snap
@@ -1,5 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Catalog check should check for missing message in the catalog 1`] = `
+Object {
+  en: Array [
+    How are you today?,
+  ],
+}
+`;
+
 exports[`Catalog collect should extract messages from source files 1`] = `
 Object {
   Hello World: Object {

--- a/packages/cli/src/api/catalog.test.ts
+++ b/packages/cli/src/api/catalog.test.ts
@@ -132,6 +132,24 @@ describe("Catalog", function () {
     })
   })
 
+  describe("check", function () {
+    it("should check for missing message in the catalog", function () {
+      const catalog = new Catalog(
+        {
+          name: "messages",
+          path: fixture("check/locales/{locale}"),
+          include: [fixture("check/src")],
+          exclude: [],
+        },
+        mockConfig({ locales: ["en"] })
+      )
+
+      const response = catalog.check(defaultMakeOptions)
+
+      expect(response).toMatchSnapshot()
+    })
+  })
+
   describe("merge", function () {
     /*
     catalog.merge(prevCatalogs, nextCatalog, options)

--- a/packages/cli/src/api/catalog.ts
+++ b/packages/cli/src/api/catalog.ts
@@ -193,6 +193,38 @@ export class Catalog {
     }, prevCatalogs)
   }
 
+  check(options: MakeOptions) {
+    const nextCatalog = this.collect(options)
+    const prevCatalogs = this.readAll()
+
+    console.log({ nextCatalog, prevCatalogs })
+
+    const missingMessageIdsByLocale = this.diff(prevCatalogs, nextCatalog)
+
+    console.log({ missingMessageIdsByLocale })
+
+    return missingMessageIdsByLocale
+  }
+
+  diff(prevCatalogs: AllCatalogsType, nextCatalog: ExtractedCatalogType) {
+    const nextCatalogMessageIds = Object.keys(nextCatalog)
+
+    const missingMessageIdsByLocale = R.mapObjIndexed(
+      (prevCatalogForLocale) => {
+        const prevMessageIdsOfLocale = Object.keys(prevCatalogForLocale)
+
+        const missingMessageIdsForLocale = nextCatalogMessageIds.filter(
+          (nextMessageId) => !prevMessageIdsOfLocale.includes(nextMessageId)
+        )
+
+        return missingMessageIdsForLocale
+      },
+      prevCatalogs
+    )
+
+    return missingMessageIdsByLocale
+  }
+
   getTranslations(locale: string, options: GetTranslationsOptions) {
     const catalogs = this.readAll()
     return R.mapObjIndexed(

--- a/packages/cli/src/api/fixtures/check/locales/en.po
+++ b/packages/cli/src/api/fixtures/check/locales/en.po
@@ -1,0 +1,24 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Sample Project\n"
+"POT-Creation-Date: 2018-08-09\n"
+"PO-Revision-Date: 2018-08-09\n"
+"Report-Msgid-Bugs-To: Daniel Krejčí <fredy.c@seznam.cz>\n"
+"Last-Translator: Tomáš Ehrlich <tomas.ehrlich@gmail.com>\n"
+"Language-Team: jsLingui\n"
+"Mime-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: en\n"
+"X-Generator: @lingui/cli\n"
+"Plural-Forms: nplurals=0\n"
+
+#: src/componentA/index.js:1
+#: src/componentA/componentA.js:3
+msgid "Hello World"
+msgstr ""
+
+#: src/componentA/index.js:3
+msgid "Not used anymore"
+msgstr "This message is not used anymore"
+

--- a/packages/cli/src/api/fixtures/check/src/componentA/componentA.js
+++ b/packages/cli/src/api/fixtures/check/src/componentA/componentA.js
@@ -1,0 +1,3 @@
+/*i18n*/ i18n._("Hello World")
+
+/*i18n*/ i18n._("How are you today?")

--- a/packages/cli/src/api/fixtures/check/src/componentA/index.js
+++ b/packages/cli/src/api/fixtures/check/src/componentA/index.js
@@ -1,0 +1,1 @@
+/*i18n*/ i18n._("Hello World")


### PR DESCRIPTION
This PR aim to implement the `lingui check` command as discuted in issue #722

The core diffing algorithm to detect the missing message have been written. It's simple but seems to be enough to build a detailed output.

### TODOs

- [ ] Write the CLI with a basic output
- [ ] Improve the CLI output to match the proposed one
- [ ] Add a verbose option

### Output

The output should show at lead these informations:
- the message id that is not extracted
- the location of the missing message
- the information in which catalogs the message is missing: a locale list (eg: `cs, fr`) or the catalogs path (eg: `src/messages/cs.po, src/messages/fr.po` )

#### Proposal one

```
$ lingui check

"some.new.message.id" 
  (from `src/componentA/foo.js:1`, and 1 other location)
     ✗ the message is missing in "src/messages/en.po"
     ✗ the message is missing in "src/messages/cs.po"
     ✗ the message is missing in "src/messages/fr.po"

"some.partially.missing.message.id" 
    (from `src/componentA/index.js:1`)
         ✗ the message is missing in "src/messages/fr.po"

✗ There is 2 issues in the catalogs. 

(use "yarn lingui extract" to update catalogs with new messages)
```

#### Proposal two

```
$ lingui check

The file "src/componentA/foo.js: contains 1 message not referenced in all catalogs:
    - "some.new.message.id" at line 1
         ✗ is missing in the catalog "src/messages/en.po"
         ✗ is missing in the catalog "src/messages/cs.po"
         ✗ is missing in the catalog  "src/messages/fr.po"

The file "src/componentA/index.js" contains 1 message not referenced in all catalogs:
    - "some.partially.missing.message.id" at line 3
         ✗ the message is missing in "src/messages/fr.po"

✗ There is 2 issues in the catalogs. 

(use "yarn lingui extract" to update catalogs with new messages)
```