### PR TITLE
feat: add the ability to extract concatenated comments

### DIFF
--- a/packages/babel-plugin-extract-messages/test/__snapshots__/index.ts.snap
+++ b/packages/babel-plugin-extract-messages/test/__snapshots__/index.ts.snap
@@ -131,7 +131,7 @@ Object {
       origin: Array [
         Array [
           js-without-macros.js,
-          11,
+          13,
         ],
       ],
     },
@@ -153,7 +153,7 @@ Object {
     origin: Array [
       Array [
         js-without-macros.js,
-        7,
+        9,
       ],
     ],
   },
@@ -166,12 +166,23 @@ Object {
       ],
     ],
   },
+  Multiline: Object {
+    extractedComments: Array [
+      this is 2 lines long,
+    ],
+    origin: Array [
+      Array [
+        js-without-macros.js,
+        7,
+      ],
+    ],
+  },
   Values {param}: Object {
     extractedComments: Array [],
     origin: Array [
       Array [
         js-without-macros.js,
-        9,
+        11,
       ],
     ],
   },

--- a/packages/babel-plugin-extract-messages/test/fixtures/js-without-macros.js
+++ b/packages/babel-plugin-extract-messages/test/fixtures/js-without-macros.js
@@ -4,6 +4,8 @@ const msg = /*i18n*/{id: 'Message'}
 
 const withDescription = /*i18n*/{id: 'Description', comment: "description"}
 
+const withMultilineComment = /*i18n*/{id: 'Multiline', comment: "this is " + "2 lines long"}
+
 const withId = /*i18n*/{id: 'ID', message: 'Message with id'}
 
 const withValues = /*i18n*/{id: 'Values {param}', values: { param: param }}


### PR DESCRIPTION
Hello! Once again thanks for lingui. We're using it more and more at Smartsheet.

I ran into this after my translation comments were quite verbose. I wanted to break them into multiple lines and concatenate them:

...
comment: "first long line" + 
"second long line",
...

1 question, if you'd like to go forward with this PR: should this concatenation extraction be applied to the id as well?