### PR TITLE
docs: fix location of date/number formatters

### DIFF
--- a/docs/releases/migration-3.rst
+++ b/docs/releases/migration-3.rst
@@ -40,8 +40,8 @@ Minimal required versions are:
 
      <Trans id="Read <a>the docs</a>!" components={{a: <a href="/docs" />}} />
 
-- ``NumberFormat`` and ``DateFormat`` components were removed. Use ``date`` and
-  ``number`` formats from ``@lingui/core`` package instead.
+- ``NumberFormat`` and ``DateFormat`` components were removed. Import ``i18n`` from ``@lingui/core``
+package and use ``i18n.date()`` and ``ì18n.number()`` instead.
 
 Removed :component:`I18nProvider` declarative API
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This remark is misleading. Core does not export date or number