### PR TITLE
fix: select props typescript

### DIFF
--- a/packages/macro/index.d.ts
+++ b/packages/macro/index.d.ts
@@ -40,10 +40,26 @@ export type ChoiceProps = {
 } & TransProps &
   ChoiceOptions<ReactNode>
 
+/**
+ * The types should be changes after this PR is merged
+ * https://github.com/Microsoft/TypeScript/pull/26797
+ *
+ * then we should be able to specify that key of values is same type as value
+ * and we would be able to remove separate type Values = {...} definition
+ * eg.
+ * type SelectProps<Values> = {
+ *  value?: Values
+ *  [key: Values]: string
+ * }
+ *
+ */
+type Values = { [key: string]: string }
+
 export type SelectProps = {
-  value?: string
-  other?: ReactNode
-} & TransProps
+  value: string
+  other: ReactNode
+} & TransProps &
+  Values
 
 export const Trans: ComponentType<TransProps>
 export const Plural: ComponentType<ChoiceProps>

--- a/packages/macro/index.d.ts
+++ b/packages/macro/index.d.ts
@@ -41,11 +41,11 @@ export type ChoiceProps = {
   ChoiceOptions<ReactNode>
 
 /**
- * The types should be changes after this PR is merged
+ * The types should be changed after this PR is merged
  * https://github.com/Microsoft/TypeScript/pull/26797
  *
- * then we should be able to specify that key of values is same type as value
- * and we would be able to remove separate type Values = {...} definition
+ * then we should be able to specify that key of values is same type as value.
+ * We would be able to remove separate type Values = {...} definition
  * eg.
  * type SelectProps<Values> = {
  *  value?: Values


### PR DESCRIPTION
Getting error if using example from documentation

```
 <Select value={gender} male="His book" female="Her book" other="Their book" />
```

```
Type '{ value: "male"; male: string; female: string; other: string; }' is not assignable to type 'IntrinsicAttributes & { value?: string | undefined; other?: ReactNode; } & TransProps & { children?: ReactNode; }'.
  Property 'male' does not exist on type 'IntrinsicAttributes & { value?: string | undefined; other?: ReactNode; } & TransProps & { children?: ReactNode; }'
```