### PR TITLE
Ensure render of I18nProvider in async scenarios

### DIFF
--- a/packages/react/src/I18nProvider.tsx
+++ b/packages/react/src/I18nProvider.tsx
@@ -74,9 +74,15 @@ export const I18nProvider: FunctionComponent<I18nProviderProps> = ({
    * I18n object from `@lingui/core` is the single source of truth for all i18n related
    * data (active locale, catalogs). When new messages are loaded or locale is changed
    * we need to trigger re-rendering of LinguiContext.Consumers.
+   *
+   * We call `setContext(makeContext())` after adding the observer in case the `change`
+   * event would already have fired between the inital renderKey calculation and the
+   * `useEffect` hook being called. This can happen if locales are loaded/activated
+   * async.
    */
   React.useEffect(() => {
     const unsubscribe = i18n.on("change", () => setContext(makeContext()))
+    setContext(makeContext())
     return () => unsubscribe()
   }, [])
 

--- a/packages/react/src/I18nProvider.tsx
+++ b/packages/react/src/I18nProvider.tsx
@@ -92,6 +92,9 @@ export const I18nProvider: FunctionComponent<I18nProviderProps> = ({
     if (renderKey === 'default') {
       setRenderKey(getRenderKey())
     }
+    if (forceRenderOnLocaleChange && renderKey === 'default') {
+      console.log("I18nProvider did not render. A call to i18n.activate still needs to happen or forceRenderOnLocaleChange must be set to false.")
+    }
     return () => unsubscribe()
   }, [])
 

--- a/packages/react/src/I18nProvider.tsx
+++ b/packages/react/src/I18nProvider.tsx
@@ -65,8 +65,12 @@ export const I18nProvider: FunctionComponent<I18nProviderProps> = ({
     i18n,
     defaultComponent,
   })
+  const getRenderKey = () => {
+    return (forceRenderOnLocaleChange ? (i18n.locale || 'default') : 'default') as string
+  }
 
-  const [context, setContext] = React.useState<I18nContext>(makeContext())
+  const [context, setContext] = React.useState<I18nContext>(makeContext()),
+    [renderKey, setRenderKey] = React.useState<string>(getRenderKey())
 
   /**
    * Subscribe for locale/message changes
@@ -81,13 +85,17 @@ export const I18nProvider: FunctionComponent<I18nProviderProps> = ({
    * async.
    */
   React.useEffect(() => {
-    const unsubscribe = i18n.on("change", () => setContext(makeContext()))
-    setContext(makeContext())
+    const unsubscribe = i18n.on("change", () => {
+      setContext(makeContext())
+      setRenderKey(getRenderKey())
+    })
+    if (renderKey === 'default') {
+      setRenderKey(getRenderKey())
+    }
     return () => unsubscribe()
   }, [])
 
-  const renderKey = forceRenderOnLocaleChange && i18n.locale
-  if (forceRenderOnLocaleChange && !renderKey) return null
+  if (forceRenderOnLocaleChange && renderKey === 'default') return null
 
   return (
     <LinguiContext.Provider value={context} key={renderKey}>


### PR DESCRIPTION
This is related to #834

This PR solves 2 issues:

* Making sure the component gets re-rendered when needed
* Provide a warning to the developer

Some more thoughts about this PR and problem:

* It is perfectly possible for the warning to appear even if the component will render. 
* It would be better to always render. We can add a warning to the developer that only defaults will be rendered. This requires the developer to make sure a language is activated before they render the component. We could even choose to completely throw if i18n is not activated yet, unless the developer set a prop indicating they are OK with defaults.
* ```forceRenderOnLocaleChange``` should be separated from ```dontRenderIfNoLocaleIsActivated```
* ideally there should be a ```i18n.on("activated" ``` which also triggers when first observed (if already triggered before). That way the extra call to ```setRenderKey``` in the effect is never needed.