### PR TITLE
fix: fix children with same key, uniqueId

### DIFF
--- a/packages/react/src/format.test.tsx
+++ b/packages/react/src/format.test.tsx
@@ -1,5 +1,4 @@
 import * as React from "react"
-import ReactDOMServer from 'react-dom/server';
 import { render } from "@testing-library/react"
 import { formatElements } from "./format"
 

--- a/packages/react/src/format.test.tsx
+++ b/packages/react/src/format.test.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+import ReactDOMServer from 'react-dom/server';
 import { render } from "@testing-library/react"
 import { formatElements } from "./format"
 
@@ -75,5 +76,12 @@ describe("formatElements", function () {
   it("should ignore paired element used as unpaired", function() {
     expect(html(formatElements("text<0/>", {0: <span />})))
         .toEqual("text<span></span>")
+  })
+
+  it("should create two children with different keys", function() {
+    const cleanPrefix = (str: string): number => Number.parseInt(str.replace("$lingui$_", ""), 10)
+    const childElements = formatElements("<div><0/><0/></div>", { 0: <span>hi</span> }) as Array<any>
+    const childKeys = childElements.map(el => el?.key).filter(Boolean);
+    expect(cleanPrefix(childKeys[0])).toBeLessThan(cleanPrefix(childKeys[1]))
   })
 })

--- a/packages/react/src/format.ts
+++ b/packages/react/src/format.ts
@@ -68,7 +68,7 @@ function formatElements(
     tree.push(
       React.cloneElement(
         element,
-        { key: uniqueId("$lingui$") },
+        { key: uniqueId() },
 
         // format children for pair tags
         // unpaired tags might have children if it's a component passed as a variable
@@ -106,7 +106,7 @@ function getElements(parts) {
   )
 }
 
-function uniqueId(prefix = "$lingui$") {
+function uniqueId(prefix: "$lingui$" = "$lingui$") {
   if (!idCounter[prefix]) {
     idCounter[prefix] = 0
   }

--- a/packages/react/src/format.ts
+++ b/packages/react/src/format.ts
@@ -3,7 +3,6 @@ import React from "react"
 // match <0>paired</0> and <1/> unpaired tags
 const tagRe = /<(\d+)>(.*?)<\/\1>|<(\d+)\/>/
 const nlRe = /(?:\r\n|\r|\n)/g
-const idCounter = {}
 
 // For HTML, certain tags should omit their close tag. We keep a whitelist for
 // those special-case tags.
@@ -37,6 +36,7 @@ function formatElements(
   value: string,
   elements: { [key: string]: React.ReactElement<any> } = {}
 ): string | Array<any> {
+  const uniqueId = makeCounter(0, '$lingui$')
   const parts = value.replace(nlRe, "").split(tagRe)
 
   // no inline elements, return
@@ -106,14 +106,6 @@ function getElements(parts) {
   )
 }
 
-function uniqueId(prefix: "$lingui$" = "$lingui$") {
-  if (!idCounter[prefix]) {
-    idCounter[prefix] = 0
-  }
-
-  const id =++idCounter[prefix]
-
-  return `${prefix}_${id}`
-}
+const makeCounter = (count = 0, prefix = "") => () => `${prefix}_${count++}`
 
 export { formatElements }

--- a/packages/react/src/format.ts
+++ b/packages/react/src/format.ts
@@ -3,6 +3,7 @@ import React from "react"
 // match <0>paired</0> and <1/> unpaired tags
 const tagRe = /<(\d+)>(.*?)<\/\1>|<(\d+)\/>/
 const nlRe = /(?:\r\n|\r|\n)/g
+const idCounter = {}
 
 // For HTML, certain tags should omit their close tag. We keep a whitelist for
 // those special-case tags.
@@ -67,7 +68,7 @@ function formatElements(
     tree.push(
       React.cloneElement(
         element,
-        { key: index },
+        { key: uniqueId("$lingui$") },
 
         // format children for pair tags
         // unpaired tags might have children if it's a component passed as a variable
@@ -103,6 +104,16 @@ function getElements(parts) {
   return [[parseInt(paired || unpaired), children || "", after]].concat(
     getElements(parts.slice(4, parts.length))
   )
+}
+
+function uniqueId(prefix = "$lingui$") {
+  if (!idCounter[prefix]) {
+    idCounter[prefix] = 0
+  }
+
+  const id =++idCounter[prefix]
+
+  return `${prefix}_${id}`
 }
 
 export { formatElements }


### PR DESCRIPTION
Fixes #757 

It's using a simpe lodash uniqueId function, just a const to keep the past id's 👍🏻 
I've introduced a little test to avoid a regression to this