### PR TITLE
fix: output .mjs files while bundling esm

### DIFF
--- a/packages/core/npm/esm/dev.mjs
+++ b/packages/core/npm/esm/dev.mjs
@@ -3,14 +3,14 @@ import {
   setupI18n as setupI18nProd,
   formats as formatsProd,
   I18n as I18nProd
-} from './dev.production.min';
+} from './dev.production.min.mjs';
 
 import {
   i18n as i18nDev,
   setupI18n as setupI18nDev,
   formats as formatsDev,
   I18n as I18nDev
-} from './dev.development';
+} from './dev.development.mjs';
 
 export const i18n = process.env.NODE_ENV === 'production' ? i18nProd : i18nDev;
 export const setupI18n = process.env.NODE_ENV === 'production' ? setupI18nProd : setupI18nDev;

--- a/packages/core/npm/esm/index.mjs
+++ b/packages/core/npm/esm/index.mjs
@@ -3,14 +3,14 @@ import {
     setupI18n as setupI18nProd,
     formats as formatsProd,
     I18n as I18nProd
-} from './core.production.min';
+} from './core.production.min.mjs';
 
 import {
     i18n as i18nDev,
     setupI18n as setupI18nDev,
     formats as formatsDev,
     I18n as I18nDev
-} from './core.development';
+} from './core.development.mjs';
 
 export const i18n = process.env.NODE_ENV === 'production' ? i18nProd : i18nDev;
 export const setupI18n = process.env.NODE_ENV === 'production' ? setupI18nProd : setupI18nDev;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,7 +4,7 @@
   "sideEffects": false,
   "description": "I18n tools for javascript",
   "main": "index.js",
-  "module": "esm/index.js",
+  "module": "esm/index.mjs",
   "types": "cjs/index.d.ts",
   "author": {
     "name": "Tomáš Ehrlich",
@@ -32,7 +32,7 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "import": "./esm/index.js"
+      "import": "./esm/index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/detect-locale/npm/esm/index.mjs
+++ b/packages/detect-locale/npm/esm/index.mjs
@@ -8,7 +8,7 @@ import {
   fromSubdomain as fromSubdomainDev,
   fromUrl as fromUrlDev,
   multipleDetect as multipleDetectDev,
-} from "./detect-locale.development.js"
+} from "./detect-locale.development.mjs"
 
 import {
   detect as detectProd,
@@ -20,7 +20,7 @@ import {
   fromSubdomain as fromSubdomainProd,
   fromUrl as fromUrlProd,
   multipleDetect as multipleDetectProd,
-} from "./detect-locale.production.min.js"
+} from "./detect-locale.production.min.mjs"
 
 export const detect = process.env.NODE_ENV === "production" ? detectProd : detectDev;
 export const fromCookie = process.env.NODE_ENV === "production" ? fromCookieProd : fromCookieDev;

--- a/packages/detect-locale/package.json
+++ b/packages/detect-locale/package.json
@@ -4,7 +4,7 @@
   "sideEffects": false,
   "description": "@Lingui package to help you find the correct browser/server locale",
   "main": "index.js",
-  "module": "esm/index.js",
+  "module": "esm/index.mjs",
   "types": "cjs/index.d.ts",
   "license": "MIT",
   "keywords": [
@@ -32,7 +32,7 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "import": "./esm/index.js"
+      "import": "./esm/index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/react/npm/esm/index.mjs
+++ b/packages/react/npm/esm/index.mjs
@@ -1,10 +1,10 @@
 import {
   I18nProvider as devI18nProvider, Trans as devTrans, useLingui as devuseLingui, withI18n as devwithI18n
-} from "./react.development.js"
+} from "./react.development.mjs"
 
 import {
   I18nProvider as I18nProviderProd, Trans as TransProd, useLingui as useLinguiProd, withI18n as withI18nProd
-} from "./react.production.min.js"
+} from "./react.production.min.mjs"
 
 export const I18nProvider = process.env.NODE_ENV === "production" ? I18nProviderProd : devI18nProvider;
 export const Trans = process.env.NODE_ENV === "production" ? TransProd : devTrans;

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -4,7 +4,7 @@
   "sideEffects": false,
   "description": "React components for translations",
   "main": "index.js",
-  "module": "esm/index.js",
+  "module": "esm/index.mjs",
   "types": "cjs/index.d.ts",
   "author": {
     "name": "Tomáš Ehrlich",

--- a/scripts/build/rollup.js
+++ b/scripts/build/rollup.js
@@ -76,17 +76,28 @@ function getFormat(bundleType) {
   }
 }
 
+function getExtension(bundleType) {
+  switch (bundleType) {
+    case ESM_PROD:
+    case ESM_DEV:
+      return ".mjs"
+    default:
+      return ".js"
+  }
+}
+
 function getFilename(bundle, bundleType) {
   const filename = bundle.label || bundle.entry
+  const extension = getExtension(bundleType)
   switch (bundleType) {
     case NODE_DEV:
     case ESM_DEV:
     case UMD_DEV:
-      return `${filename}.development.js`
+      return `${filename}.development${extension}`
     case UMD_PROD:
     case NODE_PROD:
     case ESM_PROD:
-      return `${filename}.production.min.js`
+      return `${filename}.production.min${extension}`
   }
 }
 


### PR DESCRIPTION
# Description


Rename the bundled files from `.js` to `.mjs` under `esm/`. This allows lingui to be imported in Node.js with the ESM syntax. 

Fixes https://github.com/lingui/js-lingui/issues/1254

# Checklist

- [ ] Includes tests
- [ ] Includes documentation
