### PR TITLE
fix: Move property def into `conf` package

### DIFF
--- a/packages/cli/src/api/formats/index.ts
+++ b/packages/cli/src/api/formats/index.ts
@@ -17,7 +17,6 @@ const formats: Record<CatalogFormat, CatalogFormatter> = {
 
 type CatalogFormatOptionsInternal = {
   locale: string
-  disableSelectWarning?: boolean
 } & CatalogFormatOptions
 
 export type CatalogFormatter = {

--- a/packages/conf/src/index.ts
+++ b/packages/conf/src/index.ts
@@ -11,6 +11,7 @@ export type CatalogFormat = "lingui" | "minimal" | "po" | "csv"
 export type CatalogFormatOptions = {
   origins?: boolean
   lineNumbers?: boolean
+  disableSelectWarning?: boolean
 }
 
 export type OrderBy = "messageId" | "origin"


### PR DESCRIPTION
@semoal I believe I placed this in the wrong file, the validation of the config object actually happens within the `conf` package, so that was a bit of misreading on my part. I tested this on locally and it suppresses the issue I was describing in #1073 