### PR TITLE
Raise event on missing translation

### DIFF
--- a/docs/ref/core.rst
+++ b/docs/ref/core.rst
@@ -331,3 +331,15 @@ change
 ------
 
 Triggered **after** locale is changed or new catalog is loaded. There are no arguments.
+
+missing
+------
+
+Triggered when a translation is requested with ``i18n._`` that does not exist in the active locale's messages. 
+Information about the locale and message are available from the event.
+
+.. code-block:: js
+
+   i18n.on('missing', (event) => {
+      alert(`alert(`Translation in ${event.locale} for ${event.id} is missing!`)`)
+   })

--- a/packages/core/src/i18n.test.ts
+++ b/packages/core/src/i18n.test.ts
@@ -196,6 +196,24 @@ describe("I18n", function () {
     })
   })
 
+  it("._ should emit missing event for missing translation", () => {
+    const i18n = setupI18n({
+      locale: "en",
+      messages: { en: { exists: "exists" } },
+    })
+
+    const handler = jest.fn()
+    i18n.on("missing", handler)
+    i18n._("exists")
+    expect(handler).toHaveBeenCalledTimes(0)
+    i18n._("missing")
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(handler).toHaveBeenCalledWith({
+      id: "missing",
+      locale: "en",
+    })
+  })
+
   describe("params.missing - handling missing translations", function () {
     it("._ should return custom string for missing translations", function () {
       const i18n = setupI18n({

--- a/packages/core/src/i18n.ts
+++ b/packages/core/src/i18n.ts
@@ -35,6 +35,11 @@ export type MessageDescriptor = {
   values?: Record<string, unknown>
 }
 
+export type MissingMessageEvent = {
+  locale: Locale
+  id: string
+}
+
 type setupI18nProps = {
   locale?: Locale
   locales?: Locales
@@ -45,6 +50,7 @@ type setupI18nProps = {
 
 type Events = {
   change: () => void
+  missing: (event: MissingMessageEvent) => void
 }
 
 export class I18n extends EventEmitter<Events> {
@@ -173,6 +179,10 @@ export class I18n extends EventEmitter<Events> {
     const missing = this._missing
     if (missing && !this.messages[id]) {
       return isFunction(missing) ? missing(this.locale, id) : missing
+    }
+
+    if (!this.messages[id]) {
+      this.emit("missing", { id, locale: this._locale })
     }
 
     if (process.env.NODE_ENV !== "production") {


### PR DESCRIPTION
Implements #990 

i18n instance raises an event when a message id with no resolved translation is found, implementation for if missing is the same as the `missing` option from `setupI18n()`

```js
i18n.on('missing', (event) => {
  console.log(event);
  // { id: 'missing', locale: 'en' }
});
```

I also exported `MissingMessageEvent` for convenience.

I do think the docs would be improved if events were moved into the definition of the I18n class but I didn't want to conflate the two changes so I followed the existing documentation format.