### PR TITLE
[Feature] Locked Catalogs

### DIFF
--- a/packages/cli/src/api/catalog.ts
+++ b/packages/cli/src/api/catalog.ts
@@ -7,7 +7,12 @@ import glob from "glob"
 import micromatch from "micromatch"
 import normalize from "normalize-path"
 
-import { LinguiConfig, OrderBy, FallbackLocales } from "@lingui/conf"
+import {
+  LinguiConfig,
+  OrderBy,
+  FallbackLocales,
+  CatalogStatus,
+} from "@lingui/conf"
 
 import getFormat, { CatalogFormatter } from "./formats"
 import extract from "./extractors"
@@ -73,6 +78,7 @@ export type GetTranslationsOptions = {
 type CatalogProps = {
   name?: string
   path: string
+  status?: CatalogStatus
   include: Array<string>
   exclude?: Array<string>
 }
@@ -84,9 +90,10 @@ export class Catalog {
   exclude: Array<string>
   config: LinguiConfig
   format: CatalogFormatter
+  status?: CatalogStatus
 
   constructor(
-    { name, path, include, exclude = [] }: CatalogProps,
+    { name, path, include, exclude = [], status = "active" }: CatalogProps,
     config: LinguiConfig
   ) {
     this.name = name
@@ -95,6 +102,7 @@ export class Catalog {
     this.exclude = [this.localeDir, ...exclude.map(normalizeRelativePath)]
     this.config = config
     this.format = getFormat(config.format)
+    this.status = status
   }
 
   make(options: MakeOptions) {
@@ -504,6 +512,7 @@ export function getCatalogs(config: LinguiConfig) {
             path: normalizeRelativePath(catalog.path),
             include,
             exclude,
+            status: catalog.status,
           },
           config
         )
@@ -529,6 +538,7 @@ export function getCatalogs(config: LinguiConfig) {
             path: normalizeRelativePath(catalog.path.replace(NAME, name)),
             include: include.map((path) => path.replace(NAME, name)),
             exclude: exclude.map((path) => path.replace(NAME, name)),
+            status: catalog.status,
           },
           config
         )

--- a/packages/cli/src/lingui-extract-template.ts
+++ b/packages/cli/src/lingui-extract-template.ts
@@ -3,7 +3,7 @@ import program from "commander"
 
 import { getConfig, LinguiConfig } from "@lingui/conf"
 
-import { getCatalogs } from "./api/catalog"
+import { Catalog, getCatalogs } from "./api/catalog"
 import { detect } from "./api/detect"
 
 export type CliExtractTemplateOptions = {
@@ -27,7 +27,9 @@ export default function command(
   process.env.LINGUI_EXTRACT = "1"
 
   options.verbose && console.error("Extracting messages from source files…")
-  const catalogs = getCatalogs(config)
+  const catalogs = getCatalogs(config).filter((c: Catalog) => {
+    return c.status === "active"
+  })
   const catalogStats: { [path: string]: Number } = {}
   catalogs.forEach((catalog) => {
     catalog.makeTemplate({
@@ -36,7 +38,9 @@ export default function command(
       projectType: detect(),
     })
 
-    catalogStats[catalog.templateFile] = Object.keys(catalog.readTemplate()).length
+    catalogStats[catalog.templateFile] = Object.keys(
+      catalog.readTemplate()
+    ).length
   })
 
   Object.entries(catalogStats).forEach(([key, value]) => {

--- a/packages/conf/src/index.ts
+++ b/packages/conf/src/index.ts
@@ -15,11 +15,14 @@ export type CatalogFormatOptions = {
 
 export type OrderBy = "messageId" | "origin"
 
+export type CatalogStatus = "active" | "locked"
+
 type CatalogConfig = {
   name?: string
   path: string
   include: string[]
   exclude?: string[]
+  status?: CatalogStatus
 }
 
 type LocaleObject = {
@@ -72,7 +75,7 @@ export const defaultConfig: LinguiConfig = {
     minified: true,
     jsescOption: {
       minimal: true,
-    }
+    },
   },
   extractBabelOptions: { plugins: [], presets: [] },
   fallbackLocales: {},
@@ -149,7 +152,10 @@ export function getConfig({
 
 const exampleConfig = {
   ...defaultConfig,
-  runtimeConfigModule: multipleValidOptions({i18n: ["@lingui/core", "i18n"], Trans: ["@lingui/react", "Trans"]}, ["@lingui/core", "i18n"]),
+  runtimeConfigModule: multipleValidOptions(
+    { i18n: ["@lingui/core", "i18n"], Trans: ["@lingui/react", "Trans"] },
+    ["@lingui/core", "i18n"]
+  ),
   fallbackLocales: multipleValidOptions(
     {},
     { "en-US": "en" },


### PR DESCRIPTION
This PR implements a first pass at locking a catalog to opt out of future runs of the `extract` command as discussed in #1015.  Locked catalogs have no impact on the `compile` command as we still want to consider locked catalogs as valid and loadable, just frozen in time. Releasing the lock (changing to `"active"` or deleting the property and running `extract` would update/regenerate the catalog). 

### Open Question

1. How should I test this? The CLI`extract` command is currently untested.
2. There is some confusing overlap between `status: "locked"` and `include: []`.  Maybe it makes more sense to keep this use case of "locking" a catalog in user-land by decoupling `include/exclude` from `getCatalogs` and allowing `compile` to compile catalogs regardless of their `include/exclude` patterns. What do you think? It seems like `include/exclude` is specific to `extract`?
