### PR TITLE
feat: Cloud service providers & Translation.io

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,6 +29,7 @@
     "LICENSE",
     "README.md",
     "api",
+    "services",
     "lingui.js",
     "lingui-*.js"
   ],

--- a/packages/cli/src/lingui-extract.ts
+++ b/packages/cli/src/lingui-extract.ts
@@ -68,6 +68,13 @@ export default function command(
     ) 
   }
 
+  // If service key is present in configuration, synchronize with cloud translation platform
+  if (typeof config.service === 'object' && config.service.name && config.service.name.length) {
+    import(`./services/${config.service.name}`)
+      .then(module => module.default(config, options))
+      .catch(err => console.error(`Can't load service module ${config.service.name}`, err))
+  }
+
   return true
 }
 

--- a/packages/cli/src/services/translationIO.ts
+++ b/packages/cli/src/services/translationIO.ts
@@ -1,0 +1,270 @@
+import fs from "fs"
+import { dirname } from "path"
+import PO from "pofile"
+import https from "https"
+import glob from "glob"
+
+// Main sync method, call "Init" or "Sync" depending on the project context
+export default function syncProcess(config, options) {
+  const successCallback = (project) => {
+    console.log(`\n----------\nProject successfully synchronized. Please use this URL to translate: ${project.url}\n----------`)
+  }
+
+  const failCallback = (errors) => {
+    console.error(`\n----------\nSynchronization with Translation.io failed: ${errors.join(', ')}\n----------`)
+  }
+
+  init(config, options, successCallback, (errors) => {
+    if (errors.length && errors[0] === 'This project has already been initialized.') {
+      sync(config, options, successCallback, failCallback)
+    }
+    else {
+      failCallback(errors)
+    }
+  })
+}
+
+// Initialize project with source and existing translations (only first time!)
+// Cf. https://translation.io/docs/create-library#initialization
+function init(config, options, successCallback, failCallback) {
+  const sourceLocale  = config.sourceLocale || 'en'
+  const targetLocales = config.locales.filter((value) => value != sourceLocale)
+  const paths         = poPathsPerLocale(config)
+
+  let segments = {}
+
+  targetLocales.forEach((targetLocale) => {
+    segments[targetLocale] = []
+  })
+
+  // Create segments from source locale PO items
+  paths[sourceLocale].forEach((path) => {
+    let raw = fs.readFileSync(path).toString()
+    let po = PO.parse(raw)
+
+    po.items.filter((item) => !item.obsolete).forEach((item) => {
+      targetLocales.forEach((targetLocale) => {
+        let newSegment = createSegmentFromPoItem(item)
+
+        segments[targetLocale].push(newSegment)
+      })
+    })
+  })
+
+  // Add translations to segments from target locale PO items
+  targetLocales.forEach((targetLocale) => {
+    paths[targetLocale].forEach((path) => {
+      let raw = fs.readFileSync(path).toString()
+      let po = PO.parse(raw)
+
+      po.items.filter((item) => !item.obsolete).forEach((item, index) => {
+        segments[targetLocale][index].target = item.msgstr[0]
+      })
+    })
+  })
+
+  let request = {
+    "client": "lingui",
+    "version": require("../package.json").version,
+    "source_language": sourceLocale,
+    "target_languages": targetLocales,
+    "segments": segments
+  }
+
+  postTio("init", request, config.service.apiKey, (response) => {
+    if (response.errors) {
+      failCallback(response.errors)
+    }
+    else {
+      saveSegmentsToTargetPos(config, paths, response.segments)
+      successCallback(response.project)
+    }
+  }, (error) => {
+    console.error(`\n----------\nSynchronization with Translation.io failed: ${error}\n----------`)
+  })
+}
+
+// Send all source text from PO to Translation.io and create new PO based on received translations
+// Cf. https://translation.io/docs/create-library#synchronization
+function sync(config, options, successCallback, failCallback) {
+  const sourceLocale  = config.sourceLocale || 'en'
+  const targetLocales = config.locales.filter((value) => value != sourceLocale)
+  const paths         = poPathsPerLocale(config)
+
+  let segments = []
+
+  // Create segments with correct source
+  paths[sourceLocale].forEach((path) => {
+    let raw = fs.readFileSync(path).toString()
+    let po = PO.parse(raw)
+
+    po.items.filter((item) => !item.obsolete).forEach((item) => {
+      let newSegment = createSegmentFromPoItem(item)
+
+      segments.push(newSegment)
+    })
+  })
+
+  let request = {
+    "client": "lingui",
+    "version": require("../package.json").version,
+    "source_language": sourceLocale,
+    "target_languages": targetLocales,
+    "segments": segments
+  }
+
+  postTio("sync", request, config.service.apiKey, (response) => {
+    if (response.errors) {
+      failCallback(response.errors)
+    }
+    else {
+      saveSegmentsToTargetPos(config, paths, response.segments)
+      successCallback(response.project)
+    }
+  }, (error) => {
+    console.error(`\n----------\nSynchronization with Translation.io failed: ${error}\n----------`)
+  })
+}
+
+function createSegmentFromPoItem(item) {
+  let segmentIsPlural = item.msgstr.length > 1
+  let segmentHasKey   = item.msgid != item.msgstr[0] && item.msgstr[0].length
+  let segmentType     = !segmentIsPlural && segmentHasKey ? 'key' : 'source' // no key support for plurals!
+
+  let segment = {
+    type: segmentType,
+    source: segmentHasKey ? item.msgstr[0] : item.msgid // if source segment, msgstr may be empty if --overwrite is used
+  }
+
+  if (segmentType === 'key') {
+    segment.key = item.msgid
+  }
+
+  if (item.references.length) {
+    segment.references = item.references
+  }
+
+  if (item.extractedComments.length) {
+    segment.comment = item.extractedComments.join(' | ')
+  }
+
+  return segment
+}
+
+function createPoItemFromSegment(segment) {
+  let segmentIsPlural = "source_plural" in segment
+
+  let item = new PO.Item()
+
+  item.msgid             = segment.type === "key" ? segment.key : segment.source
+  item.msgstr            = [segment.target]
+  item.references        = (segment.references && segment.references.length) ? segment.references : []
+  item.extractedComments = segment.comment ? segment.comment.split(' | ') : []
+
+  //item.msgid_plural = null
+
+  return item
+}
+
+function saveSegmentsToTargetPos(config, paths, segmentsPerLocale) {
+  const NAME = "{name}"
+  const LOCALE = "{locale}"
+
+  Object.keys(segmentsPerLocale).forEach((targetLocale) => {
+    // Remove existing target POs and JS for this target locale
+    paths[targetLocale].forEach((path) => {
+      const jsPath  = path.replace(/\.po?$/, "") + ".js"
+      const dirPath = dirname(path)
+
+      // Remove PO, JS and empty dir
+      if (fs.existsSync(path)) { fs.unlinkSync(path) }
+      if (fs.existsSync(jsPath)) { fs.unlinkSync(jsPath) }
+      if (fs.existsSync(dirPath) && fs.readdirSync(dirPath).length === 0) { fs.rmdirSync(dirPath) }
+    })
+
+    // Find target path (ignoring {name})
+    const localePath = "".concat(config.catalogs[0].path.replace(LOCALE, targetLocale).replace(NAME, ''), ".po")
+    const segments = segmentsPerLocale[targetLocale]
+
+    let po = new PO()
+    let items = []
+
+    segments.forEach((segment) => {
+      let item = createPoItemFromSegment(segment)
+      items.push(item)
+    })
+
+    // Sort items by messageId
+    po.items = items.sort((a, b) => {
+      if (a.msgid < b.msgid) { return -1 }
+      if (a.msgid > b.msgid) { return 1 }
+      return 0
+    })
+
+    // Check that localePath directory exists and save PO file
+    fs.promises.mkdir(dirname(localePath), {recursive: true}).then(() => {
+      po.save(localePath, (err) => {
+        console.error(err)
+      })
+    })
+  })
+}
+
+function poPathsPerLocale(config) {
+  const NAME = "{name}"
+  const LOCALE = "{locale}"
+  const paths = []
+
+  config.locales.forEach((locale) => {
+    paths[locale] = []
+
+    config.catalogs.forEach((catalog) => {
+      const path = "".concat(catalog.path.replace(LOCALE, locale).replace(NAME, "*"), ".po")
+
+      // If {name} is present (replaced by *), list all the existing POs
+      if (path.includes('*')) {
+        paths[locale] = paths[locale].concat(glob.sync(path))
+      }
+      else {
+        paths[locale].push(path)
+      }
+    })
+  })
+
+  return paths
+}
+
+function postTio(action, request, apiKey, successCallback, failCallback) {
+  let jsonRequest = JSON.stringify(request)
+
+  let options = {
+    hostname: 'translation.io',
+    path: '/api/v1/segments/' + action + '.json?api_key=' + apiKey,
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    }
+  }
+
+  let req = https.request(options, (res) => {
+    res.setEncoding('utf8')
+
+    let body = ""
+
+    res.on('data', (chunk) => {
+      body = body.concat(chunk)
+    })
+
+    res.on('end', () => {
+      let response = JSON.parse(body)
+      successCallback(response)
+    })
+  })
+
+  req.on('error', (e) => {
+    failCallback(e)
+  })
+
+  req.write(jsonRequest)
+  req.end()
+}

