### PR TITLE
Allow null override for default component

### DIFF
--- a/packages/react/src/Trans.test.tsx
+++ b/packages/react/src/Trans.test.tsx
@@ -44,10 +44,10 @@ describe("Trans component", function () {
     const originalConsole = console.error
     console.error = jest.fn()
 
-    renderWithI18n(<Trans render="span" id="Just a text" />)
+    renderWithI18n(<Trans render="span" id="Some text" />)
     expect(console.error).toHaveBeenCalled()
 
-    renderWithI18n(<Trans render="span" id="Just a text" />)
+    renderWithI18n(<Trans render="span" id="Some text" />)
     expect(console.error).toHaveBeenCalledTimes(2)
     console.error = originalConsole
   })
@@ -56,7 +56,7 @@ describe("Trans component", function () {
     const originalConsole = console.error
     console.error = jest.fn()
 
-    renderWithI18n(<Trans render="div" component="span" id="Just a text" />)
+    renderWithI18n(<Trans render="div" component="span" id="Some text" />)
     expect(console.error).toHaveBeenCalled()
     console.error = originalConsole
   })
@@ -137,9 +137,9 @@ describe("Trans component", function () {
   })
 
   describe("rendering", function () {
-    it("should render just a text without wrapping element", function () {
-      const txt = html(<Trans id="Just a text" />)
-      expect(txt).toEqual("Just a text")
+    it("should render a text node with no wrapper element", function () {
+      const txt = html(<Trans id="Some text" />)
+      expect(txt).toEqual("Some text")
     })
 
     it("should render custom element", function () {
@@ -173,10 +173,10 @@ describe("Trans component", function () {
       }
       const span = render(
         <I18nProvider i18n={i18n} defaultComponent={ComponentFC}>
-          <Trans id="Just a text" />
+          <Trans id="Some text" />
         </I18nProvider>
       ).container.innerHTML
-      expect(span).toEqual(`<div>Just a text</div>`)
+      expect(span).toEqual(`<div>Some text</div>`)
     })
   })
 

--- a/packages/react/src/Trans.test.tsx
+++ b/packages/react/src/Trans.test.tsx
@@ -178,6 +178,30 @@ describe("Trans component", function () {
       ).container.innerHTML
       expect(span).toEqual(`<div>Some text</div>`)
     })
+
+    it("should ignore defaultComponent when render is null", function () {
+      const ComponentFC: React.FunctionComponent = (props: { children?: React.ReactNode }) => {
+        return (<div>{props.children}</div>)
+      }
+      const translation = render(
+        <I18nProvider i18n={i18n} defaultComponent={ComponentFC}>
+          <Trans id="Some text" render={null} />
+        </I18nProvider>
+      ).container.innerHTML
+      expect(translation).toEqual("Some text")
+    })
+
+    it("should ignore defaultComponent when component is null", function () {
+      const ComponentFC: React.FunctionComponent = (props: { children?: React.ReactNode }) => {
+        return (<div>{props.children}</div>)
+      }
+      const translation = render(
+        <I18nProvider i18n={i18n} defaultComponent={ComponentFC}>
+          <Trans id="Some text" component={null} />
+        </I18nProvider>
+      ).container.innerHTML
+      expect(translation).toEqual("Some text")
+    })
   })
 
   describe("component prop rendering", function() {

--- a/packages/react/src/Trans.tsx
+++ b/packages/react/src/Trans.tsx
@@ -65,6 +65,10 @@ export function Trans(props: TransProps) {
     ? formatElements(_translation, components)
     : null
 
+  if (render === null || component === null) {
+      return translation
+  }
+
   const FallbackComponent = defaultComponent || React.Fragment
 
   // Validation of `render` and `component` props

--- a/packages/react/src/Trans.tsx
+++ b/packages/react/src/Trans.tsx
@@ -66,7 +66,7 @@ export function Trans(props: TransProps) {
     : null
 
   if (render === null || component === null) {
-      return translation
+    return translation
   }
 
   const FallbackComponent = defaultComponent || React.Fragment


### PR DESCRIPTION
the docs state that `render={null}` or `component={null}` should override the `defaultComponent` prop. (https://github.com/lingui/js-lingui/blame/v3.0.0/docs/ref/react.rst#L88)

suppose I had this

```ts
const Span = ({ children }) => {
    return <span>{children}</span>;
};

const App = () => {
    return (
        <I18nProvider i18n={i18n} defaultComponent={Span}>
            <Trans id='Hello' render={null} />
        </I18nProvider>
    );
};
```

current behaviour: `<App /> === <span>Hello</span>`
expected behaviour:`<App /> === 'Hello'`

