### PR TITLE
fix: po-gettext format issues with CLI

### DIFF
--- a/packages/cli/src/api/formats/index.ts
+++ b/packages/cli/src/api/formats/index.ts
@@ -17,6 +17,7 @@ const formats: Record<CatalogFormat, CatalogFormatter> = {
 
 type CatalogFormatOptionsInternal = {
   locale: string
+  disableSelectWarning?: boolean
 } & CatalogFormatOptions
 
 export type CatalogFormatter = {

--- a/packages/cli/src/api/formats/po-gettext.ts
+++ b/packages/cli/src/api/formats/po-gettext.ts
@@ -62,9 +62,13 @@ const serialize = (items: CatalogType, options) =>
       // The extractedComments array may be modified in this method, so create a new array with the message's elements.
       // Destructuring `undefined` is forbidden, so fallback to `[]` if the message has no extracted comments.
       item.extractedComments = [...(message.extractedComments ?? [])]
-
-      if (options.origins) {
-        item.references = message.origin ? message.origin.map(joinOrigin) : []
+      
+      if (options.origins !== false) {
+        if (message.origin && options.lineNumbers === false) {
+          item.references = message.origin.map(msg => msg.slice(0, -1)).map(joinOrigin)
+        } else {
+          item.references = message.origin ? message.origin.map(joinOrigin) : []
+        }
       }
 
       // @ts-ignore: Figure out how to set this flag


### PR DESCRIPTION
I noticed two issues with the `po-gettext` format option:

1. The `disableSelectWarning` flag is not part of the `CatalogFormatOptions` type, and so it is reported as being invalid by the CLI:

<img width="604" alt="Screen Shot 2021-05-25 at 1 32 13 PM" src="https://user-images.githubusercontent.com/26235907/119543287-7e642580-bd5e-11eb-8908-ee1cf18c4968.png">

2. The `po-gettext` format does not properly support the use of `lineNumbers` format option that the standard `po` format option supports. 
