### PR TITLE
docs: the mentioned message id should be "msg.docs"

### DIFF
--- a/docs/misc/react-intl.rst
+++ b/docs/misc/react-intl.rst
@@ -126,7 +126,7 @@ Let's compare it with `react-intl`_ solution to see the difference:
          <Trans>Read the <a href="/docs">documentation</a>.</Trans>
       </p>
 
-   The message ID is ``Read the <0>documentation</0>.`` instead of ``msg.id``. Both
+   The message ID is ``Read the <0>documentation</0>.`` instead of ``msg.docs``. Both
    solutions have pros and cons and the library lets you choose the one which works best for you.
 
 Plurals


### PR DESCRIPTION
In `Comparison with react-intl / Macros for component-based message syntax`, it shows a sample where the message id is `msg.docs`, then adds a note that says it's optional. In the explanation the previous message id is mentioned after the generated message id. The previous message id is mistakenly called out as `msg.id`.