### PR TITLE
fix: wrong detect whether a translation is plural

### DIFF
--- a/packages/cli/src/api/formats/po-gettext.ts
+++ b/packages/cli/src/api/formats/po-gettext.ts
@@ -222,7 +222,7 @@ const convertPluralsToICU = (items: POItemType[], lang?: string) => {
     const messageKey = getMessageKey(item)
 
     // Messages without multiple translations (= plural cases) need no further processing.
-    if (translationCount <= 1) {
+    if (translationCount <= 1 && !item.msgid_plural) {
       return
     }
 


### PR DESCRIPTION
The previous logic is wrong because a language like Vietnamese, Indonesian, Malaysian... does not support plural form, so gettext tools does not allow these kind of to have multiple msgstr. Therefore detecting a plural translation through number of msgstr is not true. As consequence, that causes plural macro can not be replaced with proper translation.

Ex:
```
#. js-lingui:icu=%7BmonthNumber%2C+plural%2C+one+%7B%2F+%23+th%C3%A1ng%7D+other+%7B%2F+%23+th%C3%A1ng%7D%7D&pluralize_on=monthNumber
msgid "/ # tháng"
msgid_plural "/ # tháng"
msgstr[0] "/ # bulan"
```