### PR TITLE
fix(cli): extract with --overwrite should fallback to key

### DIFF
--- a/packages/cli/src/api/catalog.test.ts
+++ b/packages/cli/src/api/catalog.test.ts
@@ -330,11 +330,17 @@ describe("Catalog", function () {
             message: "",
             translation: "Message with custom ID",
           }),
+          "Message with <0>auto-generated</0> ID": makePrevMessage({
+            translation: "Source of message with <0>auto-generated</0> ID",
+          }),
         },
         cs: {
           "custom.id": makePrevMessage({
             message: "",
             translation: "Translation of message with custom ID",
+          }),
+          "Message with <0>auto-generated</0> ID": makePrevMessage({
+            translation: "Translation of message with auto-generated ID",
           }),
         },
       }
@@ -343,10 +349,11 @@ describe("Catalog", function () {
         "custom.id": makeNextMessage({
           message: "Message with custom ID, possibly changed",
         }),
+        "Message with <0>auto-generated</0> ID": makeNextMessage(),
       }
 
       // Without `overwrite`:
-      // The translation of `custom.id` message for `sourceLocale` is kept intact
+      // The translations of all IDs for `sourceLocale` are kept intact
       expect(
         makeCatalog({ sourceLocale: "en" }).merge(
           prevCatalogs,
@@ -359,17 +366,23 @@ describe("Catalog", function () {
             message: "Message with custom ID, possibly changed",
             translation: "Message with custom ID",
           }),
+          "Message with <0>auto-generated</0> ID": expect.objectContaining({
+            translation: "Source of message with <0>auto-generated</0> ID",
+          }),
         },
         cs: {
           "custom.id": expect.objectContaining({
             message: "Message with custom ID, possibly changed",
             translation: "Translation of message with custom ID",
           }),
+          "Message with <0>auto-generated</0> ID": expect.objectContaining({
+            translation: "Translation of message with auto-generated ID",
+          }),
         },
       })
 
       // With `overwrite`
-      // The translation of `custom.id` message for `sourceLocale` is changed
+      // The translations of all IDs for `sourceLocale` are changed
       expect(
         makeCatalog({ sourceLocale: "en" }).merge(prevCatalogs, nextCatalog, {
           overwrite: true,
@@ -380,11 +393,17 @@ describe("Catalog", function () {
             message: "Message with custom ID, possibly changed",
             translation: "Message with custom ID, possibly changed",
           }),
+          "Message with <0>auto-generated</0> ID": expect.objectContaining({
+            translation: "Message with <0>auto-generated</0> ID",
+          }),
         },
         cs: {
           "custom.id": expect.objectContaining({
             message: "Message with custom ID, possibly changed",
             translation: "Translation of message with custom ID",
+          }),
+          "Message with <0>auto-generated</0> ID": expect.objectContaining({
+            translation: "Translation of message with auto-generated ID",
           }),
         },
       })

--- a/packages/cli/src/api/catalog.ts
+++ b/packages/cli/src/api/catalog.ts
@@ -228,7 +228,7 @@ export class Catalog {
             options.overwrite)
 
         const translation = updateFromDefaults
-          ? nextCatalog[key].message
+          ? nextCatalog[key].message || key
           : prevCatalog[key].translation
 
         return {

--- a/packages/cli/src/api/formats/__snapshots__/po-gettext.test.ts.snap
+++ b/packages/cli/src/api/formats/__snapshots__/po-gettext.test.ts.snap
@@ -4,6 +4,7 @@ exports[` 1`] = `
 Object {
   message_with_id: Object {
     comments: Array [],
+    context: null,
     extractedComments: Array [],
     flags: Array [],
     obsolete: false,
@@ -12,6 +13,7 @@ Object {
   },
   message_with_id_but_without_translation: Object {
     comments: Array [],
+    context: null,
     extractedComments: Array [
       Comment made by the developers.,
     ],
@@ -22,6 +24,7 @@ Object {
   },
   {anotherCount, plural, one {Singular case} other {Case number {anotherCount}}}: Object {
     comments: Array [],
+    context: null,
     extractedComments: Array [],
     flags: Array [],
     obsolete: false,
@@ -30,6 +33,7 @@ Object {
   },
   {count, plural, one {Singular} other {Plural}}: Object {
     comments: Array [],
+    context: null,
     extractedComments: Array [],
     flags: Array [],
     obsolete: false,


### PR DESCRIPTION
When we run `lingui extract --overwrite` only translations with a custom id + message were working properly.
However, if there is no default `message` but only the `id`, `--overwrite` option was resetting the translation to empty string instead of using `key` as default

This was working properly when a "new" key was added, but not when we update the key (on merge)

Also update snapshot `go-gettext.test.ts.snap` because it fails on master

Fixes #1162 
See [this repository](https://github.com/ardeois/lingui-extract-overwrite-bug) to reproduce the issue