### PR TITLE
Support typescript 4 in package.json

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -67,6 +67,6 @@
   "peerDependencies": {
     "babel-core": "6.x || ^7.0.0-bridge.0",
     "babel-plugin-macros": "^2.4.2",
-    "typescript": "2 || 3"
+    "typescript": "2 || 3 || 4"
   }
 }


### PR DESCRIPTION
Fixes #728.

TypeScript 4 was recently released but has very few backwards-incompatible changes.  I recently migrated to it on my open-source LinguiJS-based project (https://github.com/JustFixNYC/tenants2/pull/1659) and everything seems to work fine for me. This PR adds support for TypeScript 4 to the `package.json` so no peer dependency warning is logged.