### PR TITLE
No message when translations are missing

### DIFF
--- a/packages/cli/src/api/catalog.ts
+++ b/packages/cli/src/api/catalog.ts
@@ -264,7 +264,8 @@ export class Catalog {
       const configLocales = this.config.locales.join('", "')
       
       if (!catalogs[locale].hasOwnProperty(key)) {
-        throw `Message with key ${key} is missing in locale ${locale}`
+        console.error(`Message with key ${key} is missing in locale ${locale}`);
+        return null;
       }
 
       

--- a/packages/cli/src/api/catalog.ts
+++ b/packages/cli/src/api/catalog.ts
@@ -262,6 +262,12 @@ export class Catalog {
 
     const getTranslation = (locale) => {
       const configLocales = this.config.locales.join('", "')
+      
+      if (!catalogs[locale].hasOwnProperty(key)) {
+        throw `Message with key ${key} is missing in locale ${locale}`
+      }
+
+      
       if (catalogs[locale]) {
         return catalogs[locale][key].translation
       }


### PR DESCRIPTION
Hello, 
I stumble upon this issue quite frequently, sometimes someone at team accidentally deletes a string in one of translations files and it throws a generic error. 

Error:
![image](https://user-images.githubusercontent.com/24235083/106019804-57a12580-60c3-11eb-8fd0-79c965ac7a0c.png)

I saw your if check few lines before the crashing point, hovewer that if won't catch it so I moved it to correct scope. 

My fix results into this:

![image](https://user-images.githubusercontent.com/24235083/106020241-d7c78b00-60c3-11eb-8aad-3cf791ddcf4e.png)

