### PR TITLE
fix: dx on plurals not called

### DIFF
--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -21,14 +21,18 @@ const defaultFormats = (
     }
   }
 
+  if (!plurals) {
+    console.error(`Plurals for locale ${locale} aren't loaded. Use i18n.loadLocaleData method to load plurals for specific locale. Using other plural rule as a fallback.`)
+  }
+
   return {
     plural: (value, { offset = 0, ...rules }) => {
-      const message = rules[value] || rules[plurals(value - offset)]
+      const message = rules[value] || rules[plurals?.(value - offset)] || rules.other
       return replaceOctothorpe(value - offset, message)
     },
 
     selectordinal: (value, { offset = 0, ...rules }) => {
-      const message = rules[value] || rules[plurals(value - offset, true)]
+      const message = rules[value] || rules[plurals?.(value - offset, true)] || rules.other
       return replaceOctothorpe(value - offset, message)
     },
 


### PR DESCRIPTION
Will close #798

The app doesn't crash if loadLocaleData is not called, but logs a console.error warning about.