### PR TITLE
fix: no files being found when catalogs.include has more than one entry

### DIFF
--- a/packages/cli/src/api/catalog.ts
+++ b/packages/cli/src/api/catalog.ts
@@ -514,7 +514,7 @@ export function getCatalogs(config: LinguiConfig) {
 
     const patterns = include.map((path) => path.replace(NAME, "*"))
     const candidates = glob.sync(
-      patterns.length > 1 ? `{${patterns.join(",")}` : patterns[0],
+      patterns.length > 1 ? `{${patterns.join(",")}}` : patterns[0],
       {
         ignore: exclude,
         mark: true,


### PR DESCRIPTION
When catalogs.include contains an array of > 1 globs they are joined together into one expression. This expression is missing an end curly brace } and this fix adds it.