### PR TITLE
feat: add support for runtimeConfigModule w/ Trans

### DIFF
--- a/docs/ref/conf.rst
+++ b/docs/ref/conf.rst
@@ -416,6 +416,20 @@ You may use a different named export:
 
 .. config:: sourceLocale
 
+In some advanced cases you may also need to change the module from which
+`Trans` is imported. To do that, pass an object to `runtimeConfigModule`:
+
+.. code-block:: jsx
+
+   // If you import `i18n` object from custom module like this:
+   import { Trans, i18n } from "./custom-config"
+
+   // ... then add following line to Lingui configuration:
+   // "runtimeConfigModule": {
+   //   i18n: ["./custom-config", "i18n"],
+   //   Trans: ["./custom-config", "Trans"]
+   // }
+
 sourceLocale
 ------------
 

--- a/packages/conf/src/index.ts
+++ b/packages/conf/src/index.ts
@@ -27,6 +27,8 @@ type DefaultLocaleObject = {
 }
 export type FallbackLocales = LocaleObject | DefaultLocaleObject | false
 
+type ModuleSource = [string, string?];
+
 export type LinguiConfig = {
   catalogs: CatalogConfig[]
   compileNamespace: string
@@ -39,7 +41,7 @@ export type LinguiConfig = {
   orderBy: OrderBy
   pseudoLocale: string
   rootDir: string
-  runtimeConfigModule: [string, string?]
+  runtimeConfigModule: ModuleSource | {[symbolName: string]: ModuleSource},
   sourceLocale: string
 }
 

--- a/packages/macro/src/index.ts
+++ b/packages/macro/src/index.ts
@@ -5,7 +5,27 @@ import MacroJS from "./macroJs"
 import MacroJSX from "./macroJsx"
 
 const config = getConfig({ configPath: process.env.LINGUI_CONFIG })
-const [i18nImportModule, i18nImportName = "i18n"] = config.runtimeConfigModule
+
+const getSymbolSource = (name: string) => {
+  if (Array.isArray(config.runtimeConfigModule)) {
+    if (name === "i18n") {
+      return config.runtimeConfigModule
+    } else {
+      return ["@lingui/react", name]
+    }
+  } else {
+    if (
+      Object.prototype.hasOwnProperty.call(config.runtimeConfigModule, name)
+    ) {
+      return config.runtimeConfigModule[name]
+    } else {
+      return ["@lingui/react", name]
+    }
+  }
+}
+
+const [i18nImportModule, i18nImportName = `i18n`] = getSymbolSource(`i18n`)
+const [TransImportModule, TransImportName = `Trans`] = getSymbolSource(`Trans`)
 
 function macro({ references, state, babel }) {
   const jsxNodes = []
@@ -47,7 +67,7 @@ function macro({ references, state, babel }) {
   }
 
   if (jsxNodes.length) {
-    addImport(babel, state, "@lingui/react", "Trans")
+    addImport(babel, state, TransImportModule, TransImportName)
   }
 
   if (process.env.LINGUI_EXTRACT === "1") {
@@ -61,7 +81,8 @@ function addImport(babel, state, module, importName) {
   const { types: t } = babel
 
   const linguiImport = state.file.path.node.body.find(
-    (importNode) =>t.isImportDeclaration(importNode) &&
+    (importNode) =>
+      t.isImportDeclaration(importNode) &&
       importNode.source.value === module &&
       // https://github.com/lingui/js-lingui/issues/777
       importNode.importKind !== "type"

--- a/packages/macro/src/index.ts
+++ b/packages/macro/src/index.ts
@@ -24,8 +24,8 @@ const getSymbolSource = (name: string) => {
   }
 }
 
-const [i18nImportModule, i18nImportName = `i18n`] = getSymbolSource(`i18n`)
-const [TransImportModule, TransImportName = `Trans`] = getSymbolSource(`Trans`)
+const [i18nImportModule, i18nImportName = "i18n"] = getSymbolSource("i18n")
+const [TransImportModule, TransImportName = "Trans"] = getSymbolSource("Trans")
 
 function macro({ references, state, babel }) {
   const jsxNodes = []


### PR DESCRIPTION
The `runtimeConfigModule` setting cannot be used to transform the hardcoded `import {Trans} from '@lingui/react'` statements, which is problematic when the `Trans` symbol is expected to be provided by an intermediary layer (#822).

This diff addresses that by adding support for `runtimeConfigModule` being an object, in which case the key is the symbol name (either `i18n` or `Trans`), and the value is the symbol name and from where to import it. This change is completely backward compatible, only adding syntax.

The test framework doesn't seem to allow for testing `runtimeConfigModule` (its current implementation doesn't seem tested) so I couldn't add relevant tests.