### PR TITLE
Make the extractor support Babel's default file extensions. Babel sup…

### DIFF
--- a/packages/cli/src/api/extract.test.ts
+++ b/packages/cli/src/api/extract.test.ts
@@ -10,13 +10,18 @@ describe("extract", function () {
   let extract, babel, typescript
 
   beforeAll(() => {
+
+    // References to the real match functions
+    const babelMatch = require("./extractors/babel").default.match
+    const tsMatch = require("./extractors/typescript").default.match
+
     jest.doMock("./extractors/babel", () => ({
-      match: jest.fn((filename) => filename.endsWith(".js")),
+      match: jest.fn(babelMatch),
       extract: jest.fn(),
     }))
 
     jest.doMock("./extractors/typescript", () => ({
-      match: jest.fn((filename) => filename.endsWith(".ts")),
+      match: jest.fn(tsMatch),
       extract: jest.fn(),
     }))
 
@@ -31,6 +36,10 @@ describe("extract", function () {
 
         components: {
           "Babel.js": "",
+          "Babel.jsx": "",
+          "Babel.es6": "",
+          "Babel.es": "",
+          "Babel.mjs": "",
           "Typescript.ts": "",
           forbidden: {
             "apple.js": "",
@@ -60,33 +69,80 @@ describe("extract", function () {
     expect(babel.match).toHaveBeenCalledWith(
       path.join("src", "components", "Babel.js")
     )
-    expect(babel.match).toHaveBeenCalledWith(path.join("src", "index.html"))
+    expect(babel.match).toHaveBeenCalledWith(
+      path.join("src", "components", "Babel.jsx")
+    )
+    expect(babel.match).toHaveBeenCalledWith(
+      path.join("src", "components", "Babel.es6")
+    )
+    expect(babel.match).toHaveBeenCalledWith(
+      path.join("src", "components", "Babel.es")
+    )
+    expect(babel.match).toHaveBeenCalledWith(
+      path.join("src", "components", "Babel.mjs")
+    )
+		
+    expect(babel.match).toHaveBeenCalledWith(
+			path.join("src", "index.html")
+    )
 
     // This file is ignored
     expect(babel.extract).not.toHaveBeenCalledWith(
       path.join("src", "index.html")
     )
 
+    const extractArgs = [
+      "locale", 
+      { babelOptions: {}, ignore: ["forbidden"]}
+    ]
     expect(babel.extract).toHaveBeenCalledWith(
       path.join("src", "components", "Babel.js"),
-      "locale",
-      { babelOptions: {}, ignore: ["forbidden"] }
+      ...extractArgs
+    )
+    expect(babel.extract).toHaveBeenCalledWith(
+      path.join("src", "components", "Babel.jsx"),
+      ...extractArgs
+    )
+    expect(babel.extract).toHaveBeenCalledWith(
+      path.join("src", "components", "Babel.es6"),
+      ...extractArgs
+    )
+    expect(babel.extract).toHaveBeenCalledWith(
+      path.join("src", "components", "Babel.es"),
+      ...extractArgs
+    )
+    expect(babel.extract).toHaveBeenCalledWith(
+      path.join("src", "components", "Babel.mjs"),
+      ...extractArgs
     )
     expect(babel.extract).not.toHaveBeenCalledWith(
       path.join("src", "components", "Typescript.ts"),
-      "locale",
-      { babelOptions: {}, ignore: ["forbidden"] }
+      ...extractArgs
     )
 
     expect(typescript.extract).not.toHaveBeenCalledWith(
       path.join("src", "components", "Babel.js"),
-      "locale",
-      { babelOptions: {}, ignore: ["forbidden"] }
+      ...extractArgs
+    )
+    expect(typescript.extract).not.toHaveBeenCalledWith(
+      path.join("src", "components", "Babel.jsx"),
+      ...extractArgs
+    )
+    expect(typescript.extract).not.toHaveBeenCalledWith(
+      path.join("src", "components", "Babel.es6"),
+      ...extractArgs
+    )
+    expect(typescript.extract).not.toHaveBeenCalledWith(
+      path.join("src", "components", "Babel.es"),
+      ...extractArgs
+    )
+    expect(typescript.extract).not.toHaveBeenCalledWith(
+      path.join("src", "components", "Babel.mjs"),
+      ...extractArgs
     )
     expect(typescript.extract).toHaveBeenCalledWith(
       path.join("src", "components", "Typescript.ts"),
-      "locale",
-      { babelOptions: {}, ignore: ["forbidden"] }
+      ...extractArgs
     )
   })
 })

--- a/packages/cli/src/api/extractors/babel.ts
+++ b/packages/cli/src/api/extractors/babel.ts
@@ -1,11 +1,14 @@
-import { transformFileSync } from "@babel/core"
+import { transformFileSync, DEFAULT_EXTENSIONS } from "@babel/core"
 
 import linguiExtractMessages from "@lingui/babel-plugin-extract-messages"
 
 import { BabelOptions, ExtractorType } from "./types"
 import { projectType } from "../detect"
 
-const babelRe = /\.jsx?$/i
+const babelRe = new RegExp(
+	"\\.(" + DEFAULT_EXTENSIONS.map(ext => ext.slice(1)).join("|") + ")$",
+	"i"
+)
 
 const extractor: ExtractorType = {
   match(filename) {


### PR DESCRIPTION
…ports the

following file extensions by default: .js, .jsx, .es6, .es and .mjs.
In the current version, Lingui only passes files to Babel with the .js and .jsx extension, limiting the set of file extensions Babel would be able to process otherwise. Allowing Babel to process .mjs files is really handy, when someone would like to use it with native ES modules in recent version of Node.

This PR attempts to solve this issue: #739 