### PR TITLE
fix: accept catalog paths without ending slash

### DIFF
--- a/packages/cli/src/api/__snapshots__/catalog.test.ts.snap
+++ b/packages/cli/src/api/__snapshots__/catalog.test.ts.snap
@@ -363,7 +363,7 @@ Object {
 }
 `;
 
-exports[`getCatalogs should warn about missing {name} pattern in catalog path 1`] = `Catalog with path "./locales/{locale}" doesn't have a {name} pattern in it, but one of source directories uses it: "{name}/". Either add {name} pattern to "./locales/{locale}" or remove it from all source directories.`;
+exports[`getCatalogs should warn about missing {name} pattern in catalog path 1`] = `Catalog with path "./locales/{locale}" doesn't have a {name} pattern in it, but one of source directories uses it: "{name}". Either add {name} pattern to "./locales/{locale}" or remove it from all source directories.`;
 
 exports[`getCatalogs should warn if catalogPath is a directory 1`] = `Remove trailing slash from "./locales/{locale}/". Catalog path isn't a directory, but translation file without extension. For example, catalog path "./locales/{locale}" results in translation file "./locales/en.po".`;
 

--- a/packages/cli/src/api/catalog.test.ts
+++ b/packages/cli/src/api/catalog.test.ts
@@ -786,6 +786,19 @@ describe("normalizeRelativePath", function () {
       absolute.split("\\").join("/")
     )
   })
+
+  it("directories without ending slash are correctly treaten as dirs", function() {
+    mockFs({
+      componentA: {
+        "index.js": mockFs.file(),
+      },
+      "componentB": mockFs.file(),
+    })
+    // checked correctly that is a dir, cuz added that ending slash
+    expect(normalizeRelativePath("./componentA")).toEqual("componentA/")
+    // ComponentB is a file shouldn't add ending slash
+    expect(normalizeRelativePath("./componentB")).toEqual("componentB")
+  })
 })
 
 describe("cleanObsolete", function () {

--- a/packages/cli/src/api/catalog.ts
+++ b/packages/cli/src/api/catalog.ts
@@ -288,7 +288,7 @@ export class Catalog {
     )
     const patterns =
       includeGlobs.length > 1 ? `{${includeGlobs.join(",")}}` : includeGlobs[0]
-    return glob.sync(patterns, { ignore: this.exclude })
+    return glob.sync(patterns, { ignore: this.exclude, mark: true })
   }
 
   get localeDir() {
@@ -372,6 +372,7 @@ export function getCatalogs(config: LinguiConfig) {
       patterns.length > 1 ? `{${patterns.join(",")}` : patterns[0],
       {
         ignore: exclude,
+        mark: true
       }
     )
 
@@ -497,7 +498,7 @@ export function normalizeRelativePath(sourcePath: string): string {
     return normalize(sourcePath, false)
   }
 
-  const isDir = normalize(sourcePath, false).endsWith(PATHSEP)
+  const isDir = fs.existsSync(sourcePath) && fs.lstatSync(sourcePath).isDirectory()
   return (
     normalize(path.relative(process.cwd(), path.resolve(sourcePath))) +
     (isDir ? PATHSEP : "")


### PR DESCRIPTION
Closes #809 
Added mark: true to node-glob because internally node-glob needs an slash at the end, will be the same of running normalizeRelativePaths to exclude array

I want to (if you are agree of course) migrate node-glob to fdir that is significantly more faster, will work on it with some benchmarks this week 👍🏻 