### PR TITLE
fix: improved performance of formatters

### DIFF
--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -16,8 +16,7 @@ const defaultFormats = (
     return (ctx) => {
       const msg = isFunction(message) ? message(ctx) : message
       const norm = Array.isArray(msg) ? msg : [msg]
-      const formatter = new Intl.NumberFormat(locales)
-      const valueStr = formatter.format(value)
+      const valueStr = number(locales)(value)
       return norm.map((m) => (isString(m) ? m.replace("#", valueStr) : m))
     }
   }

--- a/packages/core/src/formats.test.ts
+++ b/packages/core/src/formats.test.ts
@@ -1,0 +1,49 @@
+import { date, number } from "./formats"
+
+describe("@lingui/core/formats", () => {
+  it("number formatter is memoized", async () => {
+    const firstRunt0 = performance.now()
+    number("es", {})(10000)
+    const firstRunt1 = performance.now()
+    const firstRunResult = firstRunt1 - firstRunt0
+
+    const seconddRunt0 = performance.now()
+    number("es", {})(10000)
+    const seconddRunt1 = performance.now()
+    const secondRunResult = seconddRunt1 - seconddRunt0
+
+    expect(secondRunResult).toBeLessThan(firstRunResult)
+  })
+  it("date formatter is memoized", async () => {
+    const firstRunt0 = performance.now()
+    date("es", {})(new Date())
+    const firstRunt1 = performance.now()
+    const firstRunResult = firstRunt1 - firstRunt0
+
+    const seconddRunt0 = performance.now()
+    date("es", {})(new Date())
+    const seconddRunt1 = performance.now()
+    const secondRunResult = seconddRunt1 - seconddRunt0
+
+    expect(secondRunResult).toBeLessThan(firstRunResult)
+  })
+
+  it("memoized function is faster than standard arg in a iteration", () => {
+    const loopt0 = performance.now()
+    for (let i = 0; i < 1000; i++) {
+      date("es", {})(new Date())
+    }
+    const loopt1 = performance.now()
+    const loopResult = loopt1 - loopt0
+
+    const loop0 = performance.now()
+    for (let i = 0; i < 1000; i++) {
+      date("es", {}, false)(new Date())
+    }
+    const loop1 = performance.now()
+    const withoutMemoizeResult = loop1 - loop0
+
+    console.table({ loopResult, withoutMemoizeResult })
+    expect(loopResult).toBeLessThan(withoutMemoizeResult)
+  })
+})

--- a/packages/core/src/formats.test.ts
+++ b/packages/core/src/formats.test.ts
@@ -28,13 +28,13 @@ describe("@lingui/core/formats", () => {
     expect(secondRunResult).toBeLessThan(firstRunResult)
   })
 
-  it("memoized function is faster than standard arg in a iteration", () => {
+  it("date memoized function is faster than the not memoized function", () => {
     const loopt0 = performance.now()
     for (let i = 0; i < 1000; i++) {
       date("es", {})(new Date())
     }
     const loopt1 = performance.now()
-    const loopResult = loopt1 - loopt0
+    const memoizedDateResult = loopt1 - loopt0
 
     const loop0 = performance.now()
     for (let i = 0; i < 1000; i++) {
@@ -43,7 +43,24 @@ describe("@lingui/core/formats", () => {
     const loop1 = performance.now()
     const withoutMemoizeResult = loop1 - loop0
 
-    console.table({ loopResult, withoutMemoizeResult })
-    expect(loopResult).toBeLessThan(withoutMemoizeResult)
+    expect(memoizedDateResult).toBeLessThan(withoutMemoizeResult)
+  })
+
+  it("number memoized function is faster than the not memoized function", () => {
+    const loopt0 = performance.now()
+    for (let i = 0; i < 1000; i++) {
+      number("es", {})(999666)
+    }
+    const loopt1 = performance.now()
+    const memoizedNumberResult = loopt1 - loopt0
+
+    const loop0 = performance.now()
+    for (let i = 0; i < 1000; i++) {
+      number("es", {}, false)(999666)
+    }
+    const loop1 = performance.now()
+    const withoutMemoizeResult = loop1 - loop0
+
+    expect(memoizedNumberResult).toBeLessThan(withoutMemoizeResult)
   })
 })

--- a/packages/core/src/formats.ts
+++ b/packages/core/src/formats.ts
@@ -1,21 +1,60 @@
 import { isString } from "./essentials"
 import { Locales } from "./i18n"
 
+/** Memoized cache */
+const numberFormats = new Map<string, Intl.NumberFormat>()
+const dateFormats = new Map<string, Intl.DateTimeFormat>()
+
 export function date(
   locales: Locales,
-  format: Intl.DateTimeFormatOptions = {}
+  format: Intl.DateTimeFormatOptions = {},
+  memoize: boolean = true,
 ): (value: string | Date) => string {
-  const formatter = new Intl.DateTimeFormat(locales, format)
   return (value) => {
     if (isString(value)) value = new Date(value)
+    if (memoize) {
+      const key = cacheKey<Intl.DateTimeFormatOptions>(locales, format)
+      if (dateFormats.has(key)) {
+        return dateFormats.get(key).format(value)
+      }
+
+      const formatter = new Intl.DateTimeFormat(locales, format)
+      dateFormats.set(key, formatter)
+      return formatter.format(value)
+    }
+
+    const formatter = new Intl.DateTimeFormat(locales, format)
     return formatter.format(value)
   }
 }
 
 export function number(
   locales: Locales,
-  format: Intl.NumberFormatOptions = {}
+  format: Intl.NumberFormatOptions = {},
+  memoize: boolean = true,
 ): (value: number) => string {
-  const formatter = new Intl.NumberFormat(locales, format)
-  return (value) => formatter.format(value)
+  return (value) => {
+    if (memoize) {
+      const key = cacheKey<Intl.NumberFormatOptions>(locales, format)
+      if (numberFormats.has(key)) {
+        return numberFormats.get(key).format(value)
+      }
+
+      const formatter = new Intl.NumberFormat(locales, format)
+      numberFormats.set(key, formatter)
+      return formatter.format(value)
+    }
+
+    const formatter = new Intl.NumberFormat(locales, format)
+    return formatter.format(value)
+  }
+}
+
+/** Memoize helpers */
+function cacheKey<T>(
+  locales?: string | string[],
+  options: T = {} as T,
+) {
+  const localeKey = Array.isArray(locales) ? locales.sort().join('-') : locales
+  return `${localeKey}-${JSON.stringify(options)}`
 }


### PR DESCRIPTION
Will close #472

I've added to format functions a third param to disable/enable the memoize function for testing purposes in that way we can be 100% sure that the cache is working properly.

Some results (1000x renders of `date`)
```
    ┌──────────────────────┬────────────────────┐
    │       (index)        │       Values       │
    ├──────────────────────┼────────────────────┤
    │  memoizedDateResult  │  6.58090500000003  │
    │ withoutMemoizeResult │ 263.14999799999987 │
    └──────────────────────┴────────────────────┘
```

Some results (1000x renders of `number`)
```
    ┌──────────────────────┬────────────────────┐
    │       (index)        │       Values       │
    ├──────────────────────┼────────────────────┤
    │ memoizedNumberResult │ 2.9453200000002653 │
    │ withoutMemoizeResult │ 45.79147499999999  │
    └──────────────────────┴────────────────────┘
```

