### PR TITLE
fix: extract works with template string id's

### DIFF
--- a/packages/babel-plugin-extract-messages/src/index.ts
+++ b/packages/babel-plugin-extract-messages/src/index.ts
@@ -237,8 +237,8 @@ export default function ({ types: t }) {
                 .get(`properties.${i}.value`)
                 .buildCodeFrameError("Only strings are supported as comments.")
             }
-
-            props[key.name] = value.value
+            const isIdLiteral = !value.value && key.name === "id" && t.isTemplateLiteral(value)
+            props[key.name] = isIdLiteral ? value?.quasis[0]?.value?.cooked : value.value
           })
 
         collectMessage(path, file, props)

--- a/packages/babel-plugin-extract-messages/test/__snapshots__/index.ts.snap
+++ b/packages/babel-plugin-extract-messages/test/__snapshots__/index.ts.snap
@@ -16,6 +16,15 @@ Object {
 
 exports[`@lingui/babel-plugin-extract-messages should extract all messages from JS files (macros) 1`] = `
 Object {
+  Backtick: Object {
+    extractedComments: Array [],
+    origin: Array [
+      Array [
+        js-with-macros.js,
+        24,
+      ],
+    ],
+  },
   Description: Object {
     extractedComments: Array [
       description,

--- a/packages/babel-plugin-extract-messages/test/fixtures/js-with-macros.js
+++ b/packages/babel-plugin-extract-messages/test/fixtures/js-with-macros.js
@@ -21,6 +21,10 @@ const withTId = t({
   message: "Message with id some"
 })
 
+const withTIdBacktick = t({
+  id: `Backtick`
+})
+
 const id = 'message id'
 
 const withUnknownId = t({

--- a/packages/macro/test/js-t.ts
+++ b/packages/macro/test/js-t.ts
@@ -163,6 +163,20 @@ export default [
       `,
   },
   {
+    name: "Support id in template literal",
+    input: `
+        import { t } from '@lingui/macro'
+        const msg = t({ id: \`msgId\` })
+      `,
+    expected: `import { i18n } from "@lingui/core";
+    const msg =
+      i18n._(/*i18n*/
+        {
+          id: \`msgId\`
+        });
+      `,
+  },
+  {
     name: "Newlines after continuation character are removed",
     filename: "js-t-continuation-character.js",
   },


### PR DESCRIPTION
This PR closes issue #957 macro `t` with template string id.