### PR TITLE
fix: runtimeConfigModule config validation

### DIFF
--- a/packages/conf/src/index.ts
+++ b/packages/conf/src/index.ts
@@ -148,6 +148,7 @@ export function getConfig({
 
 const exampleConfig = {
   ...defaultConfig,
+  runtimeConfigModule: multipleValidOptions({i18n: ["@lingui/core", "i18n"], Trans: ["@lingui/react", "Trans"]}, ["@lingui/core", "i18n"]),
   fallbackLocales: multipleValidOptions(
     {},
     { "en-US": "en" },


### PR DESCRIPTION
It seems like the validation got stricter, and `runtimeConfigModule` alternative syntax (#895) wasn't covered.