### PR TITLE
Add missing babel properties to config validation

### DIFF
--- a/packages/conf/src/index.ts
+++ b/packages/conf/src/index.ts
@@ -183,8 +183,10 @@ const exampleConfig = {
     rootMode: "rootmode",
     plugins: ["plugin"],
     presets: ["preset"],
-    targets: multipleValidOptions({}, 'path', ['ie', 'ff'], undefined),
+    targets: multipleValidOptions({}, '> 0.5%', ['> 0.5%', 'not dead'], undefined),
     assumptions: multipleValidOptions({}, undefined),
+    browserslistConfigFile: multipleValidOptions(true, undefined),
+    browserslistEnv: multipleValidOptions('.browserslistrc', undefined),
   },
 }
 

--- a/packages/conf/src/index.ts
+++ b/packages/conf/src/index.ts
@@ -183,6 +183,8 @@ const exampleConfig = {
     rootMode: "rootmode",
     plugins: ["plugin"],
     presets: ["preset"],
+    targets: multipleValidOptions({}, 'path', ['ie', 'ff'], undefined),
+    assumptions: multipleValidOptions({}, undefined),
   },
 }
 


### PR DESCRIPTION
`targets` `browserslistconfigfile` `browserslistenv` `assumptions` was missing in validation, fixes #1133