### PR TITLE
Update deprecated srcPathDirs in Setup React docs

### DIFF
--- a/docs/tutorials/setup-react.rst
+++ b/docs/tutorials/setup-react.rst
@@ -63,8 +63,10 @@ Install
 
       {
          "locales": ["en", "cs"],
-         "localeDir": "src/locales/",
-         "srcPathDirs": ["src/"],
+         "catalogs": [{
+            "path": "src/locales/{locale}/messages",
+            "include": ["src"]
+         }],
          "format": "po"
       }
 


### PR DESCRIPTION
Option `localeDir` and `srcPathDirs` are deprecated.
Documentation changed to use `catalogs` instead.