### PR TITLE
fix: Allow pseudoLocalize to work in @lingui/loader

### DIFF
--- a/packages/cli/src/api/compile.ts
+++ b/packages/cli/src/api/compile.ts
@@ -27,7 +27,7 @@ export type CreateCompileCatalogOptions = {
  */
 function compileSingleKey(key: string, translation: string, shouldPseudolocalize: boolean): t.ObjectProperty {
   if (shouldPseudolocalize) {
-    translation = pseudoLocalize(translation)
+    translation = pseudoLocalize(key)
   }
 
   return t.objectProperty(t.stringLiteral(key), compile(translation))


### PR DESCRIPTION
@lingui/loader uses strict mode when it's not running in production.  This is turn means that `compileSingleKey` always gets passed an empty string as `translation` for the pseudo locale to translate.  This seems to defeat the purpose of using pseudo localization.

With this change, you can use @lingui/loader and also get dynamically generated pseudo locale string.