### PR TITLE
fix: @lingui/cli not compiling if locale contains empty strings

### DIFF
--- a/packages/cli/src/api/catalog.ts
+++ b/packages/cli/src/api/catalog.ts
@@ -273,19 +273,19 @@ export class Catalog {
 
     return (
       // Get translation in target locale
-      getTranslation(locale) ||
+      getTranslation(locale) ??
       // We search in fallbackLocales as dependent of each locale
-      getMultipleFallbacks(locale) ||
+      getMultipleFallbacks(locale) ??
       // Get translation in fallbackLocales.default (if any)
-      (fallbackLocales.default && getTranslation(fallbackLocales.default)) ||
+      (fallbackLocales.default && getTranslation(fallbackLocales.default)) ??
       // Get message default
-      catalogs[locale][key].defaults ||
+      catalogs[locale][key].defaults ??
       // If sourceLocale is either target locale of fallback one, use key
-      (sourceLocale && sourceLocale === locale && key) ||
+      (sourceLocale && sourceLocale === locale && key) ??
       (sourceLocale &&
         fallbackLocales.default &&
         sourceLocale === fallbackLocales.default &&
-        key) ||
+        key) ??
       // Otherwise no translation is available
       undefined
     )


### PR DESCRIPTION
Should a locale contain a key which has not been translated yet, and is therefor an empty string. The CLI will now wrongfully fallback to the fallback locale.

It is caused by `getTranslation(locale)` being evaluated falsy due to it being an empty string, I've therefore replaced the logical OR operator with the null-coalescing operator, to only fallback if `getTranslation(locale)` is nullish. 