### PR TITLE
fix: Report correct number of missing messages in strict mode

### DIFF
--- a/packages/cli/src/lingui-compile.ts
+++ b/packages/cli/src/lingui-compile.ts
@@ -58,9 +58,12 @@ function command(config: LinguiConfig, options) {
       )
 
       if (!options.allowEmpty) {
-        const missing = R.values(messages)
+        const missingMsgIds = R.pipe(
+          R.pickBy(R.isNil),
+          R.keys,
+        )(messages)
 
-        if (missing.some(R.isNil)) {
+        if (missingMsgIds.length > 0) {
           console.error(
             chalk.red(
               `Error: Failed to compile catalog for locale ${chalk.bold(
@@ -71,9 +74,9 @@ function command(config: LinguiConfig, options) {
 
           if (options.verbose) {
             console.error(chalk.red("Missing translations:"))
-            missing.forEach((msgId) => console.log(msgId))
+            missingMsgIds.forEach((msgId) => console.log(msgId))
           } else {
-            console.error(chalk.red(`Missing ${missing.length} translation(s)`))
+            console.error(chalk.red(`Missing ${missingMsgIds.length} translation(s)`))
           }
           console.error()
           process.exit(1)


### PR DESCRIPTION
## Problem

There are two problems about the report of missing translations of `lingui compile --strict`:

1. The command reports the total number of translations not as the number of missing ones.
2. With `--verbose` option, missing values, which are always `undefined`, are reported. It is less useful.

## Changes

This PR fixes the above problems. Under the following situation:

```
$ npx lingui extract
Catalog statistics for src/locales/{locale}/messages:
┌─────────────┬─────────────┬─────────┐
│ Language    │ Total count │ Missing │
├─────────────┼─────────────┼─────────┤
│ en (source) │      4      │    -    │
│ cs          │      4      │    3    │
└─────────────┴─────────────┴─────────┘

(use "npm run extract" to update catalogs with new messages)
(use "npm run compile" to compile catalogs for production)
```

### Before

Reports the total number of translations as the number of missing ones:

```
$ npx lingui compile --strict
Compiling message catalogs…
Error: Failed to compile catalog for locale cs!
Missing 4 translation(s)
```

Reports `undefined` as the missing translations:

```
$ npx lingui compile --strict --verbose
Compiling message catalogs…
en ⇒ src/locales/en/messages.js
Error: Failed to compile catalog for locale cs!
Missing translations:
undefined
Příchozí zprávy
undefined
undefined
```

### After

Reports the correct number of missing translations:

```
$ npx lingui compile --strict
Compiling message catalogs…
Error: Failed to compile catalog for locale cs!
Missing 3 translation(s)
```

Reports missing translation message Ids:

```
$ npx lingui compile --strict --verbose
Compiling message catalogs…
en ⇒ src/locales/en/messages.js
Error: Failed to compile catalog for locale cs!
Missing translations:
Last login on {0}.
See all <0>unread messages</0> or <1>mark them</1> as read.
{messagesCount, plural, one {There's # message in your inbox.} other {There are # messages in your inbox.}}
```


