### PR TITLE
Fix test environment

### DIFF
--- a/packages/cli/src/api/catalog.test.ts
+++ b/packages/cli/src/api/catalog.test.ts
@@ -774,6 +774,10 @@ describe("getCatalogForMerge", function () {
 })
 
 describe("normalizeRelativePath", function () {
+  afterEach(() => {
+    mockFs.restore()
+  })
+
   it("should preserve absolute paths - posix", function () {
     const absolute = "/my/directory"
     expect(normalizeRelativePath(absolute)).toEqual(absolute)


### PR DESCRIPTION
The missing `mockFs.restore()` in #812 broke snapshot tests rather badly. Existing tests did not fail, but no new snapshots were written, and every test run created new ones (in some temp location).