### PR TITLE
docs: Added simpleen.io to tooling section

### DIFF
--- a/docs/misc/tooling.rst
+++ b/docs/misc/tooling.rst
@@ -8,3 +8,4 @@ Tooling
 
    "`storybook-addon-linguijs <https://www.npmjs.com/package/storybook-addon-linguijs>`_", storybook, "Storybook addon to provide language and locale switcher in storybook"
    "`Auto Transation Tool <https://auto-translation.now.sh/>`_", service, "Tool for translating JSON files for LinguiJS"
+   "`simpleen.io <https://simpleen.io/>`_", service, "Online and CLI Tool to machine translate LinguiJS JSON files"


### PR DESCRIPTION
We've created simpleen and support LinguiJS as a preconfigured translator. We handle and translate ICU messages as well.

It would be great to be listed in the docs and help more LinguiJS users translating their projects. 

Really appreciate it
