### PR TITLE
docs: Use placeholder in selectOrdinal's examples and test cases

### DIFF
--- a/docs/ref/macro.rst
+++ b/docs/ref/macro.rst
@@ -456,9 +456,9 @@ cardinal plural forms it uses ordinal forms:
 
    import { selectOrdinal } from "@lingui/macro"
    const message = selectOrdinal(count, {
-      one: "1st",
-      two: "2nd",
-      few: "3rd",
+      one: "#st",
+      two: "#nd",
+      few: "#rd",
       other: "#th",
    })
 
@@ -467,7 +467,7 @@ cardinal plural forms it uses ordinal forms:
    import { i18n } from "@lingui/core"
    const message =
    /*i18n*/
-   i18n._('{count, selectOrdinal, one {1st} two {2nd} few {3rd} other {#th}}', {
+   i18n._('{count, selectOrdinal, one {#st} two {#nd} few {#rd} other {#th}}', {
      count
    })
 
@@ -802,9 +802,9 @@ format:
    // count == 4 -> 4th
    <SelectOrdinal
        value={count}
-       one="1st"
-       two="2nd"
-       few="3rd"
+       one="#st"
+       two="#nd"
+       few="#rd"
        other="#th"
    />
 

--- a/docs/ref/message-format.rst
+++ b/docs/ref/message-format.rst
@@ -47,8 +47,8 @@ Overview
 +------------------+------------------------------------------------------------------+
 | .. icu:: ordinal | .. code-block:: none                                             |
 |                  |                                                                  |
-| Ordinals         |    {count, selectOrdinal, one {1st message}                      |
-|                  |                           two {2nd message}                      |
-|                  |                           few {3rd message}                      |
+| Ordinals         |    {count, selectOrdinal, one {#st message}                      |
+|                  |                           two {#nd message}                      |
+|                  |                           few {#rd message}                      |
 |                  |                           other {#th message}}                   |
 +------------------+------------------------------------------------------------------+

--- a/packages/cli/src/api/formats/po-gettext.test.ts
+++ b/packages/cli/src/api/formats/po-gettext.test.ts
@@ -343,7 +343,7 @@ msgstr[2] "# dní"
   describe("when using 'selectOrdinal' format", () => {
     const catalog = {
       select_ordinal_message: {
-        message: `{count, selectOrdinal, one {1st} two {2nd} few {3rd} other {#th}}`,
+        message: `{count, selectOrdinal, one {#st} two {#nd} few {#rd} other {#th}}`,
         translation: "",
       },
     }

--- a/packages/cli/src/api/pseudoLocalize.test.ts
+++ b/packages/cli/src/api/pseudoLocalize.test.ts
@@ -71,10 +71,10 @@ describe("PseudoLocalization", () => {
   it("SelectOrdinal", () => {
     expect(
       pseudoLocalize(
-        "{count, selectordinal, offset:1 one {1st} two {2nd} few {3rd} =4 {4th} many {testMany} other {#th}}"
+        "{count, selectordinal, offset:1 one {#st} two {#nd} few {#rd} =4 {4th} many {testMany} other {#th}}"
       )
     ).toEqual(
-      "{count, selectordinal, offset:1 one {1śţ} two {2ńď} few {3ŕď} =4 {4ţĥ} many {ţēśţMàńŷ} other {#ţĥ}}"
+      "{count, selectordinal, offset:1 one {#śţ} two {#ńď} few {#ŕď} =4 {4ţĥ} many {ţēśţMàńŷ} other {#ţĥ}}"
     )
   })
 

--- a/packages/core/src/dev/compile.test.ts
+++ b/packages/core/src/dev/compile.test.ts
@@ -59,7 +59,7 @@ describe("compile", function () {
 
   it("should compile selectordinal", function () {
     const cache = prepare(
-      "{value, selectordinal, one {1st Book} two {2nd Book}}"
+      "{value, selectordinal, one {#st Book} two {#nd Book}}"
     )
     expect(cache({ value: 1 })).toEqual("1st Book")
     expect(cache({ value: 2 })).toEqual("2nd Book")

--- a/packages/macro/global.d.ts
+++ b/packages/macro/global.d.ts
@@ -119,9 +119,9 @@ declare module "@lingui/macro" {
    * ```
    * import { selectOrdinal } from "@lingui/macro";
    * const message = selectOrdinal(count, {
-   *    one: "1st",
-   *    two: "2nd",
-   *    few: "3rd",
+   *    one: "#st",
+   *    two: "#nd",
+   *    few: "#rd",
    *    other: "#th",
    * });
    * ```

--- a/packages/macro/index.d.ts
+++ b/packages/macro/index.d.ts
@@ -111,9 +111,9 @@ export function plural(value: number | string, options: ChoiceOptions): string
  * ```
  * import { selectOrdinal } from "@lingui/macro";
  * const message = selectOrdinal(count, {
- *    one: "1st",
- *    two: "2nd",
- *    few: "3rd",
+ *    one: "#st",
+ *    two: "#nd",
+ *    few: "#rd",
  *    other: "#th",
  * });
  * ```

--- a/packages/macro/test/types.ts
+++ b/packages/macro/test/types.ts
@@ -44,8 +44,8 @@ select(value, {
 
 /** Select Ordinal test */
 selectOrdinal(value, {
-  one: "1st",
-  two: "2nd",
-  few: "3rd",
+  one: "#st",
+  two: "#nd",
+  few: "#rd",
   other: "#th",
 })


### PR DESCRIPTION
Currently, the following example is used in the [selectOrdinal's documentation](https://lingui.js.org/ref/macro.html#jsmacro-selectOrdinal). However, this code may return a wrong result for larger numbers. For example, it returns `"1st"` when `count` is `21` . Expected behavior is to return `"21st"`. 

```ts
   const message = selectOrdinal(count, {
      one: "1st",
      two: "2nd",
      few: "3rd",
      other: "#th",
   })
```

This is not a problem of the Lingui itself, but a problem of the documentation. I think the document should suggest proper use of placeholders as follows:

```ts
   const message = selectOrdinal(count, {
      one: "#st",
      two: "#nd",
      few: "#rd",
      other: "#th",
   })
```

This code returns `"21st"` when `count` is `21` as expected.

This PR fixes selectOrdinal's examples and test cases to use placeholders. Note that these placeholders are already used in some test cases like [js-selectOrdinal.ts](https://github.com/lingui/js-lingui/blob/v3.13.2/packages/macro/test/js-selectOrdinal.ts) and [jsx-selectOrdinal.ts](https://github.com/lingui/js-lingui/blob/main/packages/macro/test/jsx-selectOrdinal.ts).