--- a/packages/cli/src/services/translationIO.ts
+++ b/packages/cli/src/services/translationIO.ts
@@ -52,8 +52,7 @@ function init(config, options, successCallback, failCallback) {
     let raw = fs.readFileSync(path).toString()
     let po = PO.parse(raw)
 
-    // @ts-ignore: Figure out how to set this flag
-    po.items.filter((item) => !item.obsolete).forEach((item) => {
+    po.items.filter((item) => !item['obsolete']).forEach((item) => {
       targetLocales.forEach((targetLocale) => {
         let newSegment = createSegmentFromPoItem(item)
 
@@ -68,8 +67,7 @@ function init(config, options, successCallback, failCallback) {
       let raw = fs.readFileSync(path).toString()
       let po = PO.parse(raw)
 
-      // @ts-ignore: Figure out how to set this flag
-      po.items.filter((item) => !item.obsolete).forEach((item, index) => {
+      po.items.filter((item) => !item['obsolete']).forEach((item, index) => {
         segments[targetLocale][index].target = item.msgstr[0]
       })
     })
@@ -110,8 +108,7 @@ function sync(config, options, successCallback, failCallback) {
     let raw = fs.readFileSync(path).toString()
     let po = PO.parse(raw)
 
-    // @ts-ignore: Figure out how to set this flag
-    po.items.filter((item) => !item.obsolete).forEach((item) => {
+    po.items.filter((item) => !item['obsolete']).forEach((item) => {
       let newSegment = createSegmentFromPoItem(item)
 
       segments.push(newSegment)

--- a/packages/cli/src/services/translationIO.ts
+++ b/packages/cli/src/services/translationIO.ts
@@ -5,7 +5,7 @@ import https from "https"
 import glob from "glob"
 import { format as formatDate } from "date-fns"
 
-const getCreateHeaders = (language = "no") => ({
+const getCreateHeaders = (language) => ({
   "POT-Creation-Date": formatDate(new Date(), "yyyy-MM-dd HH:mmxxxx"),
   "MIME-Version": "1.0",
   "Content-Type": "text/plain; charset=utf-8",

--- a/packages/cli/src/services/translationIO.ts
+++ b/packages/cli/src/services/translationIO.ts
@@ -16,6 +16,11 @@ const getCreateHeaders = (language) => ({
 
 // Main sync method, call "Init" or "Sync" depending on the project context
 export default function syncProcess(config, options) {
+  if (config.format != 'po') {
+    console.error(`\n----------\nTranslation.io service is only compatible with the "po" format. Please update your Lingui configuration accordingly.\n----------`)
+    process.exit(1)
+  }
+
   const successCallback = (project) => {
     console.log(`\n----------\nProject successfully synchronized. Please use this URL to translate: ${project.url}\n----------`)
   }
@@ -219,8 +224,9 @@ function saveSegmentsToTargetPos(config, paths, segmentsPerLocale) {
     fs.promises.mkdir(dirname(localePath), {recursive: true}).then(() => {
       po.save(localePath, (err) => {
         if (err) {
-          console.error('Error while saving target PO files')
+          console.error('Error while saving target PO files:')
           console.error(err)
+          process.exit(1)
         }
       })
     })

--- a/packages/cli/src/services/translationIO.ts
+++ b/packages/cli/src/services/translationIO.ts
@@ -77,7 +77,7 @@ function init(config, options, successCallback, failCallback) {
 
   let request = {
     "client": "lingui",
-    "version": require("../package.json").version,
+    "version": require('@lingui/core/package.json').version,
     "source_language": sourceLocale,
     "target_languages": targetLocales,
     "segments": segments
@@ -120,7 +120,7 @@ function sync(config, options, successCallback, failCallback) {
 
   let request = {
     "client": "lingui",
-    "version": require("../package.json").version,
+    "version": require('@lingui/core/package.json').version,
     "source_language": sourceLocale,
     "target_languages": targetLocales,
     "segments": segments

--- a/packages/cli/src/services/translationIO.ts
+++ b/packages/cli/src/services/translationIO.ts
@@ -113,6 +113,11 @@ function sync(config, options, successCallback, failCallback) {
     "segments": segments
   }
 
+  // Sync and then remove unused segments (not present in the local application) from Translation.io
+  if (options.clean) {
+    request['purge'] = true
+  }
+
   postTio("sync", request, config.service.apiKey, (response) => {
     if (response.errors) {
       failCallback(response.errors)
@@ -204,7 +209,10 @@ function saveSegmentsToTargetPos(config, paths, segmentsPerLocale) {
     // Check that localePath directory exists and save PO file
     fs.promises.mkdir(dirname(localePath), {recursive: true}).then(() => {
       po.save(localePath, (err) => {
-        console.error(err)
+        if (err) {
+          console.error('Error while saving target PO files')
+          console.error(err)
+        }
       })
     })
   })

--- a/packages/cli/src/services/translationIO.ts
+++ b/packages/cli/src/services/translationIO.ts
@@ -52,6 +52,7 @@ function init(config, options, successCallback, failCallback) {
     let raw = fs.readFileSync(path).toString()
     let po = PO.parse(raw)
 
+    // @ts-ignore: Figure out how to set this flag
     po.items.filter((item) => !item.obsolete).forEach((item) => {
       targetLocales.forEach((targetLocale) => {
         let newSegment = createSegmentFromPoItem(item)
@@ -67,6 +68,7 @@ function init(config, options, successCallback, failCallback) {
       let raw = fs.readFileSync(path).toString()
       let po = PO.parse(raw)
 
+      // @ts-ignore: Figure out how to set this flag
       po.items.filter((item) => !item.obsolete).forEach((item, index) => {
         segments[targetLocale][index].target = item.msgstr[0]
       })
@@ -108,6 +110,7 @@ function sync(config, options, successCallback, failCallback) {
     let raw = fs.readFileSync(path).toString()
     let po = PO.parse(raw)
 
+    // @ts-ignore: Figure out how to set this flag
     po.items.filter((item) => !item.obsolete).forEach((item) => {
       let newSegment = createSegmentFromPoItem(item)
 
@@ -146,7 +149,10 @@ function createSegmentFromPoItem(item) {
 
   let segment = {
     type: 'source',                                 // No way to edit text for source language (inside code), so not using "key" here
-    source: itemHasId ? item.msgstr[0] : item.msgid // msgstr may be empty if --overwrite is used and no ID is used
+    source: itemHasId ? item.msgstr[0] : item.msgid, // msgstr may be empty if --overwrite is used and no ID is used
+    context: '',
+    references: [],
+    comment: ''
   }
 
   if (itemHasId) {

--- a/packages/conf/index.d.ts
+++ b/packages/conf/index.d.ts
@@ -1,6 +1,6 @@
 import type { GeneratorOptions } from "@babel/core";
 
-export declare type CatalogFormat = "lingui" | "minimal" | "po" | "csv" | "po-gettext";
+export declare type CatalogFormat = "lingui" | "minimal" | "po" | "csv" | "po-gettext";
 export type CatalogFormatOptions = {
     origins?: boolean;
     lineNumbers?: boolean;
@@ -23,9 +23,9 @@ export type DefaultLocaleObject = {
 
 export declare type FallbackLocales = LocaleObject | DefaultLocaleObject
 
-export type CatalogService = {
-    name: string
-    apiKey: string
+declare type CatalogService = {
+    name: string;
+    apiKey: string;
 }
 
 declare type ExtractorType = {
@@ -51,7 +51,7 @@ export declare type LinguiConfig = {
     rootDir: string;
     runtimeConfigModule: [string, string?];
     sourceLocale: string;
-    service: CatalogService
+    service: CatalogService;
 };
 export declare const defaultConfig: LinguiConfig;
 export declare function getConfig({ cwd, configPath, skipValidation, }?: {
@@ -69,7 +69,7 @@ export declare const configValidation: {
         };
         compilerBabelOptions: GeneratorOptions;
         catalogs: CatalogConfig[];
-        compileNamespace: "es" | "ts" | "cjs" | string;
+        compileNamespace: "es" | "ts" | "cjs" | string;
         fallbackLocales: FallbackLocales;
         format: CatalogFormat;
         formatOptions: CatalogFormatOptions;

--- a/packages/conf/index.d.ts
+++ b/packages/conf/index.d.ts
@@ -23,6 +23,11 @@ export type DefaultLocaleObject = {
 
 export declare type FallbackLocales = LocaleObject | DefaultLocaleObject
 
+export type CatalogService = {
+    name: string
+    apiKey: string
+}
+
 declare type ExtractorType = {
     match(filename: string): boolean;
     extract(filename: string, targetDir: string, options?: any): void;
@@ -46,6 +51,7 @@ export declare type LinguiConfig = {
     rootDir: string;
     runtimeConfigModule: [string, string?];
     sourceLocale: string;
+    service: CatalogService
 };
 export declare const defaultConfig: LinguiConfig;
 export declare function getConfig({ cwd, configPath, skipValidation, }?: {
@@ -73,6 +79,7 @@ export declare const configValidation: {
         rootDir: string;
         runtimeConfigModule: [string, string?];
         sourceLocale: string;
+        service: CatalogService;
     };
     deprecatedConfig: {
         fallbackLocale: (config: LinguiConfig & DeprecatedFallbackLanguage) => string;

--- a/packages/conf/src/__snapshots__/index.test.ts.snap
+++ b/packages/conf/src/__snapshots__/index.test.ts.snap
@@ -138,7 +138,10 @@ Object {
     @lingui/core,
     i18n,
   ],
-  service: Object {},
+  service: Object {
+    apiKey: ,
+    name: ,
+  },
   sourceLocale: ,
 }
 `;

--- a/packages/conf/src/__snapshots__/index.test.ts.snap
+++ b/packages/conf/src/__snapshots__/index.test.ts.snap
@@ -138,6 +138,7 @@ Object {
     @lingui/core,
     i18n,
   ],
+  service: Object {},
   sourceLocale: ,
 }
 `;

--- a/packages/conf/src/index.ts
+++ b/packages/conf/src/index.ts
@@ -33,6 +33,11 @@ export type FallbackLocales = LocaleObject | DefaultLocaleObject | false
 
 type ModuleSource = [string, string?]
 
+type CatalogService = {
+  name: string
+  apiKey: string
+}
+
 type ExtractorType = {
   match(filename: string): boolean
   extract(filename: string, targetDir: string, options?: any): void
@@ -54,6 +59,7 @@ export type LinguiConfig = {
   rootDir: string
   runtimeConfigModule: ModuleSource | { [symbolName: string]: ModuleSource }
   sourceLocale: string
+  service: CatalogService
 }
 
 // Enforce posix path delimiters internally
@@ -91,6 +97,7 @@ export const defaultConfig: LinguiConfig = {
   rootDir: ".",
   runtimeConfigModule: ["@lingui/core", "i18n"],
   sourceLocale: "",
+  service: {}
 }
 
 function configExists(path) {

--- a/packages/conf/src/index.ts
+++ b/packages/conf/src/index.ts
@@ -97,7 +97,7 @@ export const defaultConfig: LinguiConfig = {
   rootDir: ".",
   runtimeConfigModule: ["@lingui/core", "i18n"],
   sourceLocale: "",
-  service: {}
+  service: { name: "", apiKey: "" }
 }
 
 function configExists(path) {


### PR DESCRIPTION
Hello LinguiJS team,

This is a PR proposal that is open for suggestions.

## Context

I'm the founder of [Translation.io](https://translation.io), a cloud service provider that helps localize applications and smooth the syncing process with translators. We decided to push best practices to keep developers and translators happy in the long run. We already support the [Ruby on Rails](https://translation.io/rails) and [Laravel](https://translation.io/laravel) stacks with a decent success.

We tried several times to support JS/React but we didn't like the existing solutions back then. Then we found LinguiJS, and it was exactly what we were looking for all that time: GetText-like easy syntax with simple source code extraction and PO format.

You really did an amazing job! 😄

## Proposal

We have decided to add Lingui as a supported framework. After a quick proof-of-concept demo and a discussion with @semoal, we thought it would be a good idea to create a new configuration option in Lingui for it to be able to work with any cloud service provider, and not only Translation.io

So the idea is to add something like this in the `.linguirc`:

```javascript
"service": {
  "name": "TranslationIO",
  "apiKey": "abcdefghijklmnopqrstuvwxyz123456"
}
```

A new `services` folder has been created for the provider specific workflows.

I created a hook in the `lingui-extract.ts` process to be able to import the service by its name, it will be cleaner when there will be multiple services.

## How it works 

After a `lingui extract`, the service sends the content of all the PO files to Translation.io (or any other provider).

* If it's the first time, the segments will be created on Translation.io (source & translation).
* If it's not the first time, new segments will be created on Translation.io, and new translations will be sent back to your target POs.

The idea would be to **just focus on your code, and never edit your PO files again**!

Source text (usually English) will evolve in your code, and your translations will evolve on Translation.io and pushed back into your code at each `extract` (it works without conflict even if you work on multiple branches, with a process similar to `obsolete` and `--clean`).

Big advantages of a cloud provider is [auto-translation](https://translation.io/blog/automatic-translation-with-google-translate), [interpolation and HTML highlighting](https://translation.io/blog/highlighting-of-html-tags-and-interpolated-variables), (+ warning if missing), [fine-grained collaboration roles](https://translation.io/blog/fine-grained-authorization-and-role-management), history of changes, automatic notification of translators, or ICU plural management (see below).

## Demo

Here is a small demo where you can see the initialization process, the sync process and the translation interface with:

 * Variable interpolation & HTML tags management.
 * ICU Plural management with examples for French and Czech (Czech has 3 plurals).

https://user-images.githubusercontent.com/529357/127163373-3e0a5fb6-0e8b-4e19-8c62-79100b0f9a4a.mp4

## Final notes

I'm convinced that a better symbiosis between LinguiJS and cloud solutions would be beneficial for the library popularity, for LinguiJS users, and of course for cloud solutions themselves.

If you want to test this PR, feel free to: 

 1. Create an account in [Translation.io](https://translation.io).
 2. Create a Lingui project using this magic link https://translation.io/new?lingui
 3. Check the open-source checkbox and use `https://github.com/lingui/js-lingui` as link, it will provide you with a free unlimited access like any other open-source projects using Translation.io.

-----

Any feedback would be of course greatly appreciated 🙂