### PR TITLE
Export TransRenderProps from @lingui/react

### DIFF
--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -6,4 +6,4 @@ export {
   I18nContext,
   withI18nProps,
 } from "./I18nProvider"
-export { Trans, TransProps } from "./Trans"
+export { Trans, TransProps, TransRenderProps } from "./Trans"


### PR DESCRIPTION
Fixing this error 
```
⋊> /V/s/t/web on master ⨯ npx tsc                                                                                                                                                                                                                                             16:24:19
node_modules/@lingui/macro/index.d.ts:3:15 - error TS2305: Module '"../react/cjs"' has no exported member 'TransRenderProps'.

3 import type { TransRenderProps } from "@lingui/react"
                ~~~~~~~~~~~~~~~~


Found 1 error.
```

How can I verify index.d.ts is correctly setup? In my IDE I only see `Could not find a declaration file for module '@lingui/react'`
<img width="1381" alt="Screenshot 2020-11-21 at 16 43 15" src="https://user-images.githubusercontent.com/10707183/99882489-bf954480-2c18-11eb-9dca-d35b440df46b.png">
