### PR TITLE
feat(macro): Add support for passing custom i18n instance

### DIFF
--- a/docs/ref/macro.rst
+++ b/docs/ref/macro.rst
@@ -77,7 +77,7 @@ transformed into ``i18n._`` call.
 
    By default, the ``i18n`` object is imported from ``@lingui/core``.
    If you use a custom instance of ``i18n`` object, you need to set
-   :conf:`runtimeConfigModule`
+   :conf:`runtimeConfigModule` or pass a custom instance to :jsmacro:`t`.
 
 The only exception is :jsmacro:`defineMessage` which is transformed into
 message descriptor. In other words, the message isn't translated directly
@@ -119,6 +119,16 @@ Examples of JS macros
 |                                                             |                                                                    |
 |    t`Attachment ${name} saved`                              |    /*i18n*/                                                        |
 |                                                             |    i18n._("Attachment {name} saved", { name })                     |
++-------------------------------------------------------------+--------------------------------------------------------------------+
+| .. code-block:: js                                          | .. code-block:: js                                                 |
+|                                                             |                                                                    |
+|    t(customI18n)`Refresh inbox`                             |    /*i18n*/                                                        |
+|                                                             |    customI18n._("Refresh inbox")                                   |
++-------------------------------------------------------------+--------------------------------------------------------------------+
+| .. code-block:: js                                          | .. code-block:: js                                                 |
+|                                                             |                                                                    |
+|    t(customI18n)`Attachment ${name} saved`                  |    /*i18n*/                                                        |
+|                                                             |    customI18n._("Attachment {name} saved", { name })               |
 +-------------------------------------------------------------+--------------------------------------------------------------------+
 | .. code-block:: js                                          | .. code-block:: js                                                 |
 |                                                             |                                                                    |
@@ -184,7 +194,7 @@ into a *Message Descriptor* wrapped inside of ``i18n._`` call.
 
    By default, the ``i18n`` object is imported from ``@lingui/core``.
    If you use a custom instance of ``i18n`` object, you need to set
-   :conf:`runtimeConfigModule`
+   :conf:`runtimeConfigModule` or pass a custom instance to :jsmacro:`t`.
 
 *Message Descriptor* is an object with message ID, default message and other parameters.
 ``i18n._`` accepts message descriptors and performs translation and formatting:
@@ -264,6 +274,22 @@ other expressions are referenced by numeric index:
    i18n._("Today is {0}", {
      0: new Date()
    });
+
+Optionally, a custom ``i18n`` instance can be passed that can be used
+instead of the global instance:
+
+.. code-block:: jsx
+
+   import { t } from "@lingui/macro"
+   import { i18n } from "./lingui"
+   const message = t(i18n)`Hello World`
+
+   // ↓ ↓ ↓ ↓ ↓ ↓
+
+   import { i18n } from "./lingui"
+   const message =
+   /*i18n*/
+   i18n._("Hello World")
 
 It's also possible to pass custom ``id`` and ``comment`` for translators by
 calling ``t`` macro with a message descriptor:

--- a/packages/macro/global.d.ts
+++ b/packages/macro/global.d.ts
@@ -1,13 +1,68 @@
-declare module '@lingui/macro' {
-  import type { MessageDescriptor } from "@lingui/core"
+declare module "@lingui/macro" {
+  import type { MessageDescriptor, I18n } from "@lingui/core"
 
   export type BasicType = {
     id?: string
     comment?: string
   }
 
+  /**
+   * Translates a message descriptor
+   *
+   * @example
+   * ```
+   * import { t } from "@lingui/macro";
+   * const message = t({
+   *   id: "msg.hello",
+   *   comment: "Greetings at the homepage",
+   *   message: `Hello ${name}`,
+   * });
+   * ```
+   *
+   * @example
+   * ```
+   * import { t } from "@lingui/macro";
+   * const message = t({
+   *   id: "msg.plural",
+   *   message: plural(value, { one: "...", other: "..." }),
+   * });
+   * ```
+   *
+   * @param messageDescriptior The descriptor to translate
+   */
+  export function t(messageDescriptior: MessageDescriptor): string
+
+  /**
+   * Translates a template string using the global I18n instance
+   *
+   * @example
+   * ```
+   * import { t } from "@lingui/macro";
+   * const message = t`Hello ${name}`;
+   * ```
+   */
   export function t(
-    literals: TemplateStringsArray | MessageDescriptor,
+    literals: TemplateStringsArray,
+    ...placeholders: any[]
+  ): string
+
+  /**
+   * Translates a template string using a given I18n instance
+   *
+   * @example
+   * ```
+   * import { t } from "@lingui/macro";
+   * import { I18n } from "@lingui/core";
+   * const i18n = new I18n({
+   *   locale: "nl",
+   *   messages: { "Hello {0}": "Hallo {0}" },
+   * });
+   * const message = t(i18n)`Hello ${name}`;
+   * ```
+   */
+  export function t(
+    i18n: I18n,
+    literals: TemplateStringsArray,
     ...placeholders: any[]
   ): string
 
@@ -21,20 +76,107 @@ declare module '@lingui/macro' {
     other?: T
   } & UnderscoreDigit<T>
 
-  export function plural(arg: number | string, options: ChoiceOptions & BasicType): string
-  export function selectOrdinal(
-    arg: number | string,
+  /**
+   * Pluralize a message
+   *
+   * @example
+   * ```
+   * import { plural } from "@lingui/macro";
+   * const message = plural(count, {
+   *   one: "# Book",
+   *   other: "# Books",
+   * });
+   * ```
+   *
+   * @param value Determines the plural form
+   * @param options Object with available plural forms
+   */
+  export function plural(
+    value: number | string,
     options: ChoiceOptions & BasicType
   ): string
-  export function select(arg: string, choices: Record<string, string> & BasicType): string
+
+  /**
+   * Pluralize a message using ordinal forms
+   *
+   * Similar to `plural` but instead of using cardinal plural forms,
+   * it uses ordinal forms.
+   *
+   * @example
+   * ```
+   * import { selectOrdinal } from "@lingui/macro";
+   * const message = selectOrdinal(count, {
+   *    one: "1st",
+   *    two: "2nd",
+   *    few: "3rd",
+   *    other: "#th",
+   * });
+   * ```
+   *
+   * @param value Determines the plural form
+   * @param options Object with available plural forms
+   */
+  export function selectOrdinal(
+    value: number | string,
+    options: ChoiceOptions & BasicType
+  ): string
+
+  /**
+   * Selects a translation based on a value
+   *
+   * Select works like a switch statement. It will
+   * select one of the forms in `options` object which
+   * key matches exactly `value`.
+   *
+   * @example
+   * ```
+   * import { select } from "@lingui/macro";
+   * const message = select(gender, {
+   *    male: "he",
+   *    female: "she",
+   *    other: "they",
+   * });
+   * ```
+   *
+   * @param value The key of choices to use
+   * @param choices
+   */
+  export function select(
+    value: string,
+    choices: Record<string, string> & BasicType
+  ): string
+
+  /**
+   * Defines multiple messages for extraction
+   */
   export function defineMessages<M extends Record<string, MessageDescriptor>>(
     messages: M
   ): M
-  export function defineMessage(descriptor: MessageDescriptor): MessageDescriptor
+
+  /**
+   * Define a message for later use
+   *
+   * `defineMessage` can be used to add comments for translators,
+   * or to override the message ID.
+   *
+   * @example
+   * ```
+   * import { defineMessage } from "@lingui/macro";
+   * const message = defineMessage({
+   *    comment: "Greetings on the welcome page",
+   *    message: `Welcome, ${name}!`,
+   * });
+   * ```
+   *
+   * @param descriptor The message descriptor
+   */
+  export function defineMessage(
+    descriptor: MessageDescriptor
+  ): MessageDescriptor
 
   export type ChoiceProps = {
     value?: string | number
-  }  & ChoiceOptions<string>
+  } & ChoiceOptions<string>
 
   /**
    * The types should be changed after this PR is merged

--- a/packages/macro/index.d.ts
+++ b/packages/macro/index.d.ts
@@ -1,11 +1,6 @@
 import type { ReactElement, ComponentType, ReactNode } from "react"
-import type { MessageDescriptor } from "@lingui/core"
+import type { MessageDescriptor, I18n } from "@lingui/core"
 import type { TransRenderProps } from "@lingui/react"
-
-export function t(
-  literals: TemplateStringsArray | MessageDescriptor,
-  ...placeholders: any[]
-): string
 
 export type UnderscoreDigit<T = string> = { [digit: string]: T }
 export type ChoiceOptions<T = string> = {
@@ -17,15 +12,156 @@ export type ChoiceOptions<T = string> = {
   other?: T
 } & UnderscoreDigit<T>
 
-export function plural(arg: number | string, options: ChoiceOptions): string
+/**
+ * Translates a message descriptor
+ *
+ * @example
+ * ```
+ * import { t } from "@lingui/macro";
+ * const message = t({
+ *   id: "msg.hello",
+ *   comment: "Greetings at the homepage",
+ *   message: `Hello ${name}`,
+ * });
+ * ```
+ *
+ * @example
+ * ```
+ * import { t } from "@lingui/macro";
+ * const message = t({
+ *   id: "msg.plural",
+ *   message: plural(value, { one: "...", other: "..." }),
+ * });
+ * ```
+ *
+ * @param messageDescriptior The descriptor to translate
+ */
+export function t(messageDescriptior: MessageDescriptor): string
+
+/**
+ * Translates a template string using the global I18n instance
+ *
+ * @example
+ * ```
+ * import { t } from "@lingui/macro";
+ * const message = t`Hello ${name}`;
+ * ```
+ */
+export function t(
+  literals: TemplateStringsArray,
+  ...placeholders: any[]
+): string
+
+/**
+ * Translates a template string using a given I18n instance
+ *
+ * @example
+ * ```
+ * import { t } from "@lingui/macro";
+ * import { I18n } from "@lingui/core";
+ * const i18n = new I18n({
+ *   locale: "nl",
+ *   messages: { "Hello {0}": "Hallo {0}" },
+ * });
+ * const message = t(i18n)`Hello ${name}`;
+ * ```
+ */
+export function t(
+  i18n: I18n,
+  literals: TemplateStringsArray,
+  ...placeholders: any[]
+): string
+
+/**
+ * Pluralize a message
+ *
+ * @example
+ * ```
+ * import { plural } from "@lingui/macro";
+ * const message = plural(count, {
+ *   one: "# Book",
+ *   other: "# Books",
+ * });
+ * ```
+ *
+ * @param value Determines the plural form
+ * @param options Object with available plural forms
+ */
+export function plural(value: number | string, options: ChoiceOptions): string
+
+/**
+ * Pluralize a message using ordinal forms
+ *
+ * Similar to `plural` but instead of using cardinal plural forms,
+ * it uses ordinal forms.
+ *
+ * @example
+ * ```
+ * import { selectOrdinal } from "@lingui/macro";
+ * const message = selectOrdinal(count, {
+ *    one: "1st",
+ *    two: "2nd",
+ *    few: "3rd",
+ *    other: "#th",
+ * });
+ * ```
+ *
+ * @param value Determines the plural form
+ * @param options Object with available plural forms
+ */
 export function selectOrdinal(
-  arg: number | string,
+  value: number | string,
   options: ChoiceOptions
 ): string
-export function select(arg: string, choices: Record<string, string>): string
+
+/**
+ * Selects a translation based on a value
+ *
+ * Select works like a switch statement. It will
+ * select one of the forms in `options` object which
+ * key matches exactly `value`.
+ *
+ * @example
+ * ```
+ * import { select } from "@lingui/macro";
+ * const message = select(gender, {
+ *    male: "he",
+ *    female: "she",
+ *    other: "they",
+ * });
+ * ```
+ *
+ * @param value The key of choices to use
+ * @param choices
+ */
+export function select(value: string, choices: ChoiceOptions): string
+
+/**
+ * Defines multiple messages for extraction
+ *
+ * @see {@link defineMessage} for more details
+ */
 export function defineMessages<M extends Record<string, MessageDescriptor>>(
   messages: M
 ): M
+
+/**
+ * Define a message for later use
+ *
+ * `defineMessage` can be used to add comments for translators,
+ * or to override the message ID.
+ *
+ * @example
+ * ```
+ * import { defineMessage } from "@lingui/macro";
+ * const message = defineMessage({
+ *    comment: "Greetings on the welcome page",
+ *    message: `Welcome, ${name}!`,
+ * });
+ * ```
+ *
+ * @param descriptor The message descriptor
+ */
 export function defineMessage(descriptor: MessageDescriptor): MessageDescriptor
 
 export type TransProps = {

--- a/packages/macro/src/index.ts
+++ b/packages/macro/src/index.ts
@@ -30,6 +30,7 @@ const [TransImportModule, TransImportName = "Trans"] = getSymbolSource("Trans")
 function macro({ references, state, babel }) {
   const jsxNodes = []
   const jsNodes = []
+  let needsI18nImport = false
 
   Object.keys(references).forEach((tagName) => {
     const nodes = references[tagName]
@@ -53,7 +54,7 @@ function macro({ references, state, babel }) {
   jsNodes.filter(isRootPath(jsNodes)).forEach((path) => {
     if (alreadyVisited(path)) return
     const macro = new MacroJS(babel, { i18nImportName })
-    macro.replacePath(path)
+    if (macro.replacePath(path)) needsI18nImport = true
   })
 
   jsxNodes.filter(isRootPath(jsxNodes)).forEach((path) => {
@@ -62,7 +63,7 @@ function macro({ references, state, babel }) {
     macro.replacePath(path)
   })
 
-  if (jsNodes.length) {
+  if (needsI18nImport) {
     addImport(babel, state, i18nImportModule, i18nImportName)
   }
 

--- a/packages/macro/src/macroJs.test.ts
+++ b/packages/macro/src/macroJs.test.ts
@@ -20,6 +20,18 @@ describe("js macro", () => {
       ])
     })
 
+    it("with custom lingui instance", () => {
+      const macro = createMacro()
+      const exp = parseExpression("t(i18n)`Message`")
+      const tokens = macro.tokenizeTemplateLiteral(exp)
+      expect(tokens).toEqual([
+        {
+          type: "text",
+          value: "Message",
+        },
+      ])
+    })
+
     it("message with named argument", () => {
       const macro = createMacro()
       const exp = parseExpression("t`Message ${name}`")
@@ -82,50 +94,52 @@ describe("js macro", () => {
 
     it("message with unicode \\u chars is interpreted by babel", () => {
       const macro = createMacro()
-      const exp = parseExpression('t`Message \\u0020`')
+      const exp = parseExpression("t`Message \\u0020`")
       const tokens = macro.tokenizeTemplateLiteral(exp)
       expect(tokens).toEqual([
         {
           type: "text",
-          value: 'Message  ',
+          value: "Message  ",
         },
       ])
     })
 
     it("message with unicode \\x chars is interpreted by babel", () => {
       const macro = createMacro()
-      const exp = parseExpression('t`Bienvenue\\xA0!`')
+      const exp = parseExpression("t`Bienvenue\\xA0!`")
       const tokens = macro.tokenizeTemplateLiteral(exp)
       expect(tokens).toEqual([
         {
           type: "text",
-          // Looks like an empty space, but it isn't 
-          value: 'Bienvenue !',
+          // Looks like an empty space, but it isn't
+          value: "Bienvenue !",
         },
       ])
     })
 
     it("message with double scaped literals it's stripped", () => {
       const macro = createMacro()
-      const exp = parseExpression('t\`Passing \\`${argSet}\\` is not supported.\`')
+      const exp = parseExpression(
+        "t`Passing \\`${argSet}\\` is not supported.`"
+      )
       const tokens = macro.tokenizeTemplateLiteral(exp)
       expect(tokens).toEqual([
         {
           type: "text",
-          value: 'Passing `',
+          value: "Passing `",
         },
         {
           name: "argSet",
           type: "arg",
           value: {
             end: 20,
-            loc:  {
-              end:  {
+            loc: {
+              end: {
                 column: 20,
                 line: 1,
               },
               identifierName: "argSet",
-              start:  {
+              start: {
                 column: 14,
                 line: 1,
               },
@@ -298,7 +312,7 @@ describe("js macro", () => {
           female: "she",
           male: "he",
           offset: undefined,
-          other: "they"
+          other: "they",
         }),
         type: "arg",
         value: {
@@ -317,7 +331,7 @@ describe("js macro", () => {
           name: "gender",
           start: 7,
           type: "Identifier",
-        }
+        },
       })
     })
   })

--- a/packages/macro/test/js-t.ts
+++ b/packages/macro/test/js-t.ts
@@ -13,6 +13,20 @@ export default [
     `,
   },
   {
+    name: "Macro is used in expression assignment, with custom lingui instance",
+    input: `
+        import { t } from '@lingui/macro';
+        import { i18n } from './lingui';
+        const a = t(i18n)\`Expression assignment\`;
+    `,
+    expected: `
+        import { i18n } from './lingui';
+        const a =
+          /*i18n*/
+          i18n._("Expression assignment")
+    `,
+  },
+  {
     name: "Variables are replaced with named arguments",
     input: `
         import { t } from '@lingui/macro';


### PR DESCRIPTION
This allows developers that work in concurrent rendering environments
to use a Lingui instance that is locale-specific, without risking global
Lingui to be switched to another locale.

In React, `<I18nProvider>` may be used to provide a locale-specific
Lingui instance, and it can be retrieved by using `useLingui`. After
that, the instance can be passed as argument to the `t` macro and
it will be used instead of the global instance, ensuring deterministic
behaviour.

This addresses concerns raised in https://github.com/lingui/js-lingui/issues/901, https://github.com/lingui/js-lingui/issues/578

Documentation, TypeScript definition changes and (more) tests are 
left to do,  but the main goal of this PR is to receive feedback on the 
approach and to see if this is on the right track.


## Example

<details><summary>Click to expand usage example</summary>


```tsx
import { I18n } from "@lingui/core";
import { t } from "@lingui/macro";
import { useLingui } from "@lingui/react";
import React, { FC, useCallback } from "react";
import * as Yup from "yup";
import { Field, Form, Formik } from "formik";

function buildYupValidationSchema(i18n: I18n) {
  return Yup.object().shape({
    // 3. Use the `t` macro to translate with the custom instance
    name: Yup.string().required(t(i18n)`Name is required`),
    description: Yup.string().required(t(i18n)`Description is required`),
  });
}

export const ExampleForm: FC = () => {
  // 1. Retrieve the i18n instance from the context
  const { i18n } = useLingui();

  // 2. Pass the i18n instance to functions that need it
  const validationSchema = buildYupValidationSchema(i18n);

  const handleSubmit = useCallback((values) => alert(JSON.stringify(values, null, 2)), []);

  return (
    <Formik
      initialValues={{ name: "", description: "" }}
      validationSchema={validationSchema}
      onSubmit={handleSubmit}
    >
      {({ isSubmitting }) => (
        <Form>
          <Field name="name" type="text" />
          <Field name="description" type="text" />
          <button type="submit" disabled={isSubmitting}>
            Submit
          </button>
        </Form>
      )}
    </Formik>
  );
};
```

</details>