### PR TITLE
Fix typo in docs:  selectOrdinal should be lowercase ie selectordinal

### DIFF
--- a/docs/ref/macro.rst
+++ b/docs/ref/macro.rst
@@ -441,7 +441,7 @@ cardinal plural forms it uses ordinal forms:
 
    import { i18n } from "@lingui/core"
    const message = i18n._(/*i18n*/{
-     id: '{count, selectOrdinal, one {1st} two {2nd} few {3rd} other {#th}}',
+     id: '{count, selectordinal, one {1st} two {2nd} few {3rd} other {#th}}',
      values: { count }
    })
 


### PR DESCRIPTION
When using macros `selectOrdinal` doesn't work.
The fault lies in this regex which expects the macro to be lowercase:
https://github.com/lingui/js-lingui/blob/f1e1a25acd654c9877147ce3f40bc827bc54987a/packages/cli/src/api/pseudoLocalize.ts#L25

Thus, using `selectOrdinal` leads to `Message cannot be parsed due to syntax errors`

You have to use `selectordinal` instead.