### PR TITLE
fix: Add extra package.json under `/esm`

### DIFF
--- a/packages/core/npm/esm/dev.js
+++ b/packages/core/npm/esm/dev.js
@@ -3,14 +3,14 @@ import {
   setupI18n as setupI18nProd,
   formats as formatsProd,
   I18n as I18nProd
-} from './dev.production.min';
+} from './dev.production.min.js';
 
 import {
   i18n as i18nDev,
   setupI18n as setupI18nDev,
   formats as formatsDev,
   I18n as I18nDev
-} from './dev.development';
+} from './dev.development.js';
 
 export const i18n = process.env.NODE_ENV === 'production' ? i18nProd : i18nDev;
 export const setupI18n = process.env.NODE_ENV === 'production' ? setupI18nProd : setupI18nDev;

--- a/packages/core/npm/esm/index.js
+++ b/packages/core/npm/esm/index.js
@@ -3,14 +3,14 @@ import {
     setupI18n as setupI18nProd,
     formats as formatsProd,
     I18n as I18nProd
-} from './core.production.min';
+} from './core.production.min.js';
 
 import {
     i18n as i18nDev,
     setupI18n as setupI18nDev,
     formats as formatsDev,
     I18n as I18nDev
-} from './core.development';
+} from './core.development.js';
 
 export const i18n = process.env.NODE_ENV === 'production' ? i18nProd : i18nDev;
 export const setupI18n = process.env.NODE_ENV === 'production' ? setupI18nProd : setupI18nDev;

--- a/packages/core/npm/esm/package.json
+++ b/packages/core/npm/esm/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/packages/detect-locale/npm/esm/package.json
+++ b/packages/detect-locale/npm/esm/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/packages/react/npm/esm/package.json
+++ b/packages/react/npm/esm/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}


### PR DESCRIPTION

Add `package.json` with `{"type": "module"}` under `/esm`.

Fixes https://github.com/lingui/js-lingui/issues/1254