### PR TITLE
docs: update core javascript docs for setupI18n

### DIFF
--- a/docs/ref/core.rst
+++ b/docs/ref/core.rst
@@ -225,30 +225,23 @@ Reference
          // const i18n = setupI18n()
          // i18n.activate("en", ["en-UK", "ar-AS"])
 
-   .. js:attribute:: options.catalogs
+   .. js:attribute:: options.messages
 
-      Initial :js:data:`Catalogs`.
+      Initial :js:data:`Messages`.
 
       .. code-block:: jsx
 
          import { setupI18n } from "@lingui/core"
 
-         const catalogs =  {
-            en: {
-               "Hello": "Hello",
-               "Good bye": "Good bye"
-            },
-            cs: {
-               "Hello": "Ahoj",
-               "Good bye": "Nashledanou"
-            }
+         const messages: {
+           en: require("./locale/en/messages").messages, // your path to compiled messages here
+           cs: require("./locale/cs/messages").messages  // your path to compiled messages here
          }
-
-         const i18n = setupI18n({ catalogs })
+         const i18n = setupI18n({ messages })
 
          // This is a shortcut for:
          // const i18n = setupI18n()
-         // i18n.load(catalogs)
+         // i18n.load(messages)
 
    .. js:attribute:: options.missing
 

--- a/docs/ref/core.rst
+++ b/docs/ref/core.rst
@@ -273,8 +273,7 @@ Reference
 
 .. js:data:: Catalogs
 
-   Type of ``catalogs`` parameters in :js:func:`setupI18n <options.catalogs>`
-   constructor and :js:meth:`I18n.load` method:
+   Type of ``catalogs`` parameters in :js:meth:`I18n.load` method:
 
    .. code-block:: js
 


### PR DESCRIPTION
option catalogs was replaced with option messages
also clearer example to use compiled messages rather than the inconsistent use of catalogs/messages