### PR TITLE
fix: trailing whitespace

### DIFF
--- a/packages/macro/src/macroJsx.ts
+++ b/packages/macro/src/macroJsx.ts
@@ -37,6 +37,8 @@ function normalizeWhitespace(text) {
       // keep escaped newlines
       .replace(/\\n/g, "\n")
       .replace(/\\s/g, " ")
+      // we remove trailing whitespace inside Plural
+      .replace(/(\s+})/gm, "}")
       .trim()
   )
 }

--- a/packages/macro/test/jsx-plural.ts
+++ b/packages/macro/test/jsx-plural.ts
@@ -21,6 +21,33 @@ export default [
   },
   {
     input: `
+        import { Trans, Plural } from '@lingui/macro';
+        <Plural
+          value={count}
+          one={
+            <Trans>
+              <strong>#</strong> slot added
+            </Trans>
+          }
+          other={
+            <Trans>
+              <strong>#</strong> slots added
+            </Trans>
+          }
+        />;
+      `,
+    expected: `
+        import { Trans } from "@lingui/react";
+        <Trans id="{count, plural, one {<0>#</0> slot added} other {<1>#</1> slots added}}" values={{
+          count: count
+        }} components={{
+          0: <strong />,
+          1: <strong />
+        }} />;
+      `,
+  },
+  {
+    input: `
         import { Plural } from '@lingui/macro';
         <Plural
           id="msg.plural"


### PR DESCRIPTION
Fixes https://github.com/lingui/js-lingui/issues/747

This line `.replace(keepSpaceRe, " ")` is creating the whitespace, probably that regex could be reimplemented to don't do that change on this cases, but with the new regex this issue is fixed