### PR TITLE
fix(core): add string return type to i18n._

### DIFF
--- a/packages/core/src/i18n.ts
+++ b/packages/core/src/i18n.ts
@@ -193,7 +193,7 @@ export class I18n extends EventEmitter<Events> {
 
 
     // hack for parsing unicode values inside a string to get parsed in react native environments
-    if (isString(translation) && /\\u[a-fA-F0-9]{4}/g.test(translation)) return JSON.parse(`"${translation}"`)
+    if (isString(translation) && /\\u[a-fA-F0-9]{4}/g.test(translation)) return JSON.parse(`"${translation}"`) as string;
     if (isString(translation)) return translation
 
     return interpolate(


### PR DESCRIPTION
This adds a cast to the call to `JSON.parse` which allows the `_` function to properly infer the `string` return type.

My only concern is the feat/fix/breaking level of this commit, which changes an `any` to a `string`. For the most part this should be ok, especially given the expected usages of `i18n._` but I want to bring it up in any case.

I love lingui, thanks!