### PR TITLE
Enable pseudolocalization from pseudolocale folder

### DIFF
--- a/docs/ref/conf.rst
+++ b/docs/ref/conf.rst
@@ -372,7 +372,8 @@ pseudoLocale
 Default: ``""``
 
 Locale used for pseudolocalization. For example when you set ``pseudoLocale: "en"``
-then all messages in ``en`` catalog will be pseudo localized.
+then all messages in ``en`` catalog will be pseudo localized. The locale has to be included
+in `locales <https://lingui.js.org/ref/conf.html#locales>`_.
 
 rootDir
 -------

--- a/docs/ref/conf.rst
+++ b/docs/ref/conf.rst
@@ -373,7 +373,7 @@ Default: ``""``
 
 Locale used for pseudolocalization. For example when you set ``pseudoLocale: "en"``
 then all messages in ``en`` catalog will be pseudo localized. The locale has to be included
-in `locales <https://lingui.js.org/ref/conf.html#locales>`_.
+in `locales <https://lingui.js.org/ref/conf.html#locales>`_ config.
 
 rootDir
 -------

--- a/docs/ref/conf.rst
+++ b/docs/ref/conf.rst
@@ -373,7 +373,7 @@ Default: ``""``
 
 Locale used for pseudolocalization. For example when you set ``pseudoLocale: "en"``
 then all messages in ``en`` catalog will be pseudo localized. The locale has to be included
-in `locales <https://lingui.js.org/ref/conf.html#locales>`_ config.
+in :conf:`locales` config.
 
 rootDir
 -------

--- a/docs/tutorials/cli.rst
+++ b/docs/tutorials/cli.rst
@@ -207,8 +207,7 @@ examples: :conf:`en-PL`, :conf:`pseudo-LOCALE`, :conf:`pseudolocalization` or :c
 
 PseudoLocale string have to be in :conf:`locales` config as well. Otherwise no folder is going to be created.
 Pseudolocalized text is created on  ``yarn compile`` command.
-The pseudolocalization is automatically created from messages in order specified in :ref:`Preparing catalogs for production`.
-It can also be changed by setting translation in :conf:`message.json` into non-pseudolocalized text.
+The pseudolocalization is automatically created on ``yarn extract`` from messages in order specified in :ref:`Preparing catalogs for production`.
 
 How to switch your browser into specified pseudoLocale
 ------------------------------------------------------

--- a/docs/tutorials/cli.rst
+++ b/docs/tutorials/cli.rst
@@ -198,7 +198,7 @@ To setup pseudolocalization add :conf:`pseudoLocale` in ``package.json``::
 :conf:`pseudoLocale` option can be any string 
 examples: :conf:`en-PL`, :conf:`pseudo-LOCALE`, :conf:`pseudolocalization` or :conf:`en-UK`
 
-PseudoLocale string have to be in `locale` config as well. Otherwise no folder is created.
+PseudoLocale string have to be in `locale` config as well. Otherwise no folder is going to be created.
 Pseudolocalized text is created on  ``yarn compile`` command.
 The pseudolocalization is automatically created from TODOTODOTODO.
 It can also be changed by setting translation in :conf:`message.json` into non-pseudolocalized text.

--- a/docs/tutorials/cli.rst
+++ b/docs/tutorials/cli.rst
@@ -103,6 +103,13 @@ plural rules to a production ready catalog::
 The ``locale`` directory now contains the source catalogs (``messages.json``) and
 the compiled ones (``messages.js``).
 
+Messages added to compiled file are collected in specific order:
+
+1. Translated message from specified locale
+2. Translated message from fallback locale for specified locale
+3. Translated message from default fallback locale
+4. Message key
+
 It is also possible to merge the translated catalogs into a single file per locale
 by specifying :conf:`catalogsMergePath`. For example if :conf:`catalogsMergePath` is assigned
 ``locales/{locale}`` then catalogs will be compiled to ``/locales/cs.js`` and 
@@ -200,7 +207,7 @@ examples: :conf:`en-PL`, :conf:`pseudo-LOCALE`, :conf:`pseudolocalization` or :c
 
 PseudoLocale string have to be in `locale` config as well. Otherwise no folder is going to be created.
 Pseudolocalized text is created on  ``yarn compile`` command.
-The pseudolocalization is automatically created from TODOTODOTODO.
+The pseudolocalization is automatically created from messages in order specified in "LINK TO Preparing catalogs for production".
 It can also be changed by setting translation in :conf:`message.json` into non-pseudolocalized text.
 
 How to switch your browser into specified pseudoLocale

--- a/docs/tutorials/cli.rst
+++ b/docs/tutorials/cli.rst
@@ -205,7 +205,7 @@ To setup pseudolocalization add :conf:`pseudoLocale` in ``package.json``::
 :conf:`pseudoLocale` option can be any string 
 examples: :conf:`en-PL`, :conf:`pseudo-LOCALE`, :conf:`pseudolocalization` or :conf:`en-UK`
 
-PseudoLocale string have to be in `locale` config as well. Otherwise no folder is going to be created.
+PseudoLocale string have to be in :conf:`locales` config as well. Otherwise no folder is going to be created.
 Pseudolocalized text is created on  ``yarn compile`` command.
 The pseudolocalization is automatically created from messages in order specified in :ref:`Preparing catalogs for production`.
 It can also be changed by setting translation in :conf:`message.json` into non-pseudolocalized text.

--- a/docs/tutorials/cli.rst
+++ b/docs/tutorials/cli.rst
@@ -198,9 +198,9 @@ To setup pseudolocalization add :conf:`pseudoLocale` in ``package.json``::
 :conf:`pseudoLocale` option can be any string 
 examples: :conf:`en-PL`, :conf:`pseudo-LOCALE`, :conf:`pseudolocalization` or :conf:`en-UK`
 
-PseudoLocale folder is automatically created based on configuration when running 
-``yarn extract`` command. Pseudolocalized text is created on  ``yarn compile`` command.
-The pseudolocalization is automatically created from default messages. 
+PseudoLocale string have to be in `locale` config as well. Otherwise no folder is created.
+Pseudolocalized text is created on  ``yarn compile`` command.
+The pseudolocalization is automatically created from TODOTODOTODO.
 It can also be changed by setting translation in :conf:`message.json` into non-pseudolocalized text.
 
 How to switch your browser into specified pseudoLocale

--- a/docs/tutorials/cli.rst
+++ b/docs/tutorials/cli.rst
@@ -207,7 +207,7 @@ examples: :conf:`en-PL`, :conf:`pseudo-LOCALE`, :conf:`pseudolocalization` or :c
 
 PseudoLocale string have to be in `locale` config as well. Otherwise no folder is going to be created.
 Pseudolocalized text is created on  ``yarn compile`` command.
-The pseudolocalization is automatically created from messages in order specified in "LINK TO Preparing catalogs for production".
+The pseudolocalization is automatically created from messages in order specified in :ref:`Preparing catalogs for production`.
 It can also be changed by setting translation in :conf:`message.json` into non-pseudolocalized text.
 
 How to switch your browser into specified pseudoLocale

--- a/packages/cli/src/api/compile.test.ts
+++ b/packages/cli/src/api/compile.test.ts
@@ -127,7 +127,7 @@ describe("createCompiledCatalog", function () {
   describe("options.pseudoLocale", function () {
     const getCompiledCatalog = (pseudoLocale) =>
       createCompiledCatalog(
-        "cs",
+        "ps",
         {
           Hello: "Ahoj",
         },
@@ -137,7 +137,7 @@ describe("createCompiledCatalog", function () {
       )
 
     it("should return catalog with pseudolocalized messages", function () {
-      expect(getCompiledCatalog("cs")).toMatchSnapshot()
+      expect(getCompiledCatalog("ps")).toMatchSnapshot()
     })
 
     it("should return compiled catalog when pseudoLocale doesn't match current locale", function () {

--- a/packages/cli/src/api/extract.test.ts
+++ b/packages/cli/src/api/extract.test.ts
@@ -1,7 +1,7 @@
 import path from "path"
 /**
  * Fellow contributor!
- * *Never* import `extract` module outsite `it` or `beforeAll`. It would
+ * *Never* import `extract` module outside `it` or `beforeAll`. It would
  * break mocking of extractors in `extract` test suit.
  */
 import mockFs from "mock-fs"

--- a/packages/cli/src/lingui-compile.ts
+++ b/packages/cli/src/lingui-compile.ts
@@ -6,7 +6,7 @@ import * as plurals from "make-plural"
 
 import { getConfig } from "@lingui/conf"
 
-import { getCatalogs, getCatalogForMerge } from "./api/catalog"
+import { getCatalogs } from "./api/catalog"
 import { createCompiledCatalog } from "./api/compile"
 import { helpRun } from "./api/help"
 
@@ -35,9 +35,6 @@ function command(config, options) {
 
   console.error("Compiling message catalogs…")
 
-  if (config.pseudoLocale) {
-    config.locales.push(config.pseudoLocale)
-  }
   config.locales.forEach((locale) => {
     const [language] = locale.split(/[_-]/)
     if (locale !== config.pseudoLocale && !plurals[language]) {
@@ -52,7 +49,7 @@ function command(config, options) {
 
     catalogs.forEach((catalog) => {
       const messages = catalog.getTranslations(
-        locale === config.pseudoLocale ? config.sourceLocale : locale,
+        locale,
         {
           fallbackLocales: config.fallbackLocales,
           sourceLocale: config.sourceLocale,

--- a/packages/cli/src/lingui-extract.ts
+++ b/packages/cli/src/lingui-extract.ts
@@ -40,10 +40,6 @@ export default function command(
       ...options,
       orderBy: config.orderBy,
       projectType: detect(),
-      // const pseudoLocale = config.pseudoLocale
-      // if (pseudoLocale) {
-      //   catalog.addLocale(pseudoLocale)
-      // }
     })
 
     catalogStats[catalog.path] = catalog.readAll()


### PR DESCRIPTION
This PR utilises standard getTranslation eg. we first try to get translation from locale folder, then from fallback, and then keys, etc...

This will allow us to set text that is going to be pseudolocalized and it will close #744 

I do not think there is a reason to change to pseudolocalizing on extract, but it will solve the issue @nathanforce is having.