### PR TITLE
fix: cloud service `import()` on case-sensitive filesystems

### DIFF
--- a/packages/cli/src/lingui-extract.ts
+++ b/packages/cli/src/lingui-extract.ts
@@ -73,11 +73,11 @@ export default async function command(
 
   // If service key is present in configuration, synchronize with cloud translation platform
   if (typeof config.service === 'object' && config.service.name && config.service.name.length) {
-    const serviceName = config.service.name.charAt(0).toLowerCase() + config.service.name.slice(1);
+    const moduleName = config.service.name.charAt(0).toLowerCase() + config.service.name.slice(1);
 
-    import(`./services/${serviceName}`)
+    import(`./services/${moduleName}`)
       .then(module => module.default(config, options))
-      .catch(err => console.error(`Can't load service module ${serviceName}`, err))
+      .catch(err => console.error(`Can't load service module ${moduleName}`, err))
   }
 
   return true

--- a/packages/cli/src/lingui-extract.ts
+++ b/packages/cli/src/lingui-extract.ts
@@ -73,11 +73,11 @@ export default async function command(
 
   // If service key is present in configuration, synchronize with cloud translation platform
   if (typeof config.service === 'object' && config.service.name && config.service.name.length) {
-    const serviceFileName = config.service.name.charAt(0).toLowerCase() + config.service.name.slice(1);
+    const serviceName = config.service.name.charAt(0).toLowerCase() + config.service.name.slice(1);
 
-    import(`./services/${serviceFileName}`)
+    import(`./services/${serviceName}`)
       .then(module => module.default(config, options))
-      .catch(err => console.error(`Can't load service module ${config.service.name}`, err))
+      .catch(err => console.error(`Can't load service module ${serviceName}`, err))
   }
 
   return true

--- a/packages/cli/src/lingui-extract.ts
+++ b/packages/cli/src/lingui-extract.ts
@@ -73,7 +73,9 @@ export default async function command(
 
   // If service key is present in configuration, synchronize with cloud translation platform
   if (typeof config.service === 'object' && config.service.name && config.service.name.length) {
-    import(`./services/${config.service.name}`)
+    const serviceFileName = config.service.name.charAt(0).toLowerCase() + config.service.name.slice(1);
+
+    import(`./services/${serviceFileName}`)
       .then(module => module.default(config, options))
       .catch(err => console.error(`Can't load service module ${config.service.name}`, err))
   }


### PR DESCRIPTION
We found an issue on case sensitive systems where the cloud service (if one was present) was not loading correctly.

We made sure to lowercase the first letter so that it works on both case-sensitive and case-insensitive systems.