### PR TITLE
chore: added token to deploy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,8 @@ jobs:
           token: '${{ secrets.GH_TOKEN }}'
 
       - name: Release packages
+        env:
+          GH_TOKEN: ${{secrets.GH_TOKEN}}
         run: |
           yarn version:${{github.event.inputs.npmTag}}
           yarn release:${{github.event.inputs.npmTag}}


### PR DESCRIPTION
We'll try with secrets.GH_TOKEN that is the LinguiBot Account, if that doesn't work we'll change to GITHUB_TOKEN.. that should work properly.