### PR TITLE
fix: don't push pseudoLocale to translation.io provider

### DIFF
--- a/packages/cli/src/services/translationIO.ts
+++ b/packages/cli/src/services/translationIO.ts
@@ -43,7 +43,8 @@ export default function syncProcess(config, options) {
 // Cf. https://translation.io/docs/create-library#initialization
 function init(config, options, successCallback, failCallback) {
   const sourceLocale  = config.sourceLocale || 'en'
-  const targetLocales = config.locales.filter((value) => value != sourceLocale)
+  const pseudoLocale  = config.pseudoLocale || 'pseudo'
+  const targetLocales = config.locales.filter((value) => value != sourceLocale && value != pseudoLocale)
   const paths         = poPathsPerLocale(config)
 
   let segments = {}


### PR DESCRIPTION
I honestly haven't tested this change but hopefully this will fix an issue where having a pseudo locale configured in lingui prevents the translation.io sync from working with:
```
Synchronization with Translation.io failed: Invalid 'target_languages': pseudo. Please use existing language codes (https://translation.io/docs/languages) or custom languages (https://translation.io/blog/custom-languages).
```