### PR TITLE
docs: remove add-locale from documentation

### DIFF
--- a/docs/tutorials/setup-react.rst
+++ b/docs/tutorials/setup-react.rst
@@ -62,6 +62,7 @@ Install
    .. code-block:: json
 
       {
+         "locales": ["en", "cs"],
          "localeDir": "src/locales/",
          "srcPathDirs": ["src/"],
          "format": "po"
@@ -76,24 +77,12 @@ Install
 
       {
          "scripts": {
-            "add-locale": "lingui add-locale",
             "extract": "lingui extract",
             "compile": "lingui compile",
          }
       }
 
-5. Run ``npm run add-locale`` (or ``yarn add-locale``) with
-   `locale codes <https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry>`_
-   you would like to use in your app:
-
-   .. code-block:: shell
-
-      npm run add-locale en es fr  # Add English, Spanish and French locale
-
-      # or using Yarn
-      yarn add-locale en es fr
-
-6. Check the installation by running ``npm run extract`` (or ``yarn extract``):
+5. Check the installation by running ``npm run extract`` (or ``yarn extract``):
 
    .. code-block:: shell
 
@@ -117,7 +106,6 @@ Install
       │ fr       │     0       │   0     │
       └──────────┴─────────────┴─────────┘
 
-      (use "lingui add-locale <language>" to add more locales)
       (use "lingui extract" to update catalogs with new messages)
       (use "lingui compile" to compile catalogs for production)
 

--- a/packages/cli/src/lingui-extract.ts
+++ b/packages/cli/src/lingui-extract.ts
@@ -39,10 +39,6 @@ export default function command(
       ...options,
       orderBy: config.orderBy,
       projectType: detect(),
-      // const pseudoLocale = config.pseudoLocale
-      // if (pseudoLocale) {
-      //   catalog.addLocale(pseudoLocale)
-      // }
     })
 
     catalogStats[catalog.path] = catalog.readAll()


### PR DESCRIPTION
Removes information about running deprecated add-locale command from React documentation