### PR TITLE
fix: prevent adding undefined msgid to messages

### DIFF
--- a/packages/babel-plugin-extract-messages/src/index.ts
+++ b/packages/babel-plugin-extract-messages/src/index.ts
@@ -19,6 +19,9 @@ function addMessage(
   messages,
   { id, message: newDefault, origin, comment, ...props }
 ) {
+  // prevent from adding undefined msgid
+  if (id === undefined) return
+
   if (messages.has(id)) {
     const message = messages.get(id)
 
@@ -27,15 +30,15 @@ function addMessage(
       throw path.buildCodeFrameError(
         "Different defaults for the same message ID."
       )
-    } else {
-      if (newDefault) {
-        message.message = newDefault
-      }
+    }
 
-      ;[].push.apply(message.origin, origin)
-      if (comment) {
-        ;[].push.apply(message.extractedComments, [comment])
-      }
+    if (newDefault) {
+      message.message = newDefault
+    }
+
+    ;[].push.apply(message.origin, origin)
+    if (comment) {
+      ;[].push.apply(message.extractedComments, [comment])
     }
   } else {
     const extractedComments = comment ? [comment] : []

--- a/packages/babel-plugin-extract-messages/test/fixtures/js-with-macros.js
+++ b/packages/babel-plugin-extract-messages/test/fixtures/js-with-macros.js
@@ -20,3 +20,9 @@ const withTId = t({
   id: "ID Some",
   message: "Message with id some"
 })
+
+const id = 'message id'
+
+const withUnknownId = t({
+  id: id
+})


### PR DESCRIPTION
Changes in `babel-plugin-extract-messages` packages:
- added reproduction test case where undefined msgid is being generated
- added a fix for that test case
- refactored related function a bit

Closes #905