### PR TITLE
fix: required options to date, number macro

### DIFF
--- a/packages/core/src/i18n.ts
+++ b/packages/core/src/i18n.ts
@@ -188,11 +188,11 @@ export class I18n extends EventEmitter<Events> {
     )(values, formats)
   }
 
-  date(value: string | Date, format: Intl.DateTimeFormatOptions): string {
+  date(value: string | Date, format?: Intl.DateTimeFormatOptions): string {
     return date(this.locales || this.locale, format)(value)
   }
 
-  number(value: number, format: Intl.NumberFormatOptions): string {
+  number(value: number, format?: Intl.NumberFormatOptions): string {
     return number(this.locales || this.locale, format)(value)
   }
 }


### PR DESCRIPTION
We add optional params to date and number cuz they aren't required in the native functions.