### PR TITLE
feat: Support GetText template files support during compile

### DIFF
--- a/packages/cli/src/api/__snapshots__/catalog.test.ts.snap
+++ b/packages/cli/src/api/__snapshots__/catalog.test.ts.snap
@@ -1,5 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Catalog POT Flow Should get translations from template if locale file not presented 1`] = `
+Object {
+  Hello World: Hello World,
+  Test String: Test String,
+}
+`;
+
+exports[`Catalog POT Flow Should merge source messages from template if provided 1`] = `
+Object {
+  Hello World: Cześć świat,
+  Test String: Test String,
+}
+`;
+
 exports[`Catalog collect should extract messages from source files 1`] = `
 Object {
   Component A: Object {

--- a/packages/cli/src/api/catalog.test.ts
+++ b/packages/cli/src/api/catalog.test.ts
@@ -131,6 +131,61 @@ describe("Catalog", function () {
     })
   })
 
+  describe("POT Flow", function () {
+    it('Should merge source messages from template if provided', () => {
+      const catalog = new Catalog(
+        {
+          name: "messages",
+          path: path.resolve(
+            __dirname,
+            path.join("fixtures", "pot-template", "{locale}")
+          ),
+          include: [],
+          exclude: [],
+        },
+        mockConfig({
+          locales: ['en', 'pl'],
+        })
+      )
+
+      const translations = catalog.getTranslations('pl', {
+        sourceLocale: 'en',
+        fallbackLocales: {
+          default: 'en'
+        }
+      });
+
+      expect(translations).toMatchSnapshot()
+    })
+
+    it('Should get translations from template if locale file not presented', () => {
+      const catalog = new Catalog(
+        {
+          name: "messages",
+          path: path.resolve(
+            __dirname,
+            path.join("fixtures", "pot-template", "{locale}")
+          ),
+          include: [],
+          exclude: [],
+        },
+        mockConfig({
+          locales: ['en', 'pl'],
+        })
+      )
+
+      const translations = catalog.getTranslations('en', {
+        sourceLocale: 'en',
+        fallbackLocales: {
+          default: 'en'
+        }
+      });
+
+      console.log(translations);
+      expect(translations).toMatchSnapshot()
+    })
+  })
+
   describe("collect", function () {
     it("should extract messages from source files", async function () {
       const catalog = new Catalog(

--- a/packages/cli/src/api/fixtures/pot-template/messages.pot
+++ b/packages/cli/src/api/fixtures/pot-template/messages.pot
@@ -1,0 +1,5 @@
+msgid "Hello World"
+msgstr ""
+
+msgid "Test String"
+msgstr ""

--- a/packages/cli/src/api/fixtures/pot-template/pl.po
+++ b/packages/cli/src/api/fixtures/pot-template/pl.po
@@ -1,0 +1,2 @@
+msgid "Hello World"
+msgstr "Cześć świat"

--- a/packages/cli/src/lingui-extract-template.ts
+++ b/packages/cli/src/lingui-extract-template.ts
@@ -35,7 +35,7 @@ export default async function command(
 
   await Promise.all(catalogs.map(async (catalog) => {
     await catalog.makeTemplate({
-      ...options,
+      ...options as CliExtractTemplateOptions,
       orderBy: config.orderBy,
       projectType: detect(),
     })

--- a/packages/cli/src/lingui-extract.ts
+++ b/packages/cli/src/lingui-extract.ts
@@ -43,7 +43,7 @@ export default async function command(
   const catalogStats: { [path: string]: AllCatalogsType } = {}
   for (let catalog of catalogs) {
     await catalog.make({
-      ...options,
+      ...options as CliExtractOptions,
       orderBy: config.orderBy,
       extractors: config.extractors,
       projectType: detect(),

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -33,8 +33,7 @@
     "@babel/runtime": "^7.11.2",
     "@lingui/cli": "^3.14.0",
     "@lingui/conf": "^3.14.0",
-    "loader-utils": "^2.0.0",
-    "ramda": "^0.27.1"
+    "loader-utils": "^2.0.0"
   },
   "devDependencies": {
     "memory-fs": "^0.5.0"

--- a/packages/loader/src/webpackLoader.ts
+++ b/packages/loader/src/webpackLoader.ts
@@ -1,5 +1,4 @@
 import path from "path"
-import * as R from "ramda"
 import { getConfig } from "@lingui/conf"
 import {
   createCompiledCatalog,
@@ -61,15 +60,11 @@ export default function (source) {
     catalogRelativePath,
     getCatalogs(config)
   )
-  const catalogs = catalog.readAll()
-  const messages = R.mapObjIndexed(
-    (_, key) =>
-      catalog.getTranslation(catalogs, locale, key, {
-        fallbackLocales: config.fallbackLocales,
-        sourceLocale: config.sourceLocale,
-      }),
-    catalogs[locale]
-  )
+
+  const messages = catalog.getTranslations(locale, {
+    fallbackLocales: config.fallbackLocales,
+    sourceLocale: config.sourceLocale,
+  })
 
   // In production we don't want untranslated strings. It's better to use message
   // keys as a last resort.


### PR DESCRIPTION
This PR brings full e2e support for gettext *.pot files into linguijs. 

## What is a template or *.pot file? 
Template is a file where all messages extracted from sourcecode is stored. It doesn't have any translations. It treated as build artifact and could be added to gitignore. 

## What's wrong with current support of *.pot files? 
Short version: 
They are not taken into account during compiling messages.

Long version:
Standard gettext flow looks like the following
- Change source code and potentially change messages
- Run extractor and produce *.pot file
- Send *.pot file together with translations (en.po, pl.po) to the translators. 
- Translators upload .pot and *.po files into theirs translation software which merges them
- Translators translate
- Translators return translated files. 

There are few things which important to notice. 
Merging new messages to the translations should happen outside of build process. It's the responsibility of translation software (such as PoEditor or modern cloud services like crowdin) to do so, not the linguijs extractor.

In current linguijs flow, extractor tries to merge new messages (and delete old) into translation files. 

What's wrong with this? Translations files are usually under version control. Running a build with NODE_ENV=production without fresh extracted messages will cause that messages where ICU is used would be corrupted and this force developers to always extract messages before build in CI process (for test/staging builds, for production builds we assume that 100% messages are translated).

Every time we run a development build on CI, our translation files marked as changed. 

This might not be a big deal for regular repositories, but could be a dealbreaker for monorepos where some strategies for incremental builds are used. Usually tools such as turborepo / rush / ultra-runner trying to be smart and detect which project inside monorepo was changed and rebuild only this one. With linguijs this doesn't work because every build touches translations and therefore bursting the cache. 

But lingui has a command to `extract-template`, you can use this, you may say.  Actually not.

What happend if we generate template file using `lingui extract-template`? 
- The template would be generated and translations files would not be touched. That's good. 
- You build your application and realize that all plurals expressions doesn't work because they was not compiled because they are not in the translation files - That sucks. 
- Your understand that in current stage, extracting *.pot files are useless in linguijs. 

## How this PR changes it? 
Instead of merging new messages into catalogs during extraction phase, it merges template with requested catalog during compile time. If you have actual template - your translations catalogs are also actual.

