### PR TITLE
fix: wrong prop type of Trans macro

### DIFF
--- a/packages/macro/index.d.ts
+++ b/packages/macro/index.d.ts
@@ -31,7 +31,7 @@ export function defineMessage(descriptor: MessageDescriptor): MessageDescriptor
 export type TransProps = {
   id?: string
   comment?: string
-  component?: ReactElement<any, any> | null
+  component?: React.ComponentType<TransRenderProps>
   render?: (props: TransRenderProps) => ReactElement<any, any> | null
 }
 


### PR DESCRIPTION
The `component` prop of `<Trans/>` macro is incorrect, which should be consistent of https://github.com/lingui/js-lingui/blob/main/packages/react/src/Trans.tsx#L19.

This code will raises TS error without fix:

```tsx
import { Plural, Trans } from '@lingui/macro'

const Div = () => <div />

function Index() {
  return (
    <div>
      <Trans component={Div}>go back</Trans>
      {/*  Type Error:  ↑↑↑ */}

      <Plural
        id="message"
        value={1}
        _0="no messages"
        one="# message"
        other="# messages"
        component={Div}
{/*   Type Error:  ↑↑↑ */}
      />
    </div>
  )
}

```