### PR TITLE
Fix extracting with --overwrite

### DIFF
--- a/packages/cli/src/api/catalog.ts
+++ b/packages/cli/src/api/catalog.ts
@@ -191,8 +191,10 @@ export class Catalog {
           (prevCatalog[key].translation === prevCatalog[key].message ||
             options.overwrite)
 
+        // when updating from defaults, use the message in case we have one (custom keys)
+        // otherwise (with keys being the source language string) just use the key itself
         const translation = updateFromDefaults
-          ? nextCatalog[key].message
+          ? nextCatalog[key].message || key
           : prevCatalog[key].translation
 
         return {


### PR DESCRIPTION
When extracting messages coming e.g. from `<Trans>something</Trans>` we only have the key and `origin`, but no `message` in the nextCatalog. Only when using `<Trans id="foo">something</Trans>` we get an actual `message` as well.

I'm not sure if this is the best way of fixing it, but it seems to do the job.
Needs updated unit tests of course, but not sure what's the best way to test  this...

fixes #616