### PR TITLE
docs: suggest removal of types in migration docs

### DIFF
--- a/docs/releases/migration-3.rst
+++ b/docs/releases/migration-3.rst
@@ -282,3 +282,8 @@ New features
 
 Event ``change`` is fired anytime new catalogs are loaded or when locale
 is activated.
+
+`Native TypeScript support`
+--------------------------
+
+Lingui now supports TypeScript out of the box, don't forget to remove the `@types/lingui` packages from your project. 


### PR DESCRIPTION
I just noticed that TypeScript definition files are included now! Thanks for that.
We should encourage people to keep their dependency list short, so I suggest adding that to the "new features" section.