### PR TITLE
fix(@lingui/loader): accept webpack 5.x as a peer dependency

### DIFF
--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -39,6 +39,6 @@
     "memory-fs": "^0.5.0"
   },
   "peerDependencies": {
-    "webpack": "^4.0.0"
+    "webpack": "^4.0.0 || ^5.0.0"
   }
 }


### PR DESCRIPTION
npm 7 mandates matching peer dependencies. See RFC 25.

Fixes "Could not resolve dependency: npm ERR! peer webpack@"^4.0.0" from @lingui/loader"

@lingui/loader works perfectly fine with Webpack 5.x and a medium-size project.