### PR TITLE
fix(macro): add lingui peer dependencies

### DIFF
--- a/packages/macro/package.json
+++ b/packages/macro/package.json
@@ -34,6 +34,8 @@
     "ramda": "^0.27.1"
   },
   "peerDependencies": {
+    "@lingui/core": "^3.13.0",
+    "@lingui/react": "^3.13.0",
     "babel-plugin-macros": "2 || 3"
   }
 }


### PR DESCRIPTION
When @lingui/macro generates code, it could create imports using `@lingui/core`
or `@lingui/react`
With PNPM dependency manager, we need those peer dependencies, otherwise the build
could fail as we'll have missing or wrong dependencies.

Currently in one of our monorepo using different versions of lingui (v2 and v3),
typescript gets confused when we use `@lingui/macro@v3`. It sometimes resolves
`@lingui/core@v2` even if our `package.json` dependencies declare `@lingui/core@v3`.

By setting `@lingui/macro` peer dependencies, the problem disappears