### PR TITLE
fix: JSX attribute parsing issue when using double quotes

### DIFF
--- a/packages/macro/src/macroJsx.ts
+++ b/packages/macro/src/macroJsx.ts
@@ -87,11 +87,15 @@ export default class MacroJSX {
         }
       }
     } else {
+      // Quoted JSX attributes use XML-style escapes instead of JavaScript-style escapes.
+      // This means that <Trans id="Say \"hi\"!" /> is invalid, but <Trans id={"Say \"hi\"!"} /> works.
+      // We could consider removing the condition here and always wrap in a jsxExpressionContainer.
+      const value = message.includes('"')
+        ? this.types.jsxExpressionContainer(this.types.stringLiteral(message))
+        : this.types.stringLiteral(message)
+
       attributes.push(
-        this.types.jsxAttribute(
-          this.types.jsxIdentifier(ID),
-          this.types.stringLiteral(message)
-        )
+        this.types.jsxAttribute(this.types.jsxIdentifier(ID), value)
       )
     }
 

--- a/packages/macro/test/jsx-trans.ts
+++ b/packages/macro/test/jsx-trans.ts
@@ -93,6 +93,17 @@ export default [
       `,
   },
   {
+    name: "Quoted JSX attributes are handled",
+    input: `
+        import { Trans } from '@lingui/macro';
+        <Trans>Speak "friend"!</Trans>;
+      `,
+    expected: `
+        import { Trans } from "@lingui/react";
+        <Trans id={'Speak "friend"!'} />;
+      `,
+  },
+  {
     name: "Template literals as children",
     input: `
         import { Trans } from '@lingui/macro';

--- a/packages/macro/test/jsx-trans.ts
+++ b/packages/macro/test/jsx-trans.ts
@@ -97,10 +97,12 @@ export default [
     input: `
         import { Trans } from '@lingui/macro';
         <Trans>Speak "friend"!</Trans>;
+        <Trans id="custom-id">Speak "friend"!</Trans>;
       `,
     expected: `
         import { Trans } from "@lingui/react";
         <Trans id={'Speak "friend"!'} />;
+        <Trans id="custom-id" message={'Speak "friend"!'} />;
       `,
   },
   {


### PR DESCRIPTION
- Fixes https://github.com/lingui/js-lingui/issues/1225 

This was the least intrusive way I could come up with by wrapping the relevant `jsxAttribute` string literal value in a `jsxExpressionContainer`. 

This is currently done conditionally in case the message includes a double quote. Note that I believe this could safely be done unconditionally, but it requires updating a lot of tests. I happily do this if we like the suggested solution.

This has been tested out on a fairly big codebase.