### PR TITLE
fix: use pkgUp.sync to localize package.json

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -59,6 +59,7 @@
     "normalize-path": "^3.0.0",
     "ora": "^5.1.0",
     "papaparse": "^5.3.0",
+    "pkg-up": "^3.1.0",
     "plurals-cldr": "^1.0.4",
     "pofile": "^1.1.0",
     "pseudolocale": "^1.1.0",

--- a/packages/cli/src/api/detect.ts
+++ b/packages/cli/src/api/detect.ts
@@ -1,5 +1,5 @@
 import fs from "fs"
-import path from "path"
+import pkgUp from "pkg-up"
 
 export const projectType = {
   CRA: "CRA",
@@ -7,7 +7,7 @@ export const projectType = {
 }
 
 function getPackageJson() {
-  const packageJsonPath = path.resolve("package.json")
+  const packageJsonPath = pkgUp.sync()
 
   try {
     const json = fs.readFileSync(packageJsonPath, "utf8")

--- a/yarn.lock
+++ b/yarn.lock
@@ -4248,6 +4248,21 @@ child-process@^1.0.2:
   resolved "https://registry.yarnpkg.com/child-process/-/child-process-1.0.2.tgz#98974dc7ed1ee4c6229f8e305fa7313a6885a7f2"
   integrity sha1-mJdNx+0e5MYin44wX6cxOmiFp/I=
 
+chokidar@3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.1.tgz#ee9ce7bbebd2b79f49f304799d5468e31e14e68a"
+  integrity sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==
+  dependencies:
+    anymatch "~3.1.1"
+    braces "~3.0.2"
+    glob-parent "~5.1.0"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.5.0"
+  optionalDependencies:
+    fsevents "~2.3.1"
+
 chokidar@^2.1.8:
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"
@@ -4281,21 +4296,6 @@ chokidar@^3.4.1:
     readdirp "~3.4.0"
   optionalDependencies:
     fsevents "~2.1.2"
-
-chokidar@^3.5.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.1.tgz#ee9ce7bbebd2b79f49f304799d5468e31e14e68a"
-  integrity sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==
-  dependencies:
-    anymatch "~3.1.1"
-    braces "~3.0.2"
-    glob-parent "~5.1.0"
-    is-binary-path "~2.1.0"
-    is-glob "~4.0.1"
-    normalize-path "~3.0.0"
-    readdirp "~3.5.0"
-  optionalDependencies:
-    fsevents "~2.3.1"
 
 chownr@^1.0.1, chownr@^1.1.1, chownr@^1.1.2:
   version "1.1.4"


### PR DESCRIPTION
This will help detect the correct project type in situations where you want to have multiple lingui configs in a project with a shared package.json. 
For example having backend and frontend in separate folders.

I haven't tested this.