### PR TITLE
fix(#1137): configPath is passed through babel-plugin-extract-messages

### DIFF
--- a/packages/babel-plugin-extract-messages/src/index.ts
+++ b/packages/babel-plugin-extract-messages/src/index.ts
@@ -252,7 +252,7 @@ export default function ({ types: t }) {
       // Config was already validated in CLI.
       file.set(
         CONFIG,
-        getConfig({ cwd: file.opts.filename, skipValidation: true })
+        getConfig({ cwd: file.opts.filename, skipValidation: true, configPath: this.opts.configPath })
       )
 
       // Ignore else path for now. Collision is possible if other plugin is

--- a/packages/cli/src/api/catalog.ts
+++ b/packages/cli/src/api/catalog.ts
@@ -154,8 +154,8 @@ export class Catalog {
       paths.forEach((filename) =>
         extract(filename, tmpDir, {
           verbose: options.verbose,
+          configPath: options.configPath,
           babelOptions: this.config.extractBabelOptions,
-          // @ts-ignore
           extractors: options.extractors,
           projectType: options.projectType,
         })

--- a/packages/cli/src/api/extract.ts
+++ b/packages/cli/src/api/extract.ts
@@ -1,7 +1,6 @@
 import fs from "fs"
 import path from "path"
 import chalk from "chalk"
-import ora from "ora"
 import * as R from "ramda"
 
 import { prettyOrigin } from "./utils"
@@ -11,6 +10,7 @@ import cliExtractor, { ExtractorType } from "./extractors"
 type ExtractOptions = {
   ignore?: Array<string>
   verbose?: boolean
+  configPath?: string
   extractors?: ExtractorType[]
   projectType?: string
   babelOptions?: Object

--- a/packages/cli/src/api/extractors/babel.ts
+++ b/packages/cli/src/api/extractors/babel.ts
@@ -16,7 +16,7 @@ const extractor: ExtractorType = {
   },
 
   extract(filename, localeDir, options = {}) {
-    const { babelOptions: _babelOptions = {} } = options
+    const { babelOptions: _babelOptions = {}, configPath } = options
     const { plugins = [], ...babelOptions } = _babelOptions
     const frameworkOptions: BabelOptions = {}
 
@@ -30,7 +30,7 @@ const extractor: ExtractorType = {
       // we override envName to avoid issues with NODE_ENV=production
       // https://github.com/lingui/js-lingui/issues/952
       envName: "development",
-      plugins: ["macros", [linguiExtractMessages, { localeDir }], ...plugins],
+      plugins: ["macros", [linguiExtractMessages, { localeDir, configPath }], ...plugins],
     })
   },
 }

--- a/packages/cli/src/api/extractors/index.ts
+++ b/packages/cli/src/api/extractors/index.ts
@@ -11,6 +11,7 @@ export type BabelOptions = {
 export type ExtractOptions = {
   verbose?: boolean
   projectType?: string
+  configPath?: string
   extractors?: ExtractorType[]
   babelOptions?: BabelOptions
 }
@@ -36,7 +37,7 @@ export default function extract(
     if ((ext as any).default) {
       ext = (ext as any).default
     }
-    
+
     if (!ext.match(filename)) return false
 
     let spinner

--- a/packages/cli/src/api/extractors/typescript.ts
+++ b/packages/cli/src/api/extractors/typescript.ts
@@ -36,10 +36,10 @@ const extractor: ExtractorType = {
       frameworkOptions.presets = ["react-app"]
     }
 
-    const { babelOptions = {} } = options
+    const { babelOptions = {}, configPath } = options
     const plugins = [
       "macros",
-      [linguiExtractMessages, { localeDir }],
+      [linguiExtractMessages, { localeDir, configPath }],
       ...(babelOptions.plugins || []),
     ]
 

--- a/packages/cli/src/lingui-extract-template.ts
+++ b/packages/cli/src/lingui-extract-template.ts
@@ -5,9 +5,12 @@ import { getConfig, LinguiConfig } from "@lingui/conf"
 
 import { getCatalogs } from "./api/catalog"
 import { detect } from "./api/detect"
+import { ExtractorType } from "./api/extractors"
 
 export type CliExtractTemplateOptions = {
   verbose: boolean
+  configPath: string
+  extractors?: ExtractorType[]
   files?: string[]
 }
 
@@ -56,10 +59,11 @@ if (require.main === module) {
     .option("--verbose", "Verbose output")
     .parse(process.argv)
 
-  const config = getConfig({ configPath: program.config })
+  const config = getConfig({ configPath: program.config || process.env.LINGUI_CONFIG })
 
   const result = command(config, {
     verbose: program.verbose || false,
+    configPath: program.config || process.env.LINGUI_CONFIG,
   })
 
   if (!result) process.exit(1)

--- a/packages/cli/src/lingui-extract.ts
+++ b/packages/cli/src/lingui-extract.ts
@@ -1,5 +1,5 @@
 import chalk from "chalk"
-import chokidar, { watch } from "chokidar"
+import chokidar from "chokidar"
 import program from "commander"
 
 import { getConfig, LinguiConfig } from "@lingui/conf"
@@ -8,11 +8,14 @@ import { AllCatalogsType, getCatalogs } from "./api/catalog"
 import { printStats } from "./api/stats"
 import { detect } from "./api/detect"
 import { helpRun } from "./api/help"
+import { ExtractorType } from "./api/extractors"
 
 export type CliExtractOptions = {
   verbose: boolean
   files?: string[]
   clean: boolean
+  extractors?: ExtractorType[]
+  configPath: string
   overwrite: boolean
   locale: string
   prevFormat: string | null
@@ -153,6 +156,7 @@ if (require.main === module) {
       clean: program.watch ? false : program.clean || false,
       overwrite: program.watch || program.overwrite || false,
       locale: program.locale,
+      configPath: program.config || process.env.LINGUI_CONFIG,
       watch: program.watch || false,
       files: filePath?.length ? filePath : undefined,
       prevFormat,

--- a/packages/cli/src/tests.ts
+++ b/packages/cli/src/tests.ts
@@ -22,11 +22,13 @@ export const defaultMakeOptions: MakeOptions = {
   overwrite: false,
   locale: null,
   prevFormat: null,
+  configPath: null,
   orderBy: "messageId",
 }
 
 export const defaultMakeTemplateOptions: MakeTemplateOptions = {
   verbose: false,
+  configPath: null,
   orderBy: "messageId",
 }
 


### PR DESCRIPTION
Resolves #1137 