### PR TITLE
fix: exports attribute on package.json, expo compat

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,8 +29,11 @@
     "node": ">=10.0.0"
   },
   "exports": {
-    "require": "./index.js",
-    "import": "./esm/index.js"
+    ".": {
+      "require": "./index.js",
+      "import": "./esm/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "LICENSE",

--- a/packages/detect-locale/package.json
+++ b/packages/detect-locale/package.json
@@ -29,8 +29,11 @@
     "node": ">=10.0.0"
   },
   "exports": {
-    "require": "./index.js",
-    "import": "./esm/index.js"
+    ".": {
+      "require": "./index.js",
+      "import": "./esm/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "LICENSE",

--- a/packages/macro/package.json
+++ b/packages/macro/package.json
@@ -2,7 +2,7 @@
   "name": "@lingui/macro",
   "version": "3.7.0",
   "description": "Macro for generating messages in ICU MessageFormat syntax",
-  "main": "index.ts",
+  "main": "index.js",
   "author": {
     "name": "Tomáš Ehrlich",
     "email": "tomas.ehrlich@gmail.com"


### PR DESCRIPTION
React Native's Metro bundler expects all imports to be declared in the `exports` attribute when there is one defined. 
Lingui imports it (to get the version I guess?) and Metro refuses it as it was not defined as a valid export.
See https://github.com/eemeli/make-plural/issues/15 for a similar issue on the `make-plural` package

The `main` field for `@babel/macro` was also incorrect as there is no `index.ts` in this project.

These 2 changes allowed me to successfully use Lingui on a React Native project.