### PR TITLE
Add an ES module wrapper

### DIFF
--- a/packages/core/npm/esm/index.js
+++ b/packages/core/npm/esm/index.js
@@ -1,0 +1,6 @@
+import i18nModule from '../index.js'
+
+export const setupI18n = i18nModule.setupI18n
+export const I18n = i18nModule.I18n
+export const i18n = i18nModule.i18n
+export const formats = i18nModule.formats

--- a/packages/core/npm/esm/package.json
+++ b/packages/core/npm/esm/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,11 +27,16 @@
   "engines": {
     "node": ">=10.0.0"
   },
+  "exports": {
+    "require": "./index.js",
+    "import": "./esm/index.js"
+  },
   "files": [
     "LICENSE",
     "README.md",
     "index.js",
-    "cjs/"
+    "cjs/",
+    "esm/"
   ],
   "dependencies": {
     "@babel/runtime": "^7.11.2",


### PR DESCRIPTION
 With this wrapper, a Node.js based ES module can use the *named import* syntax. E.g. `import {i18n} ...`

This PR belongs to this issue: #736 