### PR TITLE
feat: allow extract to work with i18n._ calls not created from macro

### DIFF
--- a/packages/babel-plugin-extract-messages/test/__snapshots__/index.ts.snap
+++ b/packages/babel-plugin-extract-messages/test/__snapshots__/index.ts.snap
@@ -123,6 +123,72 @@ Object {
 }
 `;
 
+exports[`@lingui/babel-plugin-extract-messages should extract all messages from JS files (without macros or i18n comments) 1`] = `
+Object {
+  Context1: Object {
+    Some id: Object {
+      extractedComments: Array [],
+      origin: Array [
+        Array [
+          js-without-macros-or-comments.js,
+          11,
+        ],
+      ],
+    },
+  },
+  Description: Object {
+    extractedComments: Array [
+      description,
+    ],
+    origin: Array [
+      Array [
+        js-without-macros-or-comments.js,
+        3,
+      ],
+    ],
+  },
+  ID: Object {
+    extractedComments: Array [],
+    message: Message with id,
+    origin: Array [
+      Array [
+        js-without-macros-or-comments.js,
+        7,
+      ],
+    ],
+  },
+  Message: Object {
+    extractedComments: Array [],
+    origin: Array [
+      Array [
+        js-without-macros-or-comments.js,
+        1,
+      ],
+    ],
+  },
+  Multiline: Object {
+    extractedComments: Array [
+      this is 2 lines long,
+    ],
+    origin: Array [
+      Array [
+        js-without-macros-or-comments.js,
+        5,
+      ],
+    ],
+  },
+  Values {param}: Object {
+    extractedComments: Array [],
+    origin: Array [
+      Array [
+        js-without-macros-or-comments.js,
+        9,
+      ],
+    ],
+  },
+}
+`;
+
 exports[`@lingui/babel-plugin-extract-messages should extract all messages from JS files 1`] = `
 Object {
   Context1: Object {
@@ -316,6 +382,33 @@ Object {
       Array [
         jsx-without-macros.js,
         6,
+      ],
+    ],
+  },
+}
+`;
+
+exports[`@lingui/babel-plugin-extract-messages should handle duplicate ids 1`] = `
+Object {
+  msg: Object {
+    extractedComments: Array [],
+    message: Hello World!,
+    origin: Array [
+      Array [
+        duplicate-id-valid.js,
+        5,
+      ],
+      Array [
+        duplicate-id-valid.js,
+        8,
+      ],
+      Array [
+        duplicate-id-valid.js,
+        11,
+      ],
+      Array [
+        duplicate-id-valid.js,
+        14,
       ],
     ],
   },

--- a/packages/babel-plugin-extract-messages/test/fixtures/js-without-macros-or-comments.js
+++ b/packages/babel-plugin-extract-messages/test/fixtures/js-without-macros-or-comments.js
@@ -1,0 +1,11 @@
+const msg = i18n._('Message')
+
+const withDescription = i18n._('Description', {}, { comment: "description"});
+
+const withMultilineComment = i18n._('Multiline', {}, { comment: "this is " + "2 lines long" });
+
+const withId = i18n._('ID', {}, { message: 'Message with id' });
+
+const withValues = i18n._('Values {param}', { param: param });
+
+const withContext = i18n._('Some id', {},{ context: 'Context1'});

--- a/packages/babel-plugin-extract-messages/test/index.ts
+++ b/packages/babel-plugin-extract-messages/test/index.ts
@@ -114,6 +114,11 @@ describe("@lingui/babel-plugin-extract-messages", function () {
   })
 
   testCase(
+    "should handle duplicate ids",
+    "duplicate-id-valid.js"
+  )
+
+  testCase(
     "should extract all messages from JSX files",
     "jsx-without-macros.js"
   )
@@ -133,5 +138,10 @@ describe("@lingui/babel-plugin-extract-messages", function () {
   testCase(
     "should extract all messages from JS files (macros)",
     "js-with-macros.js"
+  )
+
+  testCase(
+    "should extract all messages from JS files (without macros or i18n comments)",
+    "js-without-macros-or-comments.js"
   )
 })


### PR DESCRIPTION
This change updates babel-plugin-extract-messages so that it will pick up usages of the i18n._ method from @lingui/core directly.

This solves the issues mentioned in https://github.com/lingui/js-lingui/issues/1178 and https://github.com/lingui/js-lingui/issues/1224#issuecomment-1317265270 without needing the workaround listed in 1178 (prefixing the id with `/*i18n*/`).

The main driver for this is to allow use of Lingui without macros, so that sites running on Next.js can use the SWC compiler instead of babel.

Aware that this is effectively adding back extract behavior that was removed previously, but hopefully this isn't too big of a deal - let me know if you have any feedback.