### PR TITLE
docs: fix broken links

### DIFF
--- a/docs/misc/react-intl.rst
+++ b/docs/misc/react-intl.rst
@@ -230,7 +230,7 @@ to the translator.
 `react-intl`_ comes with the Babel plugin which extracts messages from individual files,
 but it's up to you to merge them into one file which you can send to translators.
 
-`LinguiJS`_ provides handy `CLI <../tutorials/cli>`_ which extracts messages and merges
+`LinguiJS`_ provides handy :doc:`CLI <../tutorials/cli>` which extracts messages and merges
 them with any existing translations. Again, the story doesn't end here.
 
 Compiling messages

--- a/docs/ref/macro.rst
+++ b/docs/ref/macro.rst
@@ -2,7 +2,7 @@
 @lingui/macro - Reference
 *************************
 
-``@lingui/macro`` package provides `babel macros <babel-plugin-macros>`_ which
+``@lingui/macro`` package provides `babel macros <https://github.com/kentcdodds/babel-plugin-macros>`_ which
 transforms JavaScript objects and JSX elements into messages in ICU MessageFormat.
 
 Installation

--- a/docs/tutorials/cli.rst
+++ b/docs/tutorials/cli.rst
@@ -189,7 +189,7 @@ The ``locale/_build`` folder and ``locale/*/*.js`` (compiled catalogs) are safe 
 What you do need to keep in VCS are the json files (``locale/*/*.json``) that contain the messages
 for translators. The JavaScript functions that return the actual translations when your app runs in
 production are created from those json files. See
-`Excluding build files <../guides/excluding-build-files>`_ guide for more info.
+:doc:`Excluding build files <../guides/excluding-build-files>` guide for more info.
 
 If you're using a CI, it is a good idea to add the ``yarn extract`` and ``yarn compile``
 commands to your build process.
@@ -197,6 +197,6 @@ commands to your build process.
 Further reading
 ===============
 
-That's it! Checkout `CLI reference <../ref/cli>`_ documentation for more
-info about ``lingui`` commands or `configuration reference <../ref/conf>`_
+That's it! Checkout :doc:`CLI reference <../ref/cli>` documentation for more
+info about ``lingui`` commands or :doc:`configuration reference <../ref/conf>`
 for info about configuration parameters.

--- a/docs/tutorials/react-patterns.rst
+++ b/docs/tutorials/react-patterns.rst
@@ -3,8 +3,8 @@ Common i18n patterns in React
 *****************************
 
 Following page describes the most common i18n patterns in React. It's a follow-up
-to `tutorial <react>`_ with practical examples. See the
-`API reference <../ref/react>`_ for detailed information about all components.
+to :doc:`tutorial <react>` with practical examples. See the
+:doc:`API reference <../ref/react>` for detailed information about all components.
 
 Macros
 ======


### PR DESCRIPTION
I found several internal links are broken in docs. This PR fixes them.