### PR TITLE
feat: `lingui extract` should fail with a non-zero exit code when there are extraction failures

### DIFF
--- a/packages/cli/src/api/__snapshots__/catalog.test.ts.snap
+++ b/packages/cli/src/api/__snapshots__/catalog.test.ts.snap
@@ -93,7 +93,7 @@ Object {
 }
 `;
 
-exports[`Catalog collect should handle errors 1`] = `Object {}`;
+exports[`Catalog collect should handle errors 1`] = `undefined`;
 
 exports[`Catalog make should collect and write catalogs 1`] = `
 Object {

--- a/packages/cli/src/api/catalog.ts
+++ b/packages/cli/src/api/catalog.ts
@@ -99,8 +99,9 @@ export class Catalog {
     this.format = getFormat(config.format)
   }
 
-  async make(options: MakeOptions) {
+  async make(options: MakeOptions): Promise<boolean> {
     const nextCatalog = await this.collect(options)
+    if (!nextCatalog) return false
     const prevCatalogs = this.readAll()
 
     const catalogs = this.merge(prevCatalogs, nextCatalog, {
@@ -125,18 +126,21 @@ export class Catalog {
     } else {
       this.writeAll(sortedCatalogs)
     }
+    return true
   }
 
-  async makeTemplate(options: MakeTemplateOptions) {
+  async makeTemplate(options: MakeTemplateOptions): Promise<boolean> {
     const catalog = await this.collect(options)
+    if (!catalog) return false
     const sort = order(options.orderBy) as (catalog: CatalogType) => CatalogType
     this.writeTemplate(sort(catalog as CatalogType))
+    return true;
   }
 
   /**
    * Collect messages from source paths. Return a raw message catalog as JSON.
    */
-  async collect(options: CollectOptions) {
+  async collect(options: CollectOptions): Promise<CatalogType | undefined> {
     const tmpDir = path.join(os.tmpdir(), `lingui-${process.pid}`)
 
     if (fs.existsSync(tmpDir)) {
@@ -153,15 +157,18 @@ export class Catalog {
         paths = paths.filter((path: string) => regex.test(path))
       }
 
+      let catalogSuccess = true
       for (let filename of paths) {
-        await extract(filename, tmpDir, {
+        const fileSuccess = await extract(filename, tmpDir, {
           verbose: options.verbose,
           configPath: options.configPath,
           babelOptions: this.config.extractBabelOptions,
           extractors: options.extractors,
           projectType: options.projectType,
         })
+        catalogSuccess &&= fileSuccess
       }
+      if (!catalogSuccess) return undefined
 
       return (function traverse(directory) {
         return fs

--- a/packages/cli/src/api/catalog.ts
+++ b/packages/cli/src/api/catalog.ts
@@ -134,7 +134,7 @@ export class Catalog {
     if (!catalog) return false
     const sort = order(options.orderBy) as (catalog: CatalogType) => CatalogType
     this.writeTemplate(sort(catalog as CatalogType))
-    return true;
+    return true
   }
 
   /**

--- a/packages/cli/src/api/extractors/index.ts
+++ b/packages/cli/src/api/extractors/index.ts
@@ -58,5 +58,5 @@ export default async function extract(
     }
   }
 
-  return false
+  return true
 }

--- a/packages/cli/src/api/extractors/index.ts
+++ b/packages/cli/src/api/extractors/index.ts
@@ -45,17 +45,17 @@ export default async function extract(
 
     try {
       await ext.extract(filename, targetPath, options)
+
+      if (options.verbose && spinner) spinner.succeed()
+      return true
     } catch (e) {
       if (options.verbose && spinner) {
         spinner.fail(e.message)
       } else {
         console.error(`Cannot process file ${e.message}`)
       }
-      return true
+      return false
     }
-
-    if (options.verbose && spinner) spinner.succeed()
-    return true
   }
 
   return false

--- a/packages/cli/src/lingui-extract.ts
+++ b/packages/cli/src/lingui-extract.ts
@@ -41,8 +41,9 @@ export default async function command(
 
   const catalogs = getCatalogs(config)
   const catalogStats: { [path: string]: AllCatalogsType } = {}
+  let commandSuccess = true
   for (let catalog of catalogs) {
-    await catalog.make({
+    const catalogSuccess = await catalog.make({
       ...options as CliExtractOptions,
       orderBy: config.orderBy,
       extractors: config.extractors,
@@ -50,6 +51,7 @@ export default async function command(
     })
 
     catalogStats[catalog.path] = catalog.readAll()
+    commandSuccess &&= catalogSuccess
   }
 
   Object.entries(catalogStats).forEach(([key, value]) => {
@@ -80,7 +82,7 @@ export default async function command(
       .catch(err => console.error(`Can't load service module ${moduleName}`, err))
   }
 
-  return true
+  return commandSuccess
 }
 
 if (require.main === module) {


### PR DESCRIPTION
`lingui extract` prints extraction failures (such as `Cannot process file [path]: Different defaults for the same message ID.`) to the console but then finishes with a zero exit code. When run unattended in a CI job, this means files with failures are skipped during extraction and their messages may then be missing in a production build.

This PR propagates the `boolean` result(s) from the extractor all the way up into the CLI command. There was already code to handle it and do `process.exit(1)` when the result is `false`.