### PR TITLE
docs: fix typo in macro doc

### DIFF
--- a/docs/ref/macro.rst
+++ b/docs/ref/macro.rst
@@ -145,7 +145,7 @@ Examples of JS macros
 +-------------------------------------------------------------+--------------------------------------------------------------------+
 | .. code-block:: js                                          | .. code-block:: js                                                 |
 |                                                             |                                                                    |
-|    describeMessage({                                        |    /*i18n*/{                                                       |
+|    defineMessage({                                          |    /*i18n*/{                                                       |
 |       id: "msg.refresh",                                    |      id: "msg.refresh",                                            |
 |       message: "Refresh inbox"                              |      message: "Refresh inbox"                                      |
 |    })                                                       |    }                                                               |


### PR DESCRIPTION
This file corresponds to this page https://lingui.js.org/ref/macro.html