### PR TITLE
fix(types): correct types for  macro with custom i18n instance

### DIFF
--- a/docs/ref/macro.rst
+++ b/docs/ref/macro.rst
@@ -146,6 +146,13 @@ Examples of JS macros
 +-------------------------------------------------------------+--------------------------------------------------------------------+
 | .. code-block:: js                                          | .. code-block:: js                                                 |
 |                                                             |                                                                    |
+|    t(customI18n)({                                          |    customI18n._(/*i18n*/{                                          |
+|       id: "msg.refresh",                                    |      id: "msg.refresh",                                            |
+|       message: "Refresh inbox"                              |      message: "Refresh inbox"                                      |
+|    })                                                       |    })                                                              |
++-------------------------------------------------------------+--------------------------------------------------------------------+
+| .. code-block:: js                                          | .. code-block:: js                                                 |
+|                                                             |                                                                    |
 |    defineMessage({                                          |    /*i18n*/{                                                       |
 |       id: "msg.refresh",                                    |      id: "msg.refresh",                                            |
 |       message: "Refresh inbox"                              |      message: "Refresh inbox"                                      |

--- a/packages/macro/global.d.ts
+++ b/packages/macro/global.d.ts
@@ -61,10 +61,8 @@ declare module "@lingui/macro" {
    * ```
    */
   export function t(
-    i18n: I18n,
-    literals: TemplateStringsArray,
-    ...placeholders: any[]
-  ): string
+    i18n: I18n
+  ): (literals: TemplateStringsArray, ...placeholders: any[]) => string
 
   export type UnderscoreDigit<T = string> = { [digit: string]: T }
   export type ChoiceOptions<T = string> = {

--- a/packages/macro/global.d.ts
+++ b/packages/macro/global.d.ts
@@ -28,9 +28,9 @@ declare module "@lingui/macro" {
    * });
    * ```
    *
-   * @param messageDescriptior The descriptor to translate
+   * @param descriptor The message descriptor to translate
    */
-  export function t(messageDescriptior: MessageDescriptor): string
+  export function t(descriptor: MessageDescriptor): string
 
   /**
    * Translates a template string using the global I18n instance
@@ -47,7 +47,7 @@ declare module "@lingui/macro" {
   ): string
 
   /**
-   * Translates a template string using a given I18n instance
+   * Translates a template string or message descriptor using a given I18n instance
    *
    * @example
    * ```
@@ -59,10 +59,24 @@ declare module "@lingui/macro" {
    * });
    * const message = t(i18n)`Hello ${name}`;
    * ```
+   *
+   * @example
+   * ```
+   * import { t } from "@lingui/macro";
+   * import { I18n } from "@lingui/core";
+   * const i18n = new I18n({
+   *   locale: "nl",
+   *   messages: { "Hello {0}": "Hallo {0}" },
+   * });
+   * const message = t(i18n)({ message: `Hello ${name}` });
+   * ```
    */
   export function t(
     i18n: I18n
-  ): (literals: TemplateStringsArray, ...placeholders: any[]) => string
+  ): {
+    (literals: TemplateStringsArray, ...placeholders: any[]): string
+    (descriptor: MessageDescriptor): string
+  }
 
   export type UnderscoreDigit<T = string> = { [digit: string]: T }
   export type ChoiceOptions<T = string> = {

--- a/packages/macro/index.d.ts
+++ b/packages/macro/index.d.ts
@@ -67,10 +67,8 @@ export function t(
  * ```
  */
 export function t(
-  i18n: I18n,
-  literals: TemplateStringsArray,
-  ...placeholders: any[]
-): string
+  i18n: I18n
+): (literals: TemplateStringsArray, ...placeholders: any[]) => string
 
 /**
  * Pluralize a message

--- a/packages/macro/index.d.ts
+++ b/packages/macro/index.d.ts
@@ -34,9 +34,9 @@ export type ChoiceOptions<T = string> = {
  * });
  * ```
  *
- * @param messageDescriptior The descriptor to translate
+ * @param descriptor The message descriptor to translate
  */
-export function t(messageDescriptior: MessageDescriptor): string
+export function t(descriptor: MessageDescriptor): string
 
 /**
  * Translates a template string using the global I18n instance
@@ -53,7 +53,7 @@ export function t(
 ): string
 
 /**
- * Translates a template string using a given I18n instance
+ * Translates a template string or message descriptor using a given I18n instance
  *
  * @example
  * ```
@@ -65,10 +65,24 @@ export function t(
  * });
  * const message = t(i18n)`Hello ${name}`;
  * ```
+ *
+ * @example
+ * ```
+ * import { t } from "@lingui/macro";
+ * import { I18n } from "@lingui/core";
+ * const i18n = new I18n({
+ *   locale: "nl",
+ *   messages: { "Hello {0}": "Hallo {0}" },
+ * });
+ * const message = t(i18n)({ message: `Hello ${name}` });
+ * ```
  */
 export function t(
   i18n: I18n
-): (literals: TemplateStringsArray, ...placeholders: any[]) => string
+): {
+  (literals: TemplateStringsArray, ...placeholders: any[]): string
+  (descriptor: MessageDescriptor): string
+}
 
 /**
  * Pluralize a message

--- a/packages/macro/test/js-t.ts
+++ b/packages/macro/test/js-t.ts
@@ -140,6 +140,25 @@ export default [
       `,
   },
   {
+    name:
+      "Support template strings in t macro message, with custom i18n instance",
+    input: `
+        import { t } from '@lingui/macro'
+        import { i18n } from './lingui'
+        const msg = t(i18n)({ message: \`Hello \${name}\` })
+      `,
+    expected: `import { i18n } from "./lingui";
+    const msg =
+      i18n._(/*i18n*/
+        {
+          id: "Hello {name}",
+          values: {
+            name: name,
+          },
+        });
+      `,
+  },
+  {
     name: "Support id and comment in t macro as callExpression",
     input: `
         import { t } from '@lingui/macro'


### PR DESCRIPTION
This PR fixes an issue introduced in #1139, that would cause a type error to be raised, even if the usage was correct.

I'm not sure how I didn't notice this before, but I guess it's because either type checking was disabled while I tested it, or because the files were JS only.

The issue is that for TypeScript, doing ```t(x)`template ${string}`;```, is seen as two individual calls (`result = t(x)` and ```result`template ${string}`;```), so it also needs to be typed like that, even though the macro itself will never let it be executed as such.