### PR TITLE
docs: Fix a typo in a babel plugin name

### DIFF
--- a/docs/guides/dynamic-loading-catalogs.rst
+++ b/docs/guides/dynamic-loading-catalogs.rst
@@ -19,7 +19,7 @@ Setup
    or similar framework which already has it.
 
 We are using the `Dynamic Import() Proposal <https://github.com/tc39/proposal-dynamic-import>`_
-to ECMAScript. We need to install ``@babel/plugin-@babel/plugin-syntax-dynamic-import`` and
+to ECMAScript. We need to install ``@babel/plugin-syntax-dynamic-import`` and
 ``babel-plugin-dynamic-import-node`` to make it work. Also, the code examples given here make use of ``@babel/plugin-proposal-class-properties``
 
 .. code-block:: shell


### PR DESCRIPTION
The name of the plugin contains duplication that might confuse