### PR TITLE
fix: unicode chars were extracting with double slashes

### DIFF
--- a/packages/macro/src/macroJs.test.ts
+++ b/packages/macro/src/macroJs.test.ts
@@ -87,7 +87,7 @@ describe("js macro", () => {
       expect(tokens).toEqual([
         {
           type: "text",
-          value: 'Message \\u0020',
+          value: 'Message \/u0020',
         },
       ])
     })

--- a/packages/macro/src/macroJs.ts
+++ b/packages/macro/src/macroJs.ts
@@ -361,7 +361,7 @@ export default class MacroJs {
    */
   clearBackslashes(value: string) {
     // it's an unicode char so we should keep them
-    if (value.includes('\\u')) return value
+    if (value.includes('\\u')) return value.replace(removeExtraScapedLiterals, "\/u")
     // if not we replace the extra scaped literals
     return value.replace(removeExtraScapedLiterals, "`")
   }

--- a/packages/macro/src/macroJsx.ts
+++ b/packages/macro/src/macroJsx.ts
@@ -7,7 +7,7 @@ import { zip, makeCounter } from "./utils"
 import { ID, COMMENT, MESSAGE } from "./constants"
 
 const pluralRuleRe = /(_[\d\w]+|zero|one|two|few|many|other)/
-const removeExtraScapedLiterals = /(?:\\(.))/
+const removeExtraScapedLiterals = /(?:\\(.))/g
 const jsx2icuExactChoice = (value) =>
   value.replace(/_(\d+)/, "=$1").replace(/_(\w+)/, "$1")
 
@@ -365,7 +365,7 @@ export default class MacroJSX {
    * */
   clearBackslashes(value: string) {
     // it's an unicode char so we should keep them
-    if (value.includes('\\u')) return value
+    if (value.includes('\\u')) return value.replace(removeExtraScapedLiterals, "\/u")
     // if not we replace the extra scaped literals
     return value.replace(removeExtraScapedLiterals, "`")
   }


### PR DESCRIPTION
Re-fixes the unicode error we found migrating the passCulture application to v3.

I went for a walk and start to think about this and saw that we weren't extracting correctly the unicodes.

`\\unicode` is not correct => `\unicode`this is correct 

**probably with this adjustment we fix the wrong behaviour when we built the application to production**

About the string failing in development about not being processed as a string, we'll see tomorrow debuggin the node_modules which is the root cause 

![https://media0.giphy.com/media/LmNwrBhejkK9EFP504/200.gif](https://media0.giphy.com/media/LmNwrBhejkK9EFP504/200.gif)

#1022 