### PR TITLE
fix(types): `<Trans>`can have an `i18n` props

### DIFF
--- a/packages/macro/index.d.ts
+++ b/packages/macro/index.d.ts
@@ -175,6 +175,7 @@ export type TransProps = {
   children?: React.ReactNode
   component?: React.ComponentType<TransRenderProps>
   render?: (props: TransRenderProps) => ReactElement<any, any> | null
+  i18n?: I18n
 }
 
 export type ChoiceProps = {


### PR DESCRIPTION
Sometimes you need to force the `i18n` instance used by `<Trans>`. In my case, it is to have a server-side render of a React PDF document, where I do not have a global `i18n` instance but several global ones (one per language).

The macro seems to properly handle this, and this patch works fine locally with our app.

For example:

```tsx
component Test = () => {
    const i = useLingui()

  return <Text><Trans i18n={i.i18n}>Test String</Trans></Text>
}
```