### PR TITLE
fix: specify children for react v18 types

### DIFF
--- a/packages/macro/index.d.ts
+++ b/packages/macro/index.d.ts
@@ -172,6 +172,7 @@ export type TransProps = {
   comment?: string
   values?: Record<string, unknown>
   context?: string
+  children?: string | any[] | React.ReactNode
   component?: React.ComponentType<TransRenderProps>
   render?: (props: TransRenderProps) => ReactElement<any, any> | null
 }

--- a/packages/macro/index.d.ts
+++ b/packages/macro/index.d.ts
@@ -172,7 +172,7 @@ export type TransProps = {
   comment?: string
   values?: Record<string, unknown>
   context?: string
-  children?: string | any[] | React.ReactNode
+  children?: React.ReactNode
   component?: React.ComponentType<TransRenderProps>
   render?: (props: TransRenderProps) => ReactElement<any, any> | null
 }

--- a/packages/react/src/I18nProvider.tsx
+++ b/packages/react/src/I18nProvider.tsx
@@ -12,6 +12,7 @@ export type withI18nProps = {
 
 export type I18nProviderProps = I18nContext & {
   forceRenderOnLocaleChange?: boolean
+  children?: string | any[] | React.ReactNode
 }
 
 const LinguiContext = React.createContext<I18nContext>(null)

--- a/packages/react/src/I18nProvider.tsx
+++ b/packages/react/src/I18nProvider.tsx
@@ -12,7 +12,7 @@ export type withI18nProps = {
 
 export type I18nProviderProps = I18nContext & {
   forceRenderOnLocaleChange?: boolean
-  children?: string | any[] | React.ReactNode
+  children?: React.ReactNode
 }
 
 const LinguiContext = React.createContext<I18nContext>(null)

--- a/packages/react/src/Trans.tsx
+++ b/packages/react/src/Trans.tsx
@@ -6,7 +6,7 @@ import { formatElements } from "./format"
 export type TransRenderProps = {
   id?: string
   translation?: React.ReactNode
-  children?: string | any[] | React.ReactNode
+  children?: React.ReactNode
   message?: string | null
 }
 
@@ -17,7 +17,7 @@ export type TransProps = {
   context?: string
   components: { [key: string]: React.ElementType | any }
   formats?: Object
-  children?: string | any[] | React.ReactNode
+  children?: React.ReactNode
   component?: React.ComponentType<TransRenderProps>
   render?: (props: TransRenderProps) => React.ReactElement<any, any> | null
 }

--- a/packages/react/src/Trans.tsx
+++ b/packages/react/src/Trans.tsx
@@ -17,6 +17,7 @@ export type TransProps = {
   context?: string
   components: { [key: string]: React.ElementType | any }
   formats?: Object
+  children?: string | any[] | React.ReactNode
   component?: React.ComponentType<TransRenderProps>
   render?: (props: TransRenderProps) => React.ReactElement<any, any> | null
 }


### PR DESCRIPTION
## Short summary

After some changes in react v18, the `FunctionComponent` type no longer implicitly passes `children` as part of the props. This means that the `children` prop needs to be declared explicitly.