### PR TITLE
Automate releases with semantic release

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  branches: ["main", "next"],
+  plugins: [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/changelog",
+    "@semantic-release/github",
+  ],
+}


### PR DESCRIPTION
Hey @semoal,
I wanted to configure semantic release but it's gonna be probably more complex because this is monorepo package.

What works now:
- release script increments version and updates `package.json` of all packages. The script is configured that all packages share the same version even when only one is changed. Generally I find it easier for tracking dependencies when debugging.
- release script then publishes each package to NPM and creates git commit/tag

On top of that I would like to:
- generate changelog
- create release in GitHub

What I've checked semantic release monorepo packages, they all seem to update only package which has changed. I'm thinking about adding only `commit-analyzer`, `release-notes-generator`, `changelog`, `github` plugins and manage the rest with existing plugin. Since you have more experience with `semantic-release` I wanted to check it with you. What's your opinion about this?