### PR TITLE
fix: pin cli-table to 0.3.6

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -45,7 +45,7 @@
     "bcp-47": "^1.0.7",
     "chalk": "^4.1.0",
     "chokidar": "3.5.1",
-    "cli-table": "^0.3.1",
+    "cli-table": "0.3.6",
     "commander": "^6.1.0",
     "date-fns": "^2.16.1",
     "fs-extra": "^9.0.1",


### PR DESCRIPTION
# Description

Pins [cli-table](https://github.com/Automattic/cli-table#readme) to version 0.3.6, as version 0.3.7 brings a breaking change that prevents `npm extract` from working as expected (see #1169).

# Checklist

- [x] Includes tests
- [x] Includes documentation
