### PR TITLE
feat: extract multiple comments per translation ID

### DIFF
--- a/packages/babel-plugin-extract-messages/src/index.ts
+++ b/packages/babel-plugin-extract-messages/src/index.ts
@@ -56,7 +56,7 @@ export default function ({ types: t }) {
     t.isIdentifier(node.object, { name: "i18n" }) &&
     t.isIdentifier(node.property, { name: "_" })
 
-  function collectMessage(path, file, props) {
+  function collectMessage(path, file, {comment, ...props}) {
     const messages = file.get(MESSAGES)
 
     const rootDir = file.get(CONFIG).rootDir
@@ -64,7 +64,7 @@ export default function ({ types: t }) {
       .relative(rootDir, file.opts.filename)
       .replace(/\\/g, "/")
     const line = path.node.loc ? path.node.loc.start.line : null
-    props.origin = [[filename, line]]
+    props.origin = [[filename, line, comment]]
 
     addMessage(path, messages, props)
   }

--- a/packages/babel-plugin-extract-messages/src/index.ts
+++ b/packages/babel-plugin-extract-messages/src/index.ts
@@ -17,7 +17,7 @@ const VISITED = Symbol("I18nVisited")
 function addMessage(
   path,
   messages,
-  { id, message: newDefault, origin, ...props }
+  { id, message: newDefault, origin, comment, ...props }
 ) {
   if (messages.has(id)) {
     const message = messages.get(id)
@@ -33,9 +33,13 @@ function addMessage(
       }
 
       ;[].push.apply(message.origin, origin)
+      if (comment) {
+        ;[].push.apply(message.extractedComments, comment)
+      }
     }
   } else {
-    messages.set(id, { ...props, message: newDefault, origin })
+    const extractedComments = comment ? [comment] : []
+    messages.set(id, { ...props, message: newDefault, origin, extractedComments })
   }
 }
 
@@ -56,7 +60,7 @@ export default function ({ types: t }) {
     t.isIdentifier(node.object, { name: "i18n" }) &&
     t.isIdentifier(node.property, { name: "_" })
 
-  function collectMessage(path, file, {comment, ...props}) {
+  function collectMessage(path, file, props) {
     const messages = file.get(MESSAGES)
 
     const rootDir = file.get(CONFIG).rootDir
@@ -64,7 +68,7 @@ export default function ({ types: t }) {
       .relative(rootDir, file.opts.filename)
       .replace(/\\/g, "/")
     const line = path.node.loc ? path.node.loc.start.line : null
-    props.origin = [[filename, line, comment]]
+    props.origin = [[filename, line]]
 
     addMessage(path, messages, props)
   }

--- a/packages/babel-plugin-extract-messages/src/index.ts
+++ b/packages/babel-plugin-extract-messages/src/index.ts
@@ -34,7 +34,7 @@ function addMessage(
 
       ;[].push.apply(message.origin, origin)
       if (comment) {
-        ;[].push.apply(message.extractedComments, comment)
+        ;[].push.apply(message.extractedComments, [comment])
       }
     }
   } else {

--- a/packages/babel-plugin-extract-messages/test/__snapshots__/index.ts.snap
+++ b/packages/babel-plugin-extract-messages/test/__snapshots__/index.ts.snap
@@ -3,11 +3,11 @@
 exports[`@lingui/babel-plugin-extract-messages should extract Plural messages from JSX files when there's no Trans tag (integration) 1`] = `
 Object {
   {count, plural, one {# book} other {# books}}: Object {
+    extractedComments: Array [],
     origin: Array [
       Array [
         jsx-without-trans.js,
         3,
-        null,
       ],
     ],
   },
@@ -17,54 +17,55 @@ Object {
 exports[`@lingui/babel-plugin-extract-messages should extract all messages from JS files (macros) 1`] = `
 Object {
   Description: Object {
+    extractedComments: Array [
+      description,
+    ],
     origin: Array [
       Array [
         js-with-macros.js,
         7,
-        description,
       ],
     ],
   },
   ID: Object {
+    extractedComments: Array [],
     message: Message with id,
     origin: Array [
       Array [
         js-with-macros.js,
         12,
-        null,
       ],
     ],
   },
   ID Some: Object {
+    extractedComments: Array [],
     message: Message with id some,
     origin: Array [
       Array [
         js-with-macros.js,
         19,
-        null,
       ],
     ],
   },
   Message: Object {
+    extractedComments: Array [],
     origin: Array [
       Array [
         js-with-macros.js,
         3,
-        null,
       ],
       Array [
         js-with-macros.js,
         5,
-        null,
       ],
     ],
   },
   Values {param}: Object {
+    extractedComments: Array [],
     origin: Array [
       Array [
         js-with-macros.js,
         17,
-        null,
       ],
     ],
   },
@@ -74,39 +75,41 @@ Object {
 exports[`@lingui/babel-plugin-extract-messages should extract all messages from JS files 1`] = `
 Object {
   Description: Object {
+    extractedComments: Array [
+      description,
+    ],
     origin: Array [
       Array [
         js-without-macros.js,
         5,
-        description,
       ],
     ],
   },
   ID: Object {
+    extractedComments: Array [],
     message: Message with id,
     origin: Array [
       Array [
         js-without-macros.js,
         7,
-        null,
       ],
     ],
   },
   Message: Object {
+    extractedComments: Array [],
     origin: Array [
       Array [
         js-without-macros.js,
         3,
-        null,
       ],
     ],
   },
   Values {param}: Object {
+    extractedComments: Array [],
     origin: Array [
       Array [
         js-without-macros.js,
         9,
-        null,
       ],
     ],
   },
@@ -116,29 +119,29 @@ Object {
 exports[`@lingui/babel-plugin-extract-messages should extract all messages from JSX files (macros) 1`] = `
 Object {
   Hi, my name is {name}: Object {
+    extractedComments: Array [],
     origin: Array [
       Array [
         jsx-with-macros.js,
         3,
-        null,
       ],
     ],
   },
   Title: Object {
+    extractedComments: Array [],
     origin: Array [
       Array [
         jsx-with-macros.js,
         4,
-        null,
       ],
     ],
   },
   {count, plural, one {# book} other {# books}}: Object {
+    extractedComments: Array [],
     origin: Array [
       Array [
         jsx-with-macros.js,
         6,
-        null,
       ],
     ],
   },
@@ -148,35 +151,36 @@ Object {
 exports[`@lingui/babel-plugin-extract-messages should extract all messages from JSX files 1`] = `
 Object {
   Hi, my name is <0>{name}</0>: Object {
+    extractedComments: Array [],
     origin: Array [
       Array [
         jsx-without-macros.js,
         9,
-        null,
       ],
     ],
   },
   msg.default: Object {
+    extractedComments: Array [],
     message: Hello World,
     origin: Array [
       Array [
         jsx-without-macros.js,
         7,
-        null,
       ],
       Array [
         jsx-without-macros.js,
         8,
-        null,
       ],
     ],
   },
   msg.hello: Object {
+    extractedComments: Array [
+      Description,
+    ],
     origin: Array [
       Array [
         jsx-without-macros.js,
         6,
-        Description,
       ],
     ],
   },

--- a/packages/babel-plugin-extract-messages/test/__snapshots__/index.ts.snap
+++ b/packages/babel-plugin-extract-messages/test/__snapshots__/index.ts.snap
@@ -7,6 +7,7 @@ Object {
       Array [
         jsx-without-trans.js,
         3,
+        null,
       ],
     ],
   },
@@ -16,11 +17,11 @@ Object {
 exports[`@lingui/babel-plugin-extract-messages should extract all messages from JS files (macros) 1`] = `
 Object {
   Description: Object {
-    comment: description,
     origin: Array [
       Array [
         js-with-macros.js,
         7,
+        description,
       ],
     ],
   },
@@ -30,6 +31,7 @@ Object {
       Array [
         js-with-macros.js,
         12,
+        null,
       ],
     ],
   },
@@ -39,6 +41,7 @@ Object {
       Array [
         js-with-macros.js,
         19,
+        null,
       ],
     ],
   },
@@ -47,10 +50,12 @@ Object {
       Array [
         js-with-macros.js,
         3,
+        null,
       ],
       Array [
         js-with-macros.js,
         5,
+        null,
       ],
     ],
   },
@@ -59,6 +64,7 @@ Object {
       Array [
         js-with-macros.js,
         17,
+        null,
       ],
     ],
   },
@@ -68,11 +74,11 @@ Object {
 exports[`@lingui/babel-plugin-extract-messages should extract all messages from JS files 1`] = `
 Object {
   Description: Object {
-    comment: description,
     origin: Array [
       Array [
         js-without-macros.js,
         5,
+        description,
       ],
     ],
   },
@@ -82,6 +88,7 @@ Object {
       Array [
         js-without-macros.js,
         7,
+        null,
       ],
     ],
   },
@@ -90,6 +97,7 @@ Object {
       Array [
         js-without-macros.js,
         3,
+        null,
       ],
     ],
   },
@@ -98,6 +106,7 @@ Object {
       Array [
         js-without-macros.js,
         9,
+        null,
       ],
     ],
   },
@@ -111,6 +120,7 @@ Object {
       Array [
         jsx-with-macros.js,
         3,
+        null,
       ],
     ],
   },
@@ -119,6 +129,7 @@ Object {
       Array [
         jsx-with-macros.js,
         4,
+        null,
       ],
     ],
   },
@@ -127,6 +138,7 @@ Object {
       Array [
         jsx-with-macros.js,
         6,
+        null,
       ],
     ],
   },
@@ -140,6 +152,7 @@ Object {
       Array [
         jsx-without-macros.js,
         9,
+        null,
       ],
     ],
   },
@@ -149,19 +162,21 @@ Object {
       Array [
         jsx-without-macros.js,
         7,
+        null,
       ],
       Array [
         jsx-without-macros.js,
         8,
+        null,
       ],
     ],
   },
   msg.hello: Object {
-    comment: Description,
     origin: Array [
       Array [
         jsx-without-macros.js,
         6,
+        Description,
       ],
     ],
   },

--- a/packages/cli/src/api/__snapshots__/catalog.test.ts.snap
+++ b/packages/cli/src/api/__snapshots__/catalog.test.ts.snap
@@ -3,29 +3,29 @@
 exports[`Catalog collect should extract messages from source files 1`] = `
 Object {
   Component A: Object {
+    extractedComments: Array [],
     origin: Array [
       Array [
         collect/componentA/componentA.js,
         1,
-        null,
       ],
     ],
   },
   Component B: Object {
+    extractedComments: Array [],
     origin: Array [
       Array [
         collect/componentB.js,
         1,
-        null,
       ],
     ],
   },
   Hello World: Object {
+    extractedComments: Array [],
     origin: Array [
       Array [
         collect/componentA/index.js,
         1,
-        null,
       ],
     ],
   },
@@ -53,7 +53,6 @@ Object {
         Array [
           collect/componentA/componentA.js,
           1,
-          ,
         ],
       ],
       translation: ,
@@ -67,7 +66,6 @@ Object {
         Array [
           collect/componentA/index.js,
           1,
-          ,
         ],
       ],
       translation: ,
@@ -83,7 +81,6 @@ Object {
         Array [
           collect/componentA/componentA.js,
           1,
-          ,
         ],
       ],
       translation: ,
@@ -97,7 +94,6 @@ Object {
         Array [
           collect/componentA/index.js,
           1,
-          ,
         ],
       ],
       translation: ,
@@ -143,7 +139,6 @@ Object {
         Array [
           collect/componentA/componentA.js,
           1,
-          ,
         ],
       ],
       translation: ,
@@ -157,7 +152,6 @@ Object {
         Array [
           collect/componentB.js,
           1,
-          ,
         ],
       ],
       translation: ,
@@ -171,7 +165,6 @@ Object {
         Array [
           collect/componentA/index.js,
           1,
-          ,
         ],
       ],
       translation: Ahoj Brno,
@@ -187,7 +180,6 @@ Object {
         Array [
           collect/componentA/componentA.js,
           1,
-          ,
         ],
       ],
       translation: ,
@@ -201,7 +193,6 @@ Object {
         Array [
           collect/componentB.js,
           1,
-          ,
         ],
       ],
       translation: ,
@@ -215,7 +206,6 @@ Object {
         Array [
           collect/componentA/index.js,
           1,
-          ,
         ],
       ],
       translation: Ahoj Brno,
@@ -244,7 +234,6 @@ Object {
         Array [
           collect/componentA/componentA.js,
           1,
-          ,
         ],
       ],
       translation: ,
@@ -258,7 +247,6 @@ Object {
         Array [
           collect/componentA/index.js,
           1,
-          ,
         ],
       ],
       translation: ,
@@ -280,7 +268,6 @@ Object {
       Array [
         collect/componentA/componentA.js,
         1,
-        ,
       ],
     ],
     translation: ,
@@ -294,7 +281,6 @@ Object {
       Array [
         collect/componentA/index.js,
         1,
-        ,
       ],
     ],
     translation: ,

--- a/packages/cli/src/api/__snapshots__/catalog.test.ts.snap
+++ b/packages/cli/src/api/__snapshots__/catalog.test.ts.snap
@@ -45,8 +45,8 @@ exports[`Catalog make should collect and write catalogs 2`] = `
 Object {
   cs: Object {
     Component A: Object {
-      comment: undefined,
       comments: Array [],
+      extractedComments: Array [],
       flags: Array [],
       obsolete: false,
       origin: Array [
@@ -58,8 +58,8 @@ Object {
       translation: ,
     },
     Hello World: Object {
-      comment: undefined,
       comments: Array [],
+      extractedComments: Array [],
       flags: Array [],
       obsolete: false,
       origin: Array [
@@ -73,8 +73,8 @@ Object {
   },
   en: Object {
     Component A: Object {
-      comment: undefined,
       comments: Array [],
+      extractedComments: Array [],
       flags: Array [],
       obsolete: false,
       origin: Array [
@@ -86,8 +86,8 @@ Object {
       translation: ,
     },
     Hello World: Object {
-      comment: undefined,
       comments: Array [],
+      extractedComments: Array [],
       flags: Array [],
       obsolete: false,
       origin: Array [
@@ -106,8 +106,8 @@ exports[`Catalog make should merge with existing catalogs 1`] = `
 Object {
   cs: Object {
     Hello World: Object {
-      comment: undefined,
       comments: Array [],
+      extractedComments: Array [],
       flags: Array [],
       obsolete: false,
       origin: Array [],
@@ -116,8 +116,8 @@ Object {
   },
   en: Object {
     Hello World: Object {
-      comment: undefined,
       comments: Array [],
+      extractedComments: Array [],
       flags: Array [],
       obsolete: false,
       origin: Array [],
@@ -131,8 +131,8 @@ exports[`Catalog make should merge with existing catalogs 2`] = `
 Object {
   cs: Object {
     Component A: Object {
-      comment: undefined,
       comments: Array [],
+      extractedComments: Array [],
       flags: Array [],
       obsolete: false,
       origin: Array [
@@ -144,8 +144,8 @@ Object {
       translation: ,
     },
     Component B: Object {
-      comment: undefined,
       comments: Array [],
+      extractedComments: Array [],
       flags: Array [],
       obsolete: false,
       origin: Array [
@@ -157,8 +157,8 @@ Object {
       translation: ,
     },
     Hello World: Object {
-      comment: undefined,
       comments: Array [],
+      extractedComments: Array [],
       flags: Array [],
       obsolete: false,
       origin: Array [
@@ -172,8 +172,8 @@ Object {
   },
   en: Object {
     Component A: Object {
-      comment: undefined,
       comments: Array [],
+      extractedComments: Array [],
       flags: Array [],
       obsolete: false,
       origin: Array [
@@ -185,8 +185,8 @@ Object {
       translation: ,
     },
     Component B: Object {
-      comment: undefined,
       comments: Array [],
+      extractedComments: Array [],
       flags: Array [],
       obsolete: false,
       origin: Array [
@@ -198,8 +198,8 @@ Object {
       translation: ,
     },
     Hello World: Object {
-      comment: undefined,
       comments: Array [],
+      extractedComments: Array [],
       flags: Array [],
       obsolete: false,
       origin: Array [
@@ -226,8 +226,8 @@ Object {
   cs: null,
   en: Object {
     Component A: Object {
-      comment: undefined,
       comments: Array [],
+      extractedComments: Array [],
       flags: Array [],
       obsolete: false,
       origin: Array [
@@ -239,8 +239,8 @@ Object {
       translation: ,
     },
     Hello World: Object {
-      comment: undefined,
       comments: Array [],
+      extractedComments: Array [],
       flags: Array [],
       obsolete: false,
       origin: Array [
@@ -260,8 +260,8 @@ exports[`Catalog makeTemplate should collect and write a template 1`] = `null`;
 exports[`Catalog makeTemplate should collect and write a template 2`] = `
 Object {
   Component A: Object {
-    comment: undefined,
     comments: Array [],
+    extractedComments: Array [],
     flags: Array [],
     obsolete: false,
     origin: Array [
@@ -273,8 +273,8 @@ Object {
     translation: ,
   },
   Hello World: Object {
-    comment: undefined,
     comments: Array [],
+    extractedComments: Array [],
     flags: Array [],
     obsolete: false,
     origin: Array [
@@ -291,51 +291,53 @@ Object {
 exports[`Catalog read should read file in given format 1`] = `
 Object {
   obsolete: Object {
-    comment: undefined,
     comments: Array [],
+    extractedComments: Array [],
     flags: Array [],
     obsolete: true,
     origin: Array [],
     translation: Is marked as obsolete,
   },
   static: Object {
-    comment: undefined,
     comments: Array [],
+    extractedComments: Array [],
     flags: Array [],
     obsolete: false,
     origin: Array [],
     translation: Static message,
   },
   veryLongString: Object {
-    comment: undefined,
     comments: Array [],
+    extractedComments: Array [],
     flags: Array [],
     obsolete: false,
     origin: Array [],
     translation: One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections. The bedding was hardly able to cover it and seemed ready to slide off any moment. His many legs, pitifully thin compared with the size of the rest of him, waved about helplessly as he looked. "What's happened to me?" he thought. It wasn't a dream. His room, a proper human,
   },
   withComments: Object {
-    comment: undefined,
     comments: Array [
       Translator comment,
       This one might come from developer,
     ],
+    extractedComments: Array [],
     flags: Array [],
     obsolete: false,
     origin: Array [],
     translation: Support translator comments separately,
   },
   withDescription: Object {
-    comment: Description is comment from developers to translators,
     comments: Array [],
+    extractedComments: Array [
+      Description is comment from developers to translators,
+    ],
     flags: Array [],
     obsolete: false,
     origin: Array [],
     translation: Message with description,
   },
   withFlags: Object {
-    comment: undefined,
     comments: Array [],
+    extractedComments: Array [],
     flags: Array [
       fuzzy,
       otherFlag,
@@ -345,8 +347,8 @@ Object {
     translation: Keeps any flags that are defined,
   },
   withMultipleOrigins: Object {
-    comment: undefined,
     comments: Array [],
+    extractedComments: Array [],
     flags: Array [],
     obsolete: false,
     origin: Array [
@@ -362,8 +364,8 @@ Object {
     translation: Message with multiple origin,
   },
   withOrigin: Object {
-    comment: undefined,
     comments: Array [],
+    extractedComments: Array [],
     flags: Array [],
     obsolete: false,
     origin: Array [
@@ -383,8 +385,8 @@ exports[`Catalog readAll should read existing catalogs for all locales 1`] = `
 Object {
   cs: Object {
     Hello World: Object {
-      comment: undefined,
       comments: Array [],
+      extractedComments: Array [],
       flags: Array [],
       obsolete: false,
       origin: Array [],
@@ -393,8 +395,8 @@ Object {
   },
   en: Object {
     Hello World: Object {
-      comment: undefined,
       comments: Array [],
+      extractedComments: Array [],
       flags: Array [],
       obsolete: false,
       origin: Array [],

--- a/packages/cli/src/api/__snapshots__/catalog.test.ts.snap
+++ b/packages/cli/src/api/__snapshots__/catalog.test.ts.snap
@@ -7,6 +7,7 @@ Object {
       Array [
         collect/componentA/componentA.js,
         1,
+        null,
       ],
     ],
   },
@@ -15,6 +16,7 @@ Object {
       Array [
         collect/componentB.js,
         1,
+        null,
       ],
     ],
   },
@@ -23,6 +25,7 @@ Object {
       Array [
         collect/componentA/index.js,
         1,
+        null,
       ],
     ],
   },
@@ -50,6 +53,7 @@ Object {
         Array [
           collect/componentA/componentA.js,
           1,
+          ,
         ],
       ],
       translation: ,
@@ -63,6 +67,7 @@ Object {
         Array [
           collect/componentA/index.js,
           1,
+          ,
         ],
       ],
       translation: ,
@@ -78,6 +83,7 @@ Object {
         Array [
           collect/componentA/componentA.js,
           1,
+          ,
         ],
       ],
       translation: ,
@@ -91,6 +97,7 @@ Object {
         Array [
           collect/componentA/index.js,
           1,
+          ,
         ],
       ],
       translation: ,
@@ -136,6 +143,7 @@ Object {
         Array [
           collect/componentA/componentA.js,
           1,
+          ,
         ],
       ],
       translation: ,
@@ -149,6 +157,7 @@ Object {
         Array [
           collect/componentB.js,
           1,
+          ,
         ],
       ],
       translation: ,
@@ -162,6 +171,7 @@ Object {
         Array [
           collect/componentA/index.js,
           1,
+          ,
         ],
       ],
       translation: Ahoj Brno,
@@ -177,6 +187,7 @@ Object {
         Array [
           collect/componentA/componentA.js,
           1,
+          ,
         ],
       ],
       translation: ,
@@ -190,6 +201,7 @@ Object {
         Array [
           collect/componentB.js,
           1,
+          ,
         ],
       ],
       translation: ,
@@ -203,6 +215,7 @@ Object {
         Array [
           collect/componentA/index.js,
           1,
+          ,
         ],
       ],
       translation: Ahoj Brno,
@@ -231,6 +244,7 @@ Object {
         Array [
           collect/componentA/componentA.js,
           1,
+          ,
         ],
       ],
       translation: ,
@@ -244,6 +258,7 @@ Object {
         Array [
           collect/componentA/index.js,
           1,
+          ,
         ],
       ],
       translation: ,
@@ -265,6 +280,7 @@ Object {
       Array [
         collect/componentA/componentA.js,
         1,
+        ,
       ],
     ],
     translation: ,
@@ -278,6 +294,7 @@ Object {
       Array [
         collect/componentA/index.js,
         1,
+        ,
       ],
     ],
     translation: ,

--- a/packages/cli/src/api/__snapshots__/catalog.test.ts.snap
+++ b/packages/cli/src/api/__snapshots__/catalog.test.ts.snap
@@ -21,8 +21,15 @@ Object {
     ],
   },
   Hello World: Object {
-    extractedComments: Array [],
+    extractedComments: Array [
+      Comment A,
+      Hello comment,
+    ],
     origin: Array [
+      Array [
+        collect/componentA/componentA.js,
+        2,
+      ],
       Array [
         collect/componentA/index.js,
         1,
@@ -59,10 +66,17 @@ Object {
     },
     Hello World: Object {
       comments: Array [],
-      extractedComments: Array [],
+      extractedComments: Array [
+        Comment A,
+        Hello comment,
+      ],
       flags: Array [],
       obsolete: false,
       origin: Array [
+        Array [
+          collect/componentA/componentA.js,
+          2,
+        ],
         Array [
           collect/componentA/index.js,
           1,
@@ -87,10 +101,17 @@ Object {
     },
     Hello World: Object {
       comments: Array [],
-      extractedComments: Array [],
+      extractedComments: Array [
+        Comment A,
+        Hello comment,
+      ],
       flags: Array [],
       obsolete: false,
       origin: Array [
+        Array [
+          collect/componentA/componentA.js,
+          2,
+        ],
         Array [
           collect/componentA/index.js,
           1,
@@ -158,10 +179,17 @@ Object {
     },
     Hello World: Object {
       comments: Array [],
-      extractedComments: Array [],
+      extractedComments: Array [
+        Comment A,
+        Hello comment,
+      ],
       flags: Array [],
       obsolete: false,
       origin: Array [
+        Array [
+          collect/componentA/componentA.js,
+          2,
+        ],
         Array [
           collect/componentA/index.js,
           1,
@@ -199,10 +227,17 @@ Object {
     },
     Hello World: Object {
       comments: Array [],
-      extractedComments: Array [],
+      extractedComments: Array [
+        Comment A,
+        Hello comment,
+      ],
       flags: Array [],
       obsolete: false,
       origin: Array [
+        Array [
+          collect/componentA/componentA.js,
+          2,
+        ],
         Array [
           collect/componentA/index.js,
           1,
@@ -240,10 +275,17 @@ Object {
     },
     Hello World: Object {
       comments: Array [],
-      extractedComments: Array [],
+      extractedComments: Array [
+        Comment A,
+        Hello comment,
+      ],
       flags: Array [],
       obsolete: false,
       origin: Array [
+        Array [
+          collect/componentA/componentA.js,
+          2,
+        ],
         Array [
           collect/componentA/index.js,
           1,
@@ -274,10 +316,17 @@ Object {
   },
   Hello World: Object {
     comments: Array [],
-    extractedComments: Array [],
+    extractedComments: Array [
+      Comment A,
+      Hello comment,
+    ],
     flags: Array [],
     obsolete: false,
     origin: Array [
+      Array [
+        collect/componentA/componentA.js,
+        2,
+      ],
       Array [
         collect/componentA/index.js,
         1,

--- a/packages/cli/src/api/__snapshots__/catalog.test.ts.snap
+++ b/packages/cli/src/api/__snapshots__/catalog.test.ts.snap
@@ -23,12 +23,17 @@ Object {
   Hello World: Object {
     extractedComments: Array [
       Comment A,
+      Comment A again,
       Hello comment,
     ],
     origin: Array [
       Array [
         collect/componentA/componentA.js,
         2,
+      ],
+      Array [
+        collect/componentA/componentA.js,
+        3,
       ],
       Array [
         collect/componentA/index.js,
@@ -68,6 +73,7 @@ Object {
       comments: Array [],
       extractedComments: Array [
         Comment A,
+        Comment A again,
         Hello comment,
       ],
       flags: Array [],
@@ -76,6 +82,10 @@ Object {
         Array [
           collect/componentA/componentA.js,
           2,
+        ],
+        Array [
+          collect/componentA/componentA.js,
+          3,
         ],
         Array [
           collect/componentA/index.js,
@@ -103,6 +113,7 @@ Object {
       comments: Array [],
       extractedComments: Array [
         Comment A,
+        Comment A again,
         Hello comment,
       ],
       flags: Array [],
@@ -111,6 +122,10 @@ Object {
         Array [
           collect/componentA/componentA.js,
           2,
+        ],
+        Array [
+          collect/componentA/componentA.js,
+          3,
         ],
         Array [
           collect/componentA/index.js,
@@ -181,6 +196,7 @@ Object {
       comments: Array [],
       extractedComments: Array [
         Comment A,
+        Comment A again,
         Hello comment,
       ],
       flags: Array [],
@@ -189,6 +205,10 @@ Object {
         Array [
           collect/componentA/componentA.js,
           2,
+        ],
+        Array [
+          collect/componentA/componentA.js,
+          3,
         ],
         Array [
           collect/componentA/index.js,
@@ -229,6 +249,7 @@ Object {
       comments: Array [],
       extractedComments: Array [
         Comment A,
+        Comment A again,
         Hello comment,
       ],
       flags: Array [],
@@ -237,6 +258,10 @@ Object {
         Array [
           collect/componentA/componentA.js,
           2,
+        ],
+        Array [
+          collect/componentA/componentA.js,
+          3,
         ],
         Array [
           collect/componentA/index.js,
@@ -277,6 +302,7 @@ Object {
       comments: Array [],
       extractedComments: Array [
         Comment A,
+        Comment A again,
         Hello comment,
       ],
       flags: Array [],
@@ -285,6 +311,10 @@ Object {
         Array [
           collect/componentA/componentA.js,
           2,
+        ],
+        Array [
+          collect/componentA/componentA.js,
+          3,
         ],
         Array [
           collect/componentA/index.js,
@@ -318,6 +348,7 @@ Object {
     comments: Array [],
     extractedComments: Array [
       Comment A,
+      Comment A again,
       Hello comment,
     ],
     flags: Array [],
@@ -326,6 +357,10 @@ Object {
       Array [
         collect/componentA/componentA.js,
         2,
+      ],
+      Array [
+        collect/componentA/componentA.js,
+        3,
       ],
       Array [
         collect/componentA/index.js,

--- a/packages/cli/src/api/catalog.ts
+++ b/packages/cli/src/api/catalog.ts
@@ -168,7 +168,7 @@ export class Catalog {
           .filter(Boolean)
           .reduce(
             (catalog, messages) =>
-              R.mergeWithKey(mergeOrigins, catalog, messages),
+              R.mergeWithKey(mergeOriginsAndExtractedComments, catalog, messages),
             {}
           )
       })(tmpDir)
@@ -540,10 +540,10 @@ export function getCatalogForMerge(config: LinguiConfig) {
 }
 
 /**
- * Merge origins for messages found in different places. All other attributes
+ * Merge origins and extractedComments for messages found in different places. All other attributes
  * should be the same (raise an error if defaults are different).
  */
-function mergeOrigins(msgId, prev, next) {
+function mergeOriginsAndExtractedComments(msgId, prev, next) {
   if (prev.defaults !== next.defaults) {
     throw new Error(
       `Encountered different defaults for message ${chalk.yellow(msgId)}` +
@@ -554,6 +554,7 @@ function mergeOrigins(msgId, prev, next) {
 
   return {
     ...next,
+    extractedComments: R.concat(prev.extractedComments, next.extractedComments),
     origin: R.concat(prev.origin, next.origin),
   }
 }

--- a/packages/cli/src/api/catalog.ts
+++ b/packages/cli/src/api/catalog.ts
@@ -25,11 +25,10 @@ type MessageOrigin = [string, number];
 export type ExtractedMessageType = {
   message?: string
   origin?: MessageOrigin[]
-  comment?: string
+  extractedComments?: string[]
   comments?: string[]
   obsolete?: boolean
   flags?: string[]
-  description?: string
 }
 
 export type MessageType = ExtractedMessageType & {

--- a/packages/cli/src/api/fixtures/collect/componentA/componentA.js
+++ b/packages/cli/src/api/fixtures/collect/componentA/componentA.js
@@ -1,2 +1,3 @@
 /*i18n*/ i18n._("Component A");
 /*i18n*/ i18n._("Hello World", {}, {comment: "Comment A"});
+/*i18n*/ i18n._("Hello World", {}, {comment: "Comment A again"});

--- a/packages/cli/src/api/fixtures/collect/componentA/componentA.js
+++ b/packages/cli/src/api/fixtures/collect/componentA/componentA.js
@@ -1,1 +1,2 @@
-/*i18n*/ i18n._("Component A")
+/*i18n*/ i18n._("Component A");
+/*i18n*/ i18n._("Hello World", {}, {comment: "Comment A"});

--- a/packages/cli/src/api/fixtures/collect/componentA/index.js
+++ b/packages/cli/src/api/fixtures/collect/componentA/index.js
@@ -1,1 +1,1 @@
-/*i18n*/ i18n._("Hello World")
+/*i18n*/ i18n._("Hello World", {}, {comment: "Hello comment"})

--- a/packages/cli/src/api/formats/__snapshots__/lingui.test.ts.snap
+++ b/packages/cli/src/api/formats/__snapshots__/lingui.test.ts.snap
@@ -36,7 +36,9 @@ exports[`lingui format should write catalog in lingui format 1`] = `
   },
   "withDescription": {
     "translation": "Message with description",
-    "description": "Description is comment from developers to translators"
+    "extractedComments": [
+      "Description is comment from developers to translators"
+    ]
   },
   "withComments": {
     "comments": [

--- a/packages/cli/src/api/formats/__snapshots__/po.test.ts.snap
+++ b/packages/cli/src/api/formats/__snapshots__/po.test.ts.snap
@@ -3,9 +3,12 @@
 exports[`pofile format should correct badly used comments 1`] = `
 Object {
   withDescriptionAndComments: Object {
-    comment: Single description only,
     comments: Array [
       Translator comment,
+      Second description?,
+    ],
+    extractedComments: Array [
+      Single description only,
       Second description?,
     ],
     flags: Array [],
@@ -14,8 +17,12 @@ Object {
     translation: Second description joins translator comments,
   },
   withMultipleDescriptions: Object {
-    comment: First description,
     comments: Array [
+      Second comment,
+      Third comment,
+    ],
+    extractedComments: Array [
+      First description,
       Second comment,
       Third comment,
     ],
@@ -30,51 +37,53 @@ Object {
 exports[`pofile format should read catalog in pofile format 1`] = `
 Object {
   obsolete: Object {
-    comment: undefined,
     comments: Array [],
+    extractedComments: Array [],
     flags: Array [],
     obsolete: true,
     origin: Array [],
     translation: Is marked as obsolete,
   },
   static: Object {
-    comment: undefined,
     comments: Array [],
+    extractedComments: Array [],
     flags: Array [],
     obsolete: false,
     origin: Array [],
     translation: Static message,
   },
   veryLongString: Object {
-    comment: undefined,
     comments: Array [],
+    extractedComments: Array [],
     flags: Array [],
     obsolete: false,
     origin: Array [],
     translation: One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections. The bedding was hardly able to cover it and seemed ready to slide off any moment. His many legs, pitifully thin compared with the size of the rest of him, waved about helplessly as he looked. "What's happened to me?" he thought. It wasn't a dream. His room, a proper human,
   },
   withComments: Object {
-    comment: undefined,
     comments: Array [
       Translator comment,
       This one might come from developer,
     ],
+    extractedComments: Array [],
     flags: Array [],
     obsolete: false,
     origin: Array [],
     translation: Support translator comments separately,
   },
   withDescription: Object {
-    comment: Description is comment from developers to translators,
     comments: Array [],
+    extractedComments: Array [
+      Description is comment from developers to translators,
+    ],
     flags: Array [],
     obsolete: false,
     origin: Array [],
     translation: Message with description,
   },
   withFlags: Object {
-    comment: undefined,
     comments: Array [],
+    extractedComments: Array [],
     flags: Array [
       fuzzy,
       otherFlag,
@@ -84,8 +93,8 @@ Object {
     translation: Keeps any flags that are defined,
   },
   withMultipleOrigins: Object {
-    comment: undefined,
     comments: Array [],
+    extractedComments: Array [],
     flags: Array [],
     obsolete: false,
     origin: Array [
@@ -101,8 +110,8 @@ Object {
     translation: Message with multiple origin,
   },
   withOrigin: Object {
-    comment: undefined,
     comments: Array [],
+    extractedComments: Array [],
     flags: Array [],
     obsolete: false,
     origin: Array [
@@ -119,8 +128,8 @@ Object {
 exports[`pofile format should throw away additional msgstr if present 1`] = `
 Object {
   withMultipleTranslation: Object {
-    comment: undefined,
     comments: Array [],
+    extractedComments: Array [],
     flags: Array [],
     obsolete: false,
     origin: Array [],
@@ -151,6 +160,7 @@ msgstr "Message with origin"
 msgid "withMultipleOrigins"
 msgstr "Message with multiple origin"
 
+#. Description is comment from developers to translators
 msgid "withDescription"
 msgstr "Message with description"
 

--- a/packages/cli/src/api/formats/__snapshots__/po.test.ts.snap
+++ b/packages/cli/src/api/formats/__snapshots__/po.test.ts.snap
@@ -5,7 +5,6 @@ Object {
   withDescriptionAndComments: Object {
     comments: Array [
       Translator comment,
-      Second description?,
     ],
     extractedComments: Array [
       Single description only,
@@ -17,10 +16,7 @@ Object {
     translation: Second description joins translator comments,
   },
   withMultipleDescriptions: Object {
-    comments: Array [
-      Second comment,
-      Third comment,
-    ],
+    comments: Array [],
     extractedComments: Array [
       First description,
       Second comment,

--- a/packages/cli/src/api/formats/lingui.test.ts
+++ b/packages/cli/src/api/formats/lingui.test.ts
@@ -38,7 +38,7 @@ describe("lingui format", function () {
       },
       withDescription: {
         translation: "Message with description",
-        description: "Description is comment from developers to translators",
+        extractedComments: ["Description is comment from developers to translators"],
       },
       withComments: {
         comments: ["Translator comment", "This one might come from developer"],

--- a/packages/cli/src/api/formats/po.test.ts
+++ b/packages/cli/src/api/formats/po.test.ts
@@ -40,7 +40,7 @@ describe("pofile format", function () {
       },
       withDescription: {
         translation: "Message with description",
-        description: "Description is comment from developers to translators",
+        extractedComments: ["Description is comment from developers to translators"],
       },
       withComments: {
         comments: ["Translator comment", "This one might come from developer"],

--- a/packages/cli/src/api/formats/po.ts
+++ b/packages/cli/src/api/formats/po.ts
@@ -54,11 +54,7 @@ const deserialize: (item: Object) => Object = R.map(
   R.applySpec({
     translation: R.compose(R.head, R.defaultTo([]), getTranslations),
     extractedComments: R.compose(R.defaultTo([]), getExtractedComments),
-    comments: (item) =>
-      R.concat(
-        getTranslatorComments(item) as string,
-        R.tail(getExtractedComments(item))
-      ),
+    comments: R.compose(R.defaultTo([]), getTranslatorComments),
     obsolete: isObsolete,
     origin: R.compose(R.map(splitOrigin), R.defaultTo([]), getOrigins),
     flags: getFlags,

--- a/packages/cli/src/api/formats/po.ts
+++ b/packages/cli/src/api/formats/po.ts
@@ -24,7 +24,7 @@ const serialize = (items: CatalogType, options) =>
       item.msgid = key
       item.msgstr = [message.translation]
       item.comments = message.comments || []
-      item.extractedComments = message.comment ? [message.comment] : []
+      item.extractedComments = message.extractedComments || []
       if (options.origins) {
         item.references = message.origin ? message.origin.map(joinOrigin) : []
       }
@@ -53,7 +53,7 @@ const isObsolete = R.either(R.path(["flags", "obsolete"]), R.prop("obsolete"))
 const deserialize: (item: Object) => Object = R.map(
   R.applySpec({
     translation: R.compose(R.head, R.defaultTo([]), getTranslations),
-    comment: R.compose(R.head, R.defaultTo([]), getExtractedComments),
+    extractedComments: R.compose(R.defaultTo([]), getExtractedComments),
     comments: (item) =>
       R.concat(
         getTranslatorComments(item) as string,


### PR DESCRIPTION
This PR resolves #845 

On par file level is collects multiple ```extractedComments``` (using the same name as ```pofile``` package)
This - just like origins - gets merged together to build the catalogue.

Some refactoring was done to use the ```extractedComments``` name throughout.

**Possible issues**

This change should just work for PO file users.
However if users are using lingui file type thing might break. Namely the ```description (string)``` is replaced with ```extractedComments (string[])```. Either some backwards compatibility should be built on top of these changes, or sufficient change information should be provided.

**What can be improved***

Currently the PO file gets built like with ```extractedComments``` and ```references``` grouped: 

```po
#. Comment in code
#. Other comment
#: App.js:12
#: Screen.js:56
# msgid "Nice"
```

It would be cool to output them with comment associated with the reference file.

```po
#: App.js:12
#. Comment in code
#: Screen.js:56
#. Other comment
# msgid "Nice"
```

However, it seems that PO file here is major blocker and this change would be way to much work to achieve.