### PR TITLE
fix: stripping origin if line numbers already strippped

### DIFF
--- a/packages/cli/src/api/catalog.ts
+++ b/packages/cli/src/api/catalog.ts
@@ -21,7 +21,7 @@ const LOCALE = "{locale}"
 const LOCALE_SUFFIX_RE = /\{locale\}.*$/
 const PATHSEP = "/" // force posix everywhere
 
-type MessageOrigin = [string, number]
+type MessageOrigin = [string, number?]
 
 export type ExtractedMessageType = {
   message?: string

--- a/packages/cli/src/api/formats/po-gettext.ts
+++ b/packages/cli/src/api/formats/po-gettext.ts
@@ -65,7 +65,7 @@ const serialize = (items: CatalogType, options) =>
       
       if (options.origins !== false) {
         if (message.origin && options.lineNumbers === false) {
-          item.references = message.origin.map(msg => msg.slice(0, -1)).map(joinOrigin)
+          item.references = message.origin.map(([path]) => path);
         } else {
           item.references = message.origin ? message.origin.map(joinOrigin) : []
         }

--- a/packages/cli/src/api/formats/po.test.ts
+++ b/packages/cli/src/api/formats/po.test.ts
@@ -266,4 +266,60 @@ describe("pofile format", () => {
 
     `)
   })
+
+  it("should not include lineNumbers if lineNumbers option is false and already excluded", () => {
+    mockFs({
+      locale: {
+        en: mockFs.directory(),
+      },
+    })
+
+    const filename = path.join("locale", "en", "messages.po")
+    const catalog: CatalogType = {
+      static: {
+        translation: "Static message",
+      },
+      withOrigin: {
+        translation: "Message with origin",
+        origin: [["src/App.js"]],
+      },
+      withMultipleOrigins: {
+        translation: "Message with multiple origin",
+        origin: [
+          ["src/App.js"],
+          ["src/Component.js"],
+        ],
+      },
+    }
+    format.write(filename, catalog, {
+      origins: true,
+      lineNumbers: false,
+      locale: "en",
+    })
+    const pofile = fs.readFileSync(filename).toString()
+    mockFs.restore()
+    expect(pofile).toMatchInlineSnapshot(`
+      msgid ""
+      msgstr ""
+      "POT-Creation-Date: ${formatDate(new Date(), "yyyy-MM-dd HH:mmxxxx")}\\n"
+      "MIME-Version: 1.0\\n"
+      "Content-Type: text/plain; charset=utf-8\\n"
+      "Content-Transfer-Encoding: 8bit\\n"
+      "X-Generator: @lingui/cli\\n"
+      "Language: en\\n"
+
+      msgid "static"
+      msgstr "Static message"
+
+      #: src/App.js
+      msgid "withOrigin"
+      msgstr "Message with origin"
+
+      #: src/App.js
+      #: src/Component.js
+      msgid "withMultipleOrigins"
+      msgstr "Message with multiple origin"
+
+    `)
+  })
 })

--- a/packages/cli/src/api/formats/po.ts
+++ b/packages/cli/src/api/formats/po.ts
@@ -27,7 +27,7 @@ const serialize = (items: CatalogType, options) =>
       item.extractedComments = message.extractedComments || []
       if (options.origins !== false) {
         if (message.origin && options.lineNumbers === false) {
-          item.references = message.origin.map(msg => msg.slice(0, -1)).map(joinOrigin)
+          item.references = message.origin.map(([path]) => path);
         } else {
           item.references = message.origin ? message.origin.map(joinOrigin) : []
         }


### PR DESCRIPTION
Given config with `lineNumbers: false`, if you run extract, and then subsequently run extract with the watcher on the entire origin is stripped.

Line 30 in `po.ts` was slicing regardless of the length of the array.

Modified this to destructure the array and remove the unnecessary joinOrigin call.

Added a new test as I wasn't quite sure how to modify the existing one to include this case 🤔