### PR TITLE
fix: Pass formatter to pluralization function

### DIFF
--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -18,7 +18,7 @@ const defaultFormats = (
     return (ctx) => {
       const msg = isFunction(message) ? message(ctx) : message
       const norm = Array.isArray(msg) ? msg : [msg]
-      const valueStr = number(locales)(value)
+      const valueStr = number(locales, style('number'))(value)
       return norm.map((m) => (isString(m) ? m.replace("#", valueStr) : m))
     }
   }

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -18,7 +18,8 @@ const defaultFormats = (
     return (ctx) => {
       const msg = isFunction(message) ? message(ctx) : message
       const norm = Array.isArray(msg) ? msg : [msg]
-      const valueStr = number(locales, style('number'))(value)
+      const numberFormat = Object.keys(formats).length ? style('number') : {};
+      const valueStr = number(locales, numberFormat)(value)
       return norm.map((m) => (isString(m) ? m.replace("#", valueStr) : m))
     }
   }


### PR DESCRIPTION
Fix for https://github.com/lingui/js-lingui/issues/1203
In some cases is needed to pass the format function to `_` method, but it doesn't work if pluralization is applied. 
For instance, I don't need to use Arabic "[Hindi](https://en.wikipedia.org/wiki/Hindu%E2%80%93Arabic_numeral_system)" numbers, hence I want to pass `NumberFormatOptions` to the pluralization function 
```
{
  numberingSystem: 'latn'
}
```

In recap, consumer code will look something like this
```
    const translation = this.lingui._(value, options, {
      formats: {
        number: {
          numberingSystem: 'latn',
        },
      },
    });
```