### PR TITLE
feat(cli): make extract cmd asynchronous execution

### DIFF
--- a/packages/cli/src/api/catalog.test.ts
+++ b/packages/cli/src/api/catalog.test.ts
@@ -35,7 +35,7 @@ describe("Catalog", function () {
   })
 
   describe("make", function () {
-    it("should collect and write catalogs", function () {
+    it("should collect and write catalogs", async function () {
       const localeDir = copyFixture(fixture("locales", "initial"))
       const catalog = new Catalog(
         {
@@ -55,11 +55,11 @@ describe("Catalog", function () {
       // Everything should be empty
       expect(catalog.readAll()).toMatchSnapshot()
 
-      catalog.make(defaultMakeOptions)
+      await catalog.make(defaultMakeOptions)
       expect(catalog.readAll()).toMatchSnapshot()
     })
 
-    it("should only update the specified locale", function () {
+    it("should only update the specified locale", async function () {
       const localeDir = copyFixture(fixture("locales", "initial"))
       const catalog = new Catalog(
         {
@@ -79,11 +79,11 @@ describe("Catalog", function () {
       // Everything should be empty
       expect(catalog.readAll()).toMatchSnapshot()
 
-      catalog.make({ ...defaultMakeOptions, locale: "en" })
+      await catalog.make({ ...defaultMakeOptions, locale: "en" })
       expect(catalog.readAll()).toMatchSnapshot()
     })
 
-    it("should merge with existing catalogs", function () {
+    it("should merge with existing catalogs", async function () {
       const localeDir = copyFixture(fixture("locales", "existing"))
       const catalog = new Catalog(
         {
@@ -100,13 +100,13 @@ describe("Catalog", function () {
       // Everything should be empty
       expect(catalog.readAll()).toMatchSnapshot()
 
-      catalog.make(defaultMakeOptions)
+      await catalog.make(defaultMakeOptions)
       expect(catalog.readAll()).toMatchSnapshot()
     })
   })
 
   describe("makeTemplate", function () {
-    it("should collect and write a template", function () {
+    it("should collect and write a template", async function () {
       const localeDir = copyFixture(fixture("locales", "initial"))
       const catalog = new Catalog(
         {
@@ -126,13 +126,13 @@ describe("Catalog", function () {
       // Everything should be empty
       expect(catalog.readTemplate()).toMatchSnapshot()
 
-      catalog.makeTemplate(defaultMakeTemplateOptions)
+      await catalog.makeTemplate(defaultMakeTemplateOptions)
       expect(catalog.readTemplate()).toMatchSnapshot()
     })
   })
 
   describe("collect", function () {
-    it("should extract messages from source files", function () {
+    it("should extract messages from source files", async function () {
       const catalog = new Catalog(
         {
           name: "messages",
@@ -143,11 +143,11 @@ describe("Catalog", function () {
         mockConfig()
       )
 
-      const messages = catalog.collect(defaultMakeOptions)
+      const messages = await catalog.collect(defaultMakeOptions)
       expect(messages).toMatchSnapshot()
     })
 
-    it("should extract only files passed on options", function () {
+    it("should extract only files passed on options", async function () {
       const catalog = new Catalog(
         {
           name: "messages",
@@ -158,7 +158,7 @@ describe("Catalog", function () {
         mockConfig()
       )
 
-      const messages = catalog.collect({
+      const messages = await catalog.collect({
         ...defaultMakeOptions,
         files: [fixture("collect/componentA")]
       })
@@ -176,8 +176,8 @@ describe("Catalog", function () {
         mockConfig()
       )
 
-      mockConsole((console) => {
-        const messages = catalog.collect(defaultMakeOptions)
+      mockConsole(async (console) => {
+        const messages = await catalog.collect(defaultMakeOptions)
         expect(console.error).toBeCalledWith(
           expect.stringContaining(`Cannot process file`)
         )

--- a/packages/cli/src/api/catalog.ts
+++ b/packages/cli/src/api/catalog.ts
@@ -98,8 +98,8 @@ export class Catalog {
     this.format = getFormat(config.format)
   }
 
-  make(options: MakeOptions) {
-    const nextCatalog = this.collect(options)
+  async make(options: MakeOptions) {
+    const nextCatalog = await this.collect(options)
     const prevCatalogs = this.readAll()
 
     const catalogs = this.merge(prevCatalogs, nextCatalog, {
@@ -126,8 +126,8 @@ export class Catalog {
     }
   }
 
-  makeTemplate(options: MakeTemplateOptions) {
-    const catalog = this.collect(options)
+  async makeTemplate(options: MakeTemplateOptions) {
+    const catalog = await this.collect(options)
     const sort = order(options.orderBy) as (catalog: CatalogType) => CatalogType
     this.writeTemplate(sort(catalog as CatalogType))
   }
@@ -135,7 +135,7 @@ export class Catalog {
   /**
    * Collect messages from source paths. Return a raw message catalog as JSON.
    */
-  collect(options: CollectOptions) {
+  async collect(options: CollectOptions) {
     const tmpDir = path.join(os.tmpdir(), `lingui-${process.pid}`)
 
     if (fs.existsSync(tmpDir)) {
@@ -152,15 +152,15 @@ export class Catalog {
         paths = paths.filter((path: string) => regex.test(path))
       }
 
-      paths.forEach((filename) =>
-        extract(filename, tmpDir, {
+      for (let filename of paths) {
+        await extract(filename, tmpDir, {
           verbose: options.verbose,
           configPath: options.configPath,
           babelOptions: this.config.extractBabelOptions,
           extractors: options.extractors,
           projectType: options.projectType,
         })
-      )
+      }
 
       return (function traverse(directory) {
         return fs

--- a/packages/cli/src/api/extract.test.ts
+++ b/packages/cli/src/api/extract.test.ts
@@ -60,8 +60,8 @@ describe("extract", function () {
     mockFs.restore()
   })
 
-  it("should traverse directory and call extractors", function () {
-    extract(["src"], "locale", {
+  it("should traverse directory and call extractors", async function () {
+    await extract(["src"], "locale", {
       ignore: ["forbidden"],
       extractors: [
         babel,
@@ -153,8 +153,8 @@ describe("extract", function () {
     )
   })
 
-  it("by default the traverse directory only uses babel", function () {
-    extract(["src"], "locale", {
+  it("by default the traverse directory only uses babel", async function () {
+    await extract(["src"], "locale", {
       ignore: ["forbidden"],
       babelOptions: {},
     })

--- a/packages/cli/src/api/extract.ts
+++ b/packages/cli/src/api/extract.ts
@@ -38,7 +38,7 @@ function mergeMessage(msgId, prev, next) {
   }
 }
 
-export function extract(
+export async function extract(
   srcPaths: Array<string>,
   targetPath: string,
   options: ExtractOptions = {}
@@ -46,12 +46,12 @@ export function extract(
   const { ignore = [] } = options
   const ignorePattern = ignore.length ? new RegExp(ignore.join("|"), "i") : null
 
-  srcPaths.forEach((srcFilename) => {
+  for (let srcFilename of srcPaths) {
     if (
       !fs.existsSync(srcFilename) ||
       (ignorePattern && ignorePattern.test(srcFilename))
     )
-      return
+      continue
 
     if (fs.statSync(srcFilename).isDirectory()) {
       const subdirs = fs
@@ -59,12 +59,12 @@ export function extract(
         .sort()
         .map((filename) => path.join(srcFilename, filename))
 
-      extract(subdirs, targetPath, options)
-      return
+      await extract(subdirs, targetPath, options)
+      continue
     }
 
-    cliExtractor(srcFilename, targetPath, options)
-  })
+    await cliExtractor(srcFilename, targetPath, options)
+  }
 }
 
 export function collect(buildDir: string) {


### PR DESCRIPTION
Some [custom extractors](https://lingui.js.org/ref/conf.html#extractors) are required to have async execution. For instance, in order to extract messages from Svelte+Typescript you need to preprocess svelte files before compilation. Preprocessing is an async operation in Svelte (see [doc](https://svelte.dev/docs#svelte_preprocess)). But lingui-cli extract command doesn't support async extract method from custom extractor – see `catalog.make` method in `packages/cli/src/lingui-extract.ts` and all function calls down to `extract` method of a particular extractor.

This PR adds support for async extractors by awaiting for `extract` is finished before calling `traverse` function in `Catalog.collect` method