### PR TITLE
docs: create pseudolocalization guide

### DIFF
--- a/docs/guides/pseudolocalization.rst
+++ b/docs/guides/pseudolocalization.rst
@@ -1,0 +1,57 @@
+==================
+Pseudolocalization
+==================
+
+There is built in support for `pseudolocalization <https://en.wikipedia.org/wiki/Pseudolocalization>`. 
+Pseudolocalization is a method for testing the internationalization aspects 
+of your application by replacing your strings with altered versions 
+and maintaining string readability. It also makes hard coded strings 
+and improperly concatenated strings easy to spot so that they can be properly localized.
+
+  Example:
+  Ţĥĩś ţēxţ ĩś ƥśēũďōĺōćàĺĩźēď
+
+Configuration
+=============
+
+To setup pseudolocalization add :conf:`pseudoLocale` to your lingui :doc:`configuration file </ref/conf>`::
+
+   {
+      "lingui": {
+         "locale": ["en", "pseudo-LOCALE"],
+         "pseudoLocale": "pseudo-LOCALE"
+         "fallbackLocales": {
+            "pseudo-LOCALE": "en"
+         }
+      }
+   }
+
+:conf:`pseudoLocale` option can be any string that is in :conf:`locale` 
+
+Examples: :conf:`en-PL`, :conf:`pseudo-LOCALE`, :conf:`pseudolocalization` or :conf:`en-UK`
+
+Create pseudolocalization
+=========================
+
+PseudoLocale string have to be in :conf:`locales` config as well. 
+Otherwise no folder and no pseudlocalization is going to be created.
+After running ``yarn extract`` verify that the folder has been created.
+The pseudolocalization is automatically created on ``yarn compile`` from messages 
+in order specified in :cli:`Preparing catalogs for production`. 
+In case fallbackLocales has been used, the pseudlocalization is going to be created from translated fallbacklocale.
+
+Switch browser into specified pseudoLocale
+======================================================
+
+We can use browsers settings or extensions. Extensions allow to use any locale.
+Browsers are usually limited into valid language tags (BCP 47). 
+In that case, the locale for pseudolocalization has to be standard locale,
+which is not used in your application for example :conf:`zu_ZA` Zulu - SOUTH AFRICA
+
+Chrome:
+a) With extension (valid locale) - https://chrome.google.com/webstore/detail/locale-switcher/kngfjpghaokedippaapkfihdlmmlafcc
+b) Without extension (valid locale) - chrome://settings/?search=languages
+
+Firefox:
+a) With extension (any string) - https://addons.mozilla.org/en-GB/firefox/addon/quick-accept-language-switc/?src=search
+b) Without extension (valid locale) - about:preferences#general > Language

--- a/docs/guides/pseudolocalization.rst
+++ b/docs/guides/pseudolocalization.rst
@@ -37,7 +37,7 @@ PseudoLocale string have to be in :conf:`locales` config as well.
 Otherwise no folder and no pseudolocalization is going to be created.
 After running ``yarn extract`` verify that the folder has been created.
 The pseudolocalization is automatically created on ``yarn compile`` from messages 
-in order specified in :cli:`Preparing catalogs for production`. 
+in order specified in `in this cli section <../tutorials/cli.html#preparing-catalogs-for-production>`_.
 In case fallbackLocales has been used, the pseudolocalization is going to be created from translated fallbacklocale.
 
 Switch browser into specified pseudoLocale

--- a/docs/guides/pseudolocalization.rst
+++ b/docs/guides/pseudolocalization.rst
@@ -34,11 +34,11 @@ Create pseudolocalization
 =========================
 
 PseudoLocale string have to be in :conf:`locales` config as well. 
-Otherwise no folder and no pseudlocalization is going to be created.
+Otherwise no folder and no pseudolocalization is going to be created.
 After running ``yarn extract`` verify that the folder has been created.
 The pseudolocalization is automatically created on ``yarn compile`` from messages 
 in order specified in :cli:`Preparing catalogs for production`. 
-In case fallbackLocales has been used, the pseudlocalization is going to be created from translated fallbacklocale.
+In case fallbackLocales has been used, the pseudolocalization is going to be created from translated fallbacklocale.
 
 Switch browser into specified pseudoLocale
 ======================================================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -100,6 +100,7 @@ Documentation contents
    Optimized components <guides/optimized-components>
    How plurals work <guides/plurals>
    Lingui within monorepo <guides/monorepo>
+   Pseudolocalization <guides/pseudolocalization>
 
 .. toctree::
    :maxdepth: 1

--- a/docs/tutorials/cli.rst
+++ b/docs/tutorials/cli.rst
@@ -182,49 +182,6 @@ If you use natural language for message IDs (that's the default),
 set :conf:`sourceLocale`. You shouldn't use this config if you're using custom
 IDs (e.g: ``Component.title``).
 
-Pseudolocalization
-==================
-
-There is built in support for `pseudolocalization <https://en.wikipedia.org/wiki/Pseudolocalization>`. 
-Pseudolocalization is a method for testing the internationalization aspects 
-of your application by replacing your strings with altered versions 
-and maintaining string readability. It also makes hard coded strings 
-and improperly concatenated strings easy to spot so that they can be properly localized.
-
-  Example:
-  Ţĥĩś ţēxţ ĩś ƥśēũďōĺōćàĺĩźēď
-
-To setup pseudolocalization add :conf:`pseudoLocale` in ``package.json``::
-
-   {
-      "lingui": {
-         "pseudoLocale": "pseudo-LOCALE"
-      }
-   }
-
-:conf:`pseudoLocale` option can be any string 
-examples: :conf:`en-PL`, :conf:`pseudo-LOCALE`, :conf:`pseudolocalization` or :conf:`en-UK`
-
-PseudoLocale string have to be in :conf:`locales` config as well. Otherwise no folder is going to be created.
-Pseudolocalized text is created on  ``yarn compile`` command.
-The pseudolocalization is automatically created on ``yarn extract`` from messages in order specified in :ref:`Preparing catalogs for production`.
-
-How to switch your browser into specified pseudoLocale
-------------------------------------------------------
-
-We can use browsers settings or extensions. Extensions allow to use any locale.
-Browsers are usually limited into valid language tags (BCP 47). 
-In that case, the locale for pseudolocalization has to be standard locale,
-which is not used in your application for example :conf:`zu_ZA` Zulu - SOUTH AFRICA
-
-Chrome:
-a) With extension (any string) - https://chrome.google.com/webstore/detail/quick-language-switcher/pmjbhfmaphnpbehdanbjphdcniaelfie
-b) Without extension - chrome://settings/?search=languages
-
-Firefox:
-a) With extension (any string) - https://addons.mozilla.org/en-GB/firefox/addon/quick-accept-language-switc/?src=search
-b) Without extension - about:preferences#general > Language
-
 Catalogs in VCS and CI
 ======================
 

--- a/docs/tutorials/cli.rst
+++ b/docs/tutorials/cli.rst
@@ -6,7 +6,7 @@ Working with LinguiJS CLI
 *************************
 
 ``@lingui/cli`` provides the ``lingui`` command for extracting, merging and
-compiling message catalogs. Follow `setup instructions <../ref/cli>`_ to install required
+compiling message catalogs. Follow `setup instructions <../ref/cli.html>`_ to install required
 packages.
 
 .. note::


### PR DESCRIPTION
I have moved psedulocalization to guides from cli tutorials

This closes #838 as the documentation now specifies `fallbackLocales`