### PR TITLE
fix: Use LINGUI_CONFIG env as fallback for extract

### DIFF
--- a/packages/cli/src/lingui-extract.ts
+++ b/packages/cli/src/lingui-extract.ts
@@ -83,7 +83,9 @@ if (require.main === module) {
     .option("--format <format>", "Format of message catalogs")
     .parse(process.argv)
 
-  const config = getConfig({ configPath: program.config })
+  const config = getConfig({
+    configPath: program.config || process.env.LINGUI_CONFIG,
+  })
 
   let hasErrors = false
   if (program.format) {


### PR DESCRIPTION
Tiny fix where `macro` package is using the `LINGUI_CONFIG` env while extract command isn't. In the case of different config locations, this is causing problems. I know there is `--config` for extract, but that means having a path specified in two different ways.

Only thing I am not sure of if the env variable should take precedence over CLI arg. I chose not, but let me know.