### PR TITLE
fix: accept pseudolocalization in SelectOrdinal

### DIFF
--- a/packages/cli/src/api/pseudoLocalize.test.ts
+++ b/packages/cli/src/api/pseudoLocalize.test.ts
@@ -68,6 +68,16 @@ describe("PseudoLocalization", () => {
     })
   })
 
+  it("SelectOrdinal", () => {
+    expect(
+      pseudoLocalize(
+        "{count, selectordinal, offset:1 one {1st} two {2nd} few {3rd} =4 {4th} many {testMany} other {#th}}"
+      )
+    ).toEqual(
+      "{count, selectordinal, offset:1 one {1śţ} two {2ńď} few {3ŕď} =4 {4ţĥ} many {ţēśţMàńŷ} other {#ţĥ}}"
+    )
+  })
+
   it("should not pseudolocalize variables", () => {
     expect(pseudoLocalize("replace {count}")).toEqual("ŕēƥĺàćē {count}")
     expect(pseudoLocalize("replace { count }")).toEqual("ŕēƥĺàćē { count }")

--- a/packages/cli/src/api/pseudoLocalize.ts
+++ b/packages/cli/src/api/pseudoLocalize.ts
@@ -16,9 +16,9 @@ Example: https://regex101.com/r/bDHD9z/3
 const HTMLRegex = /<\/?\w+((\s+\w+(\s*=\s*(?:".*?"|'.*?'|[^'">\s]+))?)+\s*|\s*)\/?>/g
 /*
 Regex should match js-lingui plurals
-Example: https://regex101.com/r/utnbQw/3
+Example: https://regex101.com/r/utnbQw/4
 */
-const PluralRegex = /({\w*,\s*plural,(.|\n)*?{)|(}\s*(offset|zero|one|two|few|many|other)\s*{)/g
+const PluralRegex = /({\w*,\s*(plural|selectordinal),(.|\n)*?{)|(}\s*(offset|zero|one|two|few|many|other)\s*{)/g
 /*
 Regex should match js-lingui variables
 Example: https://regex101.com/r/dw1QHb/2


### PR DESCRIPTION
It correctly pseudolocalize SelectOrdinal. I have also tried to fix Select
```
<Select value={gender} male="His book" female="Her book" other="Their book" />
```

After extraction the message is:

```
{gender, select, other {Their book}}
```

It looks to me like a bug. I would expect `male` and `female` to be in the message as well.

