### PR TITLE
fix: t macro as function typed

### DIFF
--- a/packages/macro/index.d.ts
+++ b/packages/macro/index.d.ts
@@ -3,7 +3,7 @@ import type { MessageDescriptor } from "@lingui/core"
 import type { TransRenderProps } from "@lingui/react"
 
 export function t(
-  literals: TemplateStringsArray,
+  literals: TemplateStringsArray | MessageDescriptor,
   ...placeholders: any[]
 ): string
 


### PR DESCRIPTION
Totally forgot the type 🤕 
Will fix @Bertg comment of #807
![Screenshot 2020-11-05 at 12 26 06](https://user-images.githubusercontent.com/22656541/98235482-21d81f00-1f62-11eb-9666-247a04e7a859.png)
