### PR TITLE
fix: compilerBabelOptions jest-validate

### DIFF
--- a/packages/cli/src/api/compile.ts
+++ b/packages/cli/src/api/compile.ts
@@ -1,5 +1,5 @@
 import * as t from "@babel/types"
-import generate from "@babel/generator"
+import generate, { GeneratorOptions } from "@babel/generator"
 import { parse } from "messageformat-parser"
 import * as R from "ramda"
 
@@ -15,7 +15,7 @@ export type CreateCompileCatalogOptions = {
   strict?: boolean
   namespace?: CompiledCatalogNamespace
   pseudoLocale?: string
-  compilerBabelOptions?: Record<string, unknown>
+  compilerBabelOptions?: GeneratorOptions
 }
 
 export function createCompiledCatalog(

--- a/packages/conf/index.d.ts
+++ b/packages/conf/index.d.ts
@@ -1,3 +1,5 @@
+import type { GeneratorOptions } from "@babel/core";
+
 export declare type CatalogFormat = "lingui" | "minimal" | "po" | "csv" | "po-gettext";
 export type CatalogFormatOptions = {
     origins?: boolean;
@@ -24,7 +26,7 @@ export declare type LinguiConfig = {
     catalogs: CatalogConfig[];
     compileNamespace: string;
     extractBabelOptions: Record<string, unknown>;
-    compilerBabelOptions: Record<string, unknown>;
+    compilerBabelOptions: GeneratorOptions;
     fallbackLocales: FallbackLocales;
     format: CatalogFormat;
     prevFormat: CatalogFormat;
@@ -52,7 +54,7 @@ export declare const configValidation: {
             plugins: string[];
             presets: string[];
         };
-        compilerBabelOptions: Record<string, unknown>;
+        compilerBabelOptions: GeneratorOptions;
         catalogs: CatalogConfig[];
         compileNamespace: string;
         fallbackLocales: FallbackLocales;

--- a/packages/conf/src/__snapshots__/index.test.ts.snap
+++ b/packages/conf/src/__snapshots__/index.test.ts.snap
@@ -110,7 +110,12 @@ Object {
   ],
   catalogsMergePath: ,
   compileNamespace: cjs,
-  compilerBabelOptions: Object {},
+  compilerBabelOptions: Object {
+    jsescOption: Object {
+      minimal: true,
+    },
+    minified: true,
+  },
   extractBabelOptions: Object {
     plugins: Array [],
     presets: Array [],

--- a/packages/conf/src/index.ts
+++ b/packages/conf/src/index.ts
@@ -1,3 +1,4 @@
+import type { GeneratorOptions } from "@babel/core"
 import path from "path"
 import fs from "fs"
 import chalk from "chalk"
@@ -33,7 +34,7 @@ export type LinguiConfig = {
   catalogs: CatalogConfig[]
   compileNamespace: string
   extractBabelOptions: Record<string, unknown>
-  compilerBabelOptions: Record<string, unknown>
+  compilerBabelOptions: GeneratorOptions
   fallbackLocales?: FallbackLocales
   format: CatalogFormat
   formatOptions: CatalogFormatOptions
@@ -65,7 +66,12 @@ export const defaultConfig: LinguiConfig = {
   ],
   catalogsMergePath: "",
   compileNamespace: "cjs",
-  compilerBabelOptions: {},
+  compilerBabelOptions: {
+    minified: true,
+    jsescOption: {
+      minimal: true,
+    }
+  },
   extractBabelOptions: { plugins: [], presets: [] },
   fallbackLocales: {},
   format: "po",
@@ -251,7 +257,7 @@ export function replaceRootDir(
     } else if (typeof value === "string") {
       return replace(value)
     } else if (Array.isArray(value)) {
-      return value.map((item) => replaceDeep(item, rootDir)) as any
+      return (value as any).map((item) => replaceDeep(item, rootDir))
     } else if (typeof value === "object") {
       Object.keys(value).forEach((key) => {
         const newKey = replaceDeep(key, rootDir)


### PR DESCRIPTION
Will close #935 

unfortunately jest-validate doesn't work if in the example config we set an empty object, we must strict declare the values we accept. I'll setup the default values that we're using and probably the only ones that the final user should be able to change.. Dunno

