### PR TITLE
fix: i18n.load typescript inference

### DIFF
--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -1,4 +1,4 @@
-import { Locales } from "./i18n"
+import { CompiledMessage, Locales } from "./i18n"
 import { date, number } from "./formats"
 import { isString, isFunction } from "./essentials"
 
@@ -69,7 +69,7 @@ function context({ locale, locales, values, formats, localeData }) {
 }
 
 export function interpolate(
-  translation: string | Array<string | [string, string?, Object?]>,
+  translation: CompiledMessage,
   locale: string,
   locales: Locales,
   localeData: Object

--- a/packages/core/src/dev/compile.ts
+++ b/packages/core/src/dev/compile.ts
@@ -1,5 +1,6 @@
 import { parse } from "messageformat-parser"
 import { isString } from "../essentials"
+import { CompiledMessage } from "../i18n"
 
 // [Tokens] -> (CTX -> String)
 function processTokens(tokens) {
@@ -48,7 +49,7 @@ function processTokens(tokens) {
 // Message -> (Params -> String)
 export default function compile(
   message: string
-): Array<string | [string, string?, Object?]> | string {
+): CompiledMessage {
   try {
     return processTokens(parse(message))
   } catch (e) {

--- a/packages/core/src/i18n.ts
+++ b/packages/core/src/i18n.ts
@@ -20,7 +20,7 @@ export type AllLocaleData = Record<Locale, LocaleData>
 
 export type CompiledMessage =
   | string
-  | Array<string | [string, string?, (string | Object)?]>
+  | Array<string | Array<string | (string | undefined) | Record<string, unknown>>>;
 
 export type Messages = Record<string, CompiledMessage>
 


### PR DESCRIPTION
Fixes #764 

**Screenshots**

<img width="1387" alt="Screenshot 2020-10-17 at 18 04 24" src="https://user-images.githubusercontent.com/22656541/96347625-3469e180-10a3-11eb-9b4c-d3ba9e25f3ac.png">

Not need to type anything, and autocompletes messages list :)