### PR TITLE
docs: Fix syntax of `plural` in docs

### DIFF
--- a/docs/tutorials/javascript.rst
+++ b/docs/tutorials/javascript.rst
@@ -97,8 +97,7 @@ Plurals and selections are possible using plural and select methods:
 
    const count = 42
 
-   plural({
-     value: count,
+   plural(count, {
      one: "# book",
      other: "# books"
    })


### PR DESCRIPTION
I was wondering why `plural` wasn't working in my project:

```
@lingui/macro: Cannot read property 'properties' of undefined Learn more: https://www.npmjs.com/package/@lingui/macro
    at Array.forEach (<anonymous>)
```

Actually it's due to a typo in the docs, related to an old version of LinguiJS.

I think:

```javascript
plural({
  value: count,
  one: "# book",
  other: "# books"
})
```

should be updated to:

```javascript
plural(count, {
  one: "# book",
  other: "# books"
})
```