### PR TITLE
docs(setup-react): correct links to react and macro pages

### DIFF
--- a/docs/tutorials/setup-react.rst
+++ b/docs/tutorials/setup-react.rst
@@ -122,7 +122,7 @@ Further reading
 Checkout these reference guides for full documentation:
 
 - :doc:`ICU Message Format </ref/message-format>`
-- :doc:`React reference </ref/macro>`
-- :doc:`Macro reference </ref/react>`
+- :doc:`React reference </ref/react>`
+- :doc:`Macro reference </ref/macro>`
 - :doc:`CLI reference </ref/cli>`
 - :doc:`Configuration reference </ref/conf>`


### PR DESCRIPTION
React and macro links was mixed up