### PR TITLE
docs: correct syntax error in I18nProvider example

### DIFF
--- a/docs/ref/react.rst
+++ b/docs/ref/react.rst
@@ -173,7 +173,7 @@ top-level application component. However, if the ``locale`` is stored in a
    import React from 'react';
    import { I18nProvider } from '@lingui/react';
    import { i18n } from '@lingui/core';
-   import { messages as MessagesEn } from './locales/en/messages.js';
+   import { messages as messagesEn } from './locales/en/messages.js';
 
    i18n.load({
       en: messagesEn,


### PR DESCRIPTION
Correct syntax error in I18nProvider example