### PR TITLE
fix: allow lingui compile to compile for languages without plural rules

### DIFF
--- a/packages/cli/src/lingui-compile.ts
+++ b/packages/cli/src/lingui-compile.ts
@@ -46,7 +46,6 @@ function command(config: LinguiConfig, options) {
         )
       )
       console.error()
-      process.exit(1)
     }
 
     catalogs.forEach((catalog) => {


### PR DESCRIPTION
For languages that don't have plurals such as "mi", "kr" and "ht", lingui compiler exits when plurals are not found despite the language not having plural rules. 

This allows the compiler to complete for these languages. 

Related PR for lingui loader:
https://github.com/lingui/js-lingui/pull/824