### PR TITLE
docs: explain locales config in the Setup tutorial

### DIFF
--- a/docs/tutorials/react.rst
+++ b/docs/tutorials/react.rst
@@ -186,6 +186,12 @@ We're going to use `CLI` again. Run :cli:`extract` command to extract messages::
 
    Add 'locales' to your configuration. See https://lingui.js.org/ref/conf.html#locales
 
+We need here to fix the configuration. Create a .linguirc file with 
+   
+   {
+      "locales": ["en", "de", "fr"]
+   }
+
 After fixing configuration, let's run :cli:`extract` command again::
 
    $ lingui extract


### PR DESCRIPTION
A new user has no idea how the configuration file should be, so writing "After fixing configuration" in the tutorial is not helping anything.
And actually just putting the locales in the config will make lingui scan the /node_modules/ directory, which will throw a lot of errors. 
So a minimal working .linguirc/config example would be great.