### PR TITLE
fix: remove the obsolete `defineMessages` function from the typings.

### DIFF
--- a/packages/macro/global.d.ts
+++ b/packages/macro/global.d.ts
@@ -160,13 +160,6 @@ declare module "@lingui/macro" {
   ): string
 
   /**
-   * Defines multiple messages for extraction
-   */
-  export function defineMessages<M extends Record<string, MessageDescriptor>>(
-    messages: M
-  ): M
-
-  /**
    * Define a message for later use
    *
    * `defineMessage` can be used to add comments for translators,

--- a/packages/macro/index.d.ts
+++ b/packages/macro/index.d.ts
@@ -149,15 +149,6 @@ export function selectOrdinal(
 export function select(value: string, choices: ChoiceOptions): string
 
 /**
- * Defines multiple messages for extraction
- *
- * @see {@link defineMessage} for more details
- */
-export function defineMessages<M extends Record<string, MessageDescriptor>>(
-  messages: M
-): M
-
-/**
  * Define a message for later use
  *
  * `defineMessage` can be used to add comments for translators,

--- a/packages/macro/src/index.ts
+++ b/packages/macro/src/index.ts
@@ -134,7 +134,6 @@ function alreadyVisited(path) {
 
 function getMacroType(tagName) {
   switch (tagName) {
-    case "defineMessages":
     case "defineMessage":
     case "arg":
     case "t":


### PR DESCRIPTION
When working in a TypeScript environment, the typings suggest that a function called `defineMessages` (note the plural) should be available. However, this function is not actually available in the code, and its use will cause errors at runtime. It appears that this function was removed as obsolete a while back, so it should also be removed from the typings.

The only other place this function was referenced was in the switch statement in `getMacroType()`, which is also cleaned up in this change.

I found these related changes:

- https://github.com/lingui/js-lingui/commit/9ea2f2ed8446a7a44679809e480ac03605300e68 removed the `defineMessages` function from the API reference, saying it's obsolete
- https://github.com/lingui/js-lingui/pull/651 states the intention to remove the `defineMessages` declaration from the types, but doesn't actually do so
