### PR TITLE
fix: add extract-template for po-gettext format

### DIFF
--- a/packages/cli/src/api/catalog.ts
+++ b/packages/cli/src/api/catalog.ts
@@ -359,8 +359,7 @@ export class Catalog {
       fs.mkdirpSync(basedir)
     }
     const options = { ...this.config.formatOptions, locale: undefined }
-    const poFormat = getFormat("po")
-    poFormat.write(filename, messages, options)
+    this.format.write(filename, messages, options)
   }
 
   writeCompiled(


### PR DESCRIPTION
The previous implemented of `lingui extract-template` command does not work with po-gettext format because of hard-coded `po`. This change support any further `po-xyz` format in the future.