### PR TITLE
Make clear that v3 migration pre-release

### DIFF
--- a/docs/releases/migration-3.rst
+++ b/docs/releases/migration-3.rst
@@ -2,6 +2,9 @@
 Migration guide from 2.x to 3.x
 ********************************
 
+> ⚠️ LinguiJS v3 is in pre-release.
+> Migration steps mentiond in this document do not apply to your setup unless you have specifically chosen to use the pre release version.
+
 Backward incompatible changes
 =============================
 


### PR DESCRIPTION
I have wrongly tried to apply changes from this document to my code, as I assumed that the latest version is v3.
Ideally there should be a operate site for the v2 and v3 documentation.