### PR TITLE
fix: Make pseudolocal use the message AST instead of the key

### DIFF
--- a/packages/cli/src/api/__snapshots__/compile.test.ts.snap
+++ b/packages/cli/src/api/__snapshots__/compile.test.ts.snap
@@ -26,6 +26,14 @@ exports[`createCompiledCatalog options.pseudoLocale should return catalog with p
 
 exports[`createCompiledCatalog options.pseudoLocale should return compiled catalog when pseudoLocale doesn't match current locale 1`] = `/*eslint-disable*/module.exports={messages:{"Hello":"Ahoj"}};`;
 
+exports[`createCompiledCatalog options.pure should return code catalog 1`] = `/*eslint-disable*/module.exports={messages:{"Hello":"Ahoj"}};`;
+
+exports[`createCompiledCatalog options.pure should return pure catalog 1`] = `
+Object {
+  Hello: Ahoj,
+}
+`;
+
 exports[`createCompiledCatalog options.strict should return message key as a fallback translation 1`] = `/*eslint-disable*/module.exports={messages:{"Hello":"Ahoj","Missing":"Missing","Select":[["id","select",{Gen:"Genesis","1John":"1 John",other:"____"}]]}};`;
 
 exports[`createCompiledCatalog options.strict should't return message key as a fallback in strict mode 1`] = `/*eslint-disable*/module.exports={messages:{"Hello":"Ahoj","Missing":"","Select":[["id","select",{Gen:"Genesis","1John":"1 John",other:"____"}]]}};`;

--- a/packages/cli/src/api/__snapshots__/compile.test.ts.snap
+++ b/packages/cli/src/api/__snapshots__/compile.test.ts.snap
@@ -6,6 +6,8 @@ Can't parse message. Please check correct syntax: "{value, plural, one {Book} ot
  Messageformat-parser trace: Expected "#", "{", "}", doubled apostrophe, escaped string, or plain char but end of input found.
 `;
 
+exports[`createCompiledCatalog nested message 1`] = `/*eslint-disable*/module.exports={messages:{"nested":{"one":"Uno","two":"Dos","three":"Tres","hello":["Hola ",["name"]]}}};`;
+
 exports[`createCompiledCatalog options.compilerBabelOptions by default should return catalog without ASCII chars 1`] = `/*eslint-disable*/module.exports={messages:{"Hello":"Alohà"}};`;
 
 exports[`createCompiledCatalog options.compilerBabelOptions should return catalog without ASCII chars 1`] = `/*eslint-disable*/module.exports={messages:{"Hello":"Aloh\\xE0"}};`;
@@ -20,7 +22,7 @@ exports[`createCompiledCatalog options.namespace should compile with window 1`] 
 
 exports[`createCompiledCatalog options.namespace should error with invalid value 1`] = `Invalid namespace param: "global"`;
 
-exports[`createCompiledCatalog options.pseudoLocale should return catalog with pseudolocalized messages 1`] = `/*eslint-disable*/module.exports={messages:{"Hello":"Ĥēĺĺō"}};`;
+exports[`createCompiledCatalog options.pseudoLocale should return catalog with pseudolocalized messages 1`] = `/*eslint-disable*/module.exports={messages:{"Hello":"ÀĥōĴ"}};`;
 
 exports[`createCompiledCatalog options.pseudoLocale should return compiled catalog when pseudoLocale doesn't match current locale 1`] = `/*eslint-disable*/module.exports={messages:{"Hello":"Ahoj"}};`;
 

--- a/packages/cli/src/api/compile.test.ts
+++ b/packages/cli/src/api/compile.test.ts
@@ -2,10 +2,11 @@ import generate from "@babel/generator"
 import { compile, createCompiledCatalog } from "./compile"
 
 describe("compile", () => {
-  const getSource = (message) =>
-    generate(compile(message) as any, {
+  const getSource = (message: string, shouldPseudolocalize: boolean = false) =>
+    generate(compile(message, shouldPseudolocalize) as any, {
       compact: true,
       minified: true,
+      jsescOption: { minimal: true },
     }).code
 
   it("should optimize string only messages", () => {
@@ -67,14 +68,165 @@ describe("compile", () => {
     )
   })
 
+  it("should compile multiple plurals", () => {
+    expect(
+      getSource(
+        "{bcount, plural, one {boy} other {# boys}} {gcount, plural, one {girl} other {# girls}}"
+      )
+    ).toEqual(
+      '[["bcount","plural",{one:"boy",other:["#"," boys"]}]," ",["gcount","plural",{one:"girl",other:["#"," girls"]}]]'
+    )
+  })
+
   it("should report failed message on error", () => {
     expect(() =>
       getSource("{value, plural, one {Book} other {Books")
     ).toThrowErrorMatchingSnapshot()
   })
+
+  describe("with pseudo-localization", () => {
+    const getPSource = (message: string) => getSource(message, true)
+
+    it("should pseudolocalize strings", () => {
+      expect(getPSource("Martin Černý")).toEqual('"Màŕţĩń Čēŕńý"')
+    })
+
+    it("should pseudolocalize escaping syntax characters", () => {
+      // TODO: should this turn into pseudoLocale string?
+      expect(getSource("'{name}'", true)).toEqual('"{name}"')
+      // expect(getSource("'{name}'", true)).toEqual('"{ńàmē}"')
+    })
+
+    it("should not pseudolocalize arguments", () => {
+      expect(getPSource("{name}")).toEqual('[["name"]]')
+      expect(getPSource("B4 {name} A4")).toEqual('["ß4 ",["name"]," À4"]')
+    })
+
+    it("should not pseudolocalize arguments nor formats", () => {
+      expect(getPSource("{name, number}")).toEqual('[["name","number"]]')
+      expect(getPSource("{name, number, percent}")).toEqual(
+        '[["name","number","percent"]]'
+      )
+    })
+
+    it("should not pseudolocalize HTML tags", () => {
+      expect(getPSource('Martin <span id="spanId">Černý</span>')).toEqual(
+        '"Màŕţĩń <span id=\\"spanId\\">Čēŕńý</span>"'
+      )
+      expect(
+        getPSource("Martin Cerny  123a<span id='id'>Černý</span>")
+      ).toEqual('"Màŕţĩń Ćēŕńŷ  123à<span id=\'id\'>Čēŕńý</span>"')
+      expect(getPSource("Martin <a title='>>a'>a</a>")).toEqual(
+        '"Màŕţĩń <a title=\'>>a\'>à</a>"'
+      )
+      expect(getPSource("<a title=TITLE>text</a>")).toEqual(
+        '"<a title=TITLE>ţēxţ</a>"'
+      )
+    })
+
+    describe("Plurals", () => {
+      it("with value", () => {
+        expect(
+          getPSource("{value, plural, one {# book} other {# books}}")
+        ).toEqual('[["value","plural",{one:["#"," ƀōōķ"],other:["#"," ƀōōķś"]}]]')
+      })
+
+      it("with variable placeholder", () => {
+        expect(
+          getPSource(
+            "{count, plural, one {{countString} book} other {{countString} books}}"
+          )
+        ).toEqual(
+          '[["count","plural",{one:[["countString"]," ƀōōķ"],other:[["countString"]," ƀōōķś"]}]]'
+        )
+      })
+
+      it("with offset", () => {
+        expect(
+          getPSource(
+            "{count, plural, offset:1 zero {There are no messages} other {There are # messages in your inbox}}"
+          )
+        ).toEqual(
+          '[["count","plural",{offset:1,zero:"Ţĥēŕē àŕē ńō mēśśàĝēś",other:["Ţĥēŕē àŕē ","#"," mēśśàĝēś ĩń ŷōũŕ ĩńƀōx"]}]]'
+        )
+      })
+
+      it("with HTML tags", () => {
+        expect(
+          getPSource(
+            "{count, plural, zero {There's # <span>message</span>} other {There are # messages}}"
+          )
+        ).toEqual(
+          '[["count","plural",{zero:["Ţĥēŕē\'ś ","#"," <span>mēśśàĝē</span>"],other:["Ţĥēŕē àŕē ","#"," mēśśàĝēś"]}]]'
+        )
+      })
+
+      it("with exact number", () => {
+        expect(
+          getPSource(
+            "{count, plural, =0 {There's # <span>message</span>} other {There are # messages}}"
+          )
+        ).toEqual(
+          '[["count","plural",{0:["Ţĥēŕē\'ś ","#"," <span>mēśśàĝē</span>"],other:["Ţĥēŕē àŕē ","#"," mēśśàĝēś"]}]]'
+        )
+      })
+    })
+
+    it("SelectOrdinal", () => {
+      expect(
+        getPSource(
+          "{count, selectordinal, offset:1 one {#st} two {#nd} few {#rd} =4 {4th} many {testMany} other {#th}}"
+        )
+      ).toEqual(
+          '[["count","selectordinal",{offset:1,one:["#","śţ"],two:["#","ńď"],few:["#","ŕď"],4:"4ţĥ",many:"ţēśţMàńŷ",other:["#","ţĥ"]}]]'
+      )
+    })
+
+    it("Select", () => {
+      expect(
+        getPSource(
+          "{gender, select, male {He} female {She} other {<span>Other</span>}}"
+        )
+      ).toEqual(
+        '[["gender","select",{male:"Ĥē",female:"Śĥē",other:"<span>Ōţĥēŕ</span>"}]]'
+      )
+    })
+
+    it("should not pseudolocalize variables", () => {
+      expect(getPSource("replace {count}")).toEqual('["ŕēƥĺàćē ",["count"]]')
+      expect(getPSource("replace { count }")).toEqual('["ŕēƥĺàćē ",["count"]]')
+    })
+
+    it("Multiple Plurals", () => {
+      expect(
+        getPSource(
+          "{bcount, plural, one {boy} other {# boys}} {gcount, plural, one {girl} other {# girls}}"
+        )
+      ).toEqual(
+        '[["bcount","plural",{one:"ƀōŷ",other:["#"," ƀōŷś"]}]," ",["gcount","plural",{one:"ĝĩŕĺ",other:["#"," ĝĩŕĺś"]}]]'
+      )
+    })
+  })
 })
 
 describe("createCompiledCatalog", () => {
+  it("nested message", () => {
+      expect(
+        createCompiledCatalog(
+          "cs",
+          {
+            nested: {
+              one: "Uno",
+              two: "Dos",
+              three: "Tres",
+              hello: "Hola {name}",
+            },
+          },
+          {}
+        )
+      ).toMatchSnapshot()
+  })
+
   describe("options.namespace", () => {
     const getCompiledCatalog = (namespace) =>
       createCompiledCatalog(
@@ -113,7 +265,7 @@ describe("createCompiledCatalog", () => {
         {
           Hello: "Ahoj",
           Missing: "",
-          Select: "{id, select, Gen {Genesis} 1John {1 John}  other {____}}"
+          Select: "{id, select, Gen {Genesis} 1John {1 John}  other {____}}",
         },
         {
           strict,
@@ -165,13 +317,15 @@ describe("createCompiledCatalog", () => {
     })
 
     it("should return catalog without ASCII chars", () => {
-      expect(getCompiledCatalog({
-        compilerBabelOptions: { 
-          jsescOption: {
-            minimal: false,
-          }
-        }
-      })).toMatchSnapshot()
+      expect(
+        getCompiledCatalog({
+          compilerBabelOptions: {
+            jsescOption: {
+              minimal: false,
+            },
+          },
+        })
+      ).toMatchSnapshot()
     })
   })
 })

--- a/packages/cli/src/api/pseudoLocalize.test.ts
+++ b/packages/cli/src/api/pseudoLocalize.test.ts
@@ -50,20 +50,20 @@ describe("PseudoLocalization", () => {
     it("with HTML tags", () => {
       expect(
         pseudoLocalize(
-          "{count, plural, zero {There's # <span>message</span>} other {There are # messages}"
+          "{count, plural, zero {There's # <span>message</span>} other {There are # messages}}"
         )
       ).toEqual(
-        "{count, plural, zero {Ţĥēŕē'ś # <span>mēśśàĝē</span>} other {Ţĥēŕē àŕē # mēśśàĝēś}"
+        "{count, plural, zero {Ţĥēŕē'ś # <span>mēśśàĝē</span>} other {Ţĥēŕē àŕē # mēśśàĝēś}}"
       )
     })
 
     it("with exact number", () => {
       expect(
         pseudoLocalize(
-          "{count, plural, =0 {There's # <span>message</span>} other {There are # messages}"
+          "{count, plural, =0 {There's # <span>message</span>} other {There are # messages}}"
         )
       ).toEqual(
-        "{count, plural, =0 {Ţĥēŕē'ś # <span>mēśśàĝē</span>} other {Ţĥēŕē àŕē # mēśśàĝēś}"
+        "{count, plural, =0 {Ţĥēŕē'ś # <span>mēśśàĝē</span>} other {Ţĥēŕē àŕē # mēśśàĝēś}}"
       )
     })
   })
@@ -91,5 +91,15 @@ describe("PseudoLocalization", () => {
   it("should not pseudolocalize variables", () => {
     expect(pseudoLocalize("replace {count}")).toEqual("ŕēƥĺàćē {count}")
     expect(pseudoLocalize("replace { count }")).toEqual("ŕēƥĺàćē { count }")
+  })
+
+  it("multiple plurals is wrong45", () => {
+    expect(
+      pseudoLocalize(
+        "{bcount, plural, one {boy} other {# boys}} {gcount, plural, one {girl} other {# girls}}"
+      )
+    ).not.toEqual(
+      "{bcount, plural, one {ƀōŷ} other {# ƀōŷś}} {gcount, plural, one {ĝĩŕĺ} other {# ĝĩŕĺś}}"
+    )
   })
 })

--- a/packages/cli/src/api/pseudoLocalize.test.ts
+++ b/packages/cli/src/api/pseudoLocalize.test.ts
@@ -93,7 +93,7 @@ describe("PseudoLocalization", () => {
     expect(pseudoLocalize("replace { count }")).toEqual("ŕēƥĺàćē { count }")
   })
 
-  it("multiple plurals is wrong45", () => {
+  it("multiple plurals pseudolocalize gives wrong ICU message", () => {
     expect(
       pseudoLocalize(
         "{bcount, plural, one {boy} other {# boys}} {gcount, plural, one {girl} other {# girls}}"


### PR DESCRIPTION
This is fixing this issue: https://github.com/lingui/js-lingui/issues/1213

I'm not sure why in this PR (https://github.com/lingui/js-lingui/pull/1165) there was a change from the message to the key, but I hope I don't mess anything

Also, I wonder if we should remove the `addDelimitersVariables` & `addDelimitersMacro` and keep only the handling of HTML inside the `pseudoLocalize.ts` code