### PR TITLE
Update migration-3.rst - `setupI18n` is not exported by @lingui/react anymore

### DIFF
--- a/docs/releases/migration-3.rst
+++ b/docs/releases/migration-3.rst
@@ -40,8 +40,8 @@ is simplified and accepts ``i18n`` manager, which must be created manually:
 
 .. code-block:: diff
 
-   - import { I18nProvider } from '@lingui/react'
-   + import { setupI18n, I18nProvider } from '@lingui/react'
+     import { I18nProvider } from '@lingui/react'
+   + import { setupI18n } from '@lingui/core'
      import catalogEn from './locale/en/messages.js'
 
    + const i18n = setupI18n()


### PR DESCRIPTION
Starting from v3.0.0-4, package `@lingui/react` apparently does not export the function `setupI18n` anymore