### PR TITLE
fix: add null undefined check

### DIFF
--- a/packages/cli/src/lingui-extract-template.ts
+++ b/packages/cli/src/lingui-extract-template.ts
@@ -39,8 +39,13 @@ export default async function command(
       orderBy: config.orderBy,
       projectType: detect(),
     })
-
-    catalogStats[catalog.templateFile] = Object.keys(catalog.readTemplate()).length
+    const catalogTemplate = catalog.readTemplate()
+    if (
+      catalogTemplate !== null &&
+      catalogTemplate !== undefined
+    ) {
+      catalogStats[catalog.templateFile] = Object.keys(catalogTemplate).length
+    }
   }))
 
   Object.entries(catalogStats).forEach(([key, value]) => {


### PR DESCRIPTION
Hello!

I noticed a [bug](https://github.com/lingui/js-lingui/issues/1284) where I got a TypeError when running the extract-template command.

I added a simple null and undefined check, so that it would just run.

