### PR TITLE
feat: add plural rule into compiled catalogs

### DIFF
--- a/packages/cli/api.d.ts
+++ b/packages/cli/api.d.ts
@@ -1,0 +1,1 @@
+export * from "./src/api"

--- a/packages/cli/src/api/__snapshots__/compile.test.ts.snap
+++ b/packages/cli/src/api/__snapshots__/compile.test.ts.snap
@@ -1,25 +1,49 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`createCompiledCatalog nested message 1`] = `/*eslint-disable*/module.exports={messages:JSON.parse("{\\"nested\\":{\\"one\\":\\"Uno\\",\\"two\\":\\"Dos\\",\\"three\\":\\"Tres\\",\\"hello\\":[\\"Hola \\",[\\"name\\"]]}}")};`;
+exports[`createCompiledCatalog nested message 1`] = `/*eslint-disable*/module.exports={messages:JSON.parse("{\\"nested\\":{\\"one\\":\\"Uno\\",\\"two\\":\\"Dos\\",\\"three\\":\\"Tres\\",\\"hello\\":[\\"Hola \\",[\\"name\\"]]}}"),plurals:(n,ord)=>{return n==1?"one":"other"}};`;
 
-exports[`createCompiledCatalog options.compilerBabelOptions by default should return catalog without ASCII chars 1`] = `/*eslint-disable*/module.exports={messages:JSON.parse("{\\"Hello\\":\\"Alohà\\"}")};`;
+exports[`createCompiledCatalog options.compilerBabelOptions by default should return catalog without ASCII chars 1`] = `/*eslint-disable*/module.exports={messages:JSON.parse("{\\"Hello\\":\\"Alohà\\"}"),plurals:(n,ord)=>{return n==1?"one":"other"}};`;
 
-exports[`createCompiledCatalog options.compilerBabelOptions should return catalog without ASCII chars 1`] = `/*eslint-disable*/module.exports={messages:JSON.parse("{\\"Hello\\":\\"Aloh\\xE0\\"}")};`;
+exports[`createCompiledCatalog options.compilerBabelOptions should return catalog without ASCII chars 1`] = `/*eslint-disable*/module.exports={messages:JSON.parse("{\\"Hello\\":\\"Aloh\\xE0\\"}"),plurals:(n,ord)=>{return n==1?"one":"other"}};`;
 
-exports[`createCompiledCatalog options.namespace should compile with es 1`] = `/*eslint-disable*/export const messages=JSON.parse("{}");`;
+exports[`createCompiledCatalog options.namespace should compile with es 1`] = `
+/*eslint-disable*/export const messages = JSON.parse("{}");
+export const plurals = (n, ord) => {
+  return n == 1 ? 'one' : 'other';
+};
+`;
 
-exports[`createCompiledCatalog options.namespace should compile with global 1`] = `/*eslint-disable*/global.test={messages:JSON.parse("{}")};`;
+exports[`createCompiledCatalog options.namespace should compile with global 1`] = `
+/*eslint-disable*/global.test = {
+  messages: JSON.parse("{}"),
+  plurals: (n, ord) => {
+    return n == 1 ? 'one' : 'other';
+  }
+};
+`;
 
-exports[`createCompiledCatalog options.namespace should compile with ts 1`] = `/*eslint-disable*/export const messages=JSON.parse("{}");`;
+exports[`createCompiledCatalog options.namespace should compile with ts 1`] = `
+/*eslint-disable*/export const messages = JSON.parse("{}");
+export const plurals = (n, ord) => {
+  return n == 1 ? 'one' : 'other';
+};
+`;
 
-exports[`createCompiledCatalog options.namespace should compile with window 1`] = `/*eslint-disable*/window.test={messages:JSON.parse("{}")};`;
+exports[`createCompiledCatalog options.namespace should compile with window 1`] = `
+/*eslint-disable*/window.test = {
+  messages: JSON.parse("{}"),
+  plurals: (n, ord) => {
+    return n == 1 ? 'one' : 'other';
+  }
+};
+`;
 
 exports[`createCompiledCatalog options.namespace should error with invalid value 1`] = `Invalid namespace param: "global"`;
 
-exports[`createCompiledCatalog options.pseudoLocale should return catalog with pseudolocalized messages 1`] = `/*eslint-disable*/module.exports={messages:JSON.parse("{\\"Hello\\":\\"ÀĥōĴ\\"}")};`;
+exports[`createCompiledCatalog options.pseudoLocale should return catalog with pseudolocalized messages 1`] = `/*eslint-disable*/module.exports={messages:JSON.parse("{\\"Hello\\":\\"ÀĥōĴ\\"}"),plurals:(n,ord)=>{return n==1?"one":"other"}};`;
 
-exports[`createCompiledCatalog options.pseudoLocale should return compiled catalog when pseudoLocale doesn't match current locale 1`] = `/*eslint-disable*/module.exports={messages:JSON.parse("{\\"Hello\\":\\"Ahoj\\"}")};`;
+exports[`createCompiledCatalog options.pseudoLocale should return compiled catalog when pseudoLocale doesn't match current locale 1`] = `/*eslint-disable*/module.exports={messages:JSON.parse("{\\"Hello\\":\\"Ahoj\\"}"),plurals:(n,ord)=>{return n==1?"one":"other"}};`;
 
-exports[`createCompiledCatalog options.strict should return message key as a fallback translation 1`] = `/*eslint-disable*/module.exports={messages:JSON.parse("{\\"Hello\\":\\"Ahoj\\",\\"Missing\\":\\"Missing\\",\\"Select\\":[[\\"id\\",\\"select\\",{\\"Gen\\":\\"Genesis\\",\\"1John\\":\\"1 John\\",\\"other\\":\\"____\\"}]]}")};`;
+exports[`createCompiledCatalog options.strict should return message key as a fallback translation 1`] = `/*eslint-disable*/module.exports={messages:JSON.parse("{\\"Hello\\":\\"Ahoj\\",\\"Missing\\":\\"Missing\\",\\"Select\\":[[\\"id\\",\\"select\\",{\\"Gen\\":\\"Genesis\\",\\"1John\\":\\"1 John\\",\\"other\\":\\"____\\"}]]}"),plurals:(n,ord)=>{return n==1?"one":"other"}};`;
 
-exports[`createCompiledCatalog options.strict should't return message key as a fallback in strict mode 1`] = `/*eslint-disable*/module.exports={messages:JSON.parse("{\\"Hello\\":\\"Ahoj\\",\\"Missing\\":\\"\\",\\"Select\\":[[\\"id\\",\\"select\\",{\\"Gen\\":\\"Genesis\\",\\"1John\\":\\"1 John\\",\\"other\\":\\"____\\"}]]}")};`;
+exports[`createCompiledCatalog options.strict should't return message key as a fallback in strict mode 1`] = `/*eslint-disable*/module.exports={messages:JSON.parse("{\\"Hello\\":\\"Ahoj\\",\\"Missing\\":\\"\\",\\"Select\\":[[\\"id\\",\\"select\\",{\\"Gen\\":\\"Genesis\\",\\"1John\\":\\"1 John\\",\\"other\\":\\"____\\"}]]}"),plurals:(n,ord)=>{return n==1?"one":"other"}};`;

--- a/packages/cli/src/api/catalog.test.ts
+++ b/packages/cli/src/api/catalog.test.ts
@@ -29,6 +29,8 @@ export const fixture = (...dirs) =>
   // preserve trailing slash
   (dirs[dirs.length - 1].endsWith("/") ? "/" : "")
 
+const enPluralRule = "(n, ord) => {return n == 1  ? 'one' : 'other';}"
+
 describe("Catalog", function () {
   afterEach(() => {
     mockFs.restore()
@@ -1072,6 +1074,8 @@ describe("order", function () {
 
 describe("writeCompiled", function () {
   const localeDir = copyFixture(fixture("locales", "initial/"))
+  const enPluralRule = "(n, ord) => {return n == 1 ? 'one' : 'other';}"
+
   const catalog = new Catalog(
     {
       name: "messages",
@@ -1092,7 +1096,7 @@ describe("writeCompiled", function () {
   ])(
     "Should save namespace $namespace in $extension extension",
     ({ namespace, extension }) => {
-      const compiledCatalog = createCompiledCatalog("en", {}, { namespace })
+      const compiledCatalog = createCompiledCatalog("en", {}, enPluralRule, { namespace })
       // Test that the file extension of the compiled catalog is `.mjs`
       expect(catalog.writeCompiled("en", compiledCatalog, namespace)).toMatch(
         extension

--- a/packages/cli/src/api/catalog.ts
+++ b/packages/cli/src/api/catalog.ts
@@ -6,6 +6,7 @@ import chalk from "chalk"
 import glob from "glob"
 import micromatch from "micromatch"
 import normalize from "normalize-path"
+import * as plurals from "make-plural/plurals"
 
 import { LinguiConfig, OrderBy, FallbackLocales } from "@lingui/conf"
 
@@ -270,6 +271,15 @@ export class Catalog {
       (_value, key) => this.getTranslation(catalogs, locale, key, options),
       { ...template, ...catalogs[locale] }
     )
+  }
+
+  /**
+   *
+   * Return strigified plural rule function which can be hydrated and used in client code
+   */
+  getPluralRule(locale: string): string {
+    const l = locale as keyof typeof plurals;
+    return plurals[l].toString()
   }
 
   getTranslation(

--- a/packages/cli/src/api/compile.ts
+++ b/packages/cli/src/api/compile.ts
@@ -2,6 +2,7 @@ import * as t from "@babel/types"
 import generate, {GeneratorOptions} from "@babel/generator"
 import {compileMessage} from "@lingui/core/compile"
 import pseudoLocalize from "./pseudoLocalize"
+import { parse as babelParse } from "@babel/parser"
 
 export type CompiledCatalogNamespace = "cjs" | "es" | "ts" | string
 
@@ -19,6 +20,7 @@ export type CreateCompileCatalogOptions = {
 export function createCompiledCatalog(
   locale: string,
   messages: CompiledCatalogType,
+  plurals: string,
   options: CreateCompileCatalogOptions
 ): string {
   const {strict = false, namespace = "cjs", pseudoLocale, compilerBabelOptions = {}} = options
@@ -46,13 +48,16 @@ export function createCompiledCatalog(
   }, {})
 
   const ast = buildExportStatement(
-    //build JSON.parse(<compiledMessages>) statement
-    t.callExpression(
-      t.memberExpression(
-        t.identifier('JSON'), t.identifier('parse')
-      ),
-      [t.stringLiteral(JSON.stringify(compiledMessages))]
-    ),
+    {
+      //build JSON.parse(<compiledMessages>) statement
+      messages: t.callExpression(
+          t.memberExpression(
+            t.identifier('JSON'), t.identifier('parse')
+          ),
+          [t.stringLiteral(JSON.stringify(compiledMessages))]
+        ),
+      plurals: buildPluralFunctionStatement(plurals),
+    },
     namespace
   )
 
@@ -67,13 +72,33 @@ export function createCompiledCatalog(
   return "/*eslint-disable*/" + code;
 }
 
-function buildExportStatement(expression, namespace: CompiledCatalogNamespace) {
+function buildPluralFunctionStatement(block: string) {
+  const exp = (babelParse(block).program.body[0]);
+
+  // (n, ord) => {...}
+  if (t.isExpressionStatement(exp)) {
+    return exp.expression;
+  }
+
+  // function en(n, ord) => {...}
+  if (t.isFunctionDeclaration(exp)) {
+    return t.functionExpression(exp.id, exp.params, exp.body)
+  }
+
+  throw new Error('Plural rule fn passed to the createCompiledCatalog is malformed');
+}
+
+function buildExportStatement(exports: { [identifier: string]: t.Expression }, namespace: CompiledCatalogNamespace) {
   if (namespace === "es" || namespace === "ts") {
     // export const messages = { message: "Translation" }
-    return t.exportNamedDeclaration(
-      t.variableDeclaration("const", [
-        t.variableDeclarator(t.identifier("messages"), expression),
-      ])
+    return t.program(
+      Object.keys(exports).map((identifier) => {
+        return t.exportNamedDeclaration(
+          t.variableDeclaration("const", [
+            t.variableDeclarator(t.identifier(identifier), exports[identifier]),
+          ]),
+        )
+      }),
     )
   } else {
     let exportExpression = null
@@ -82,13 +107,13 @@ function buildExportStatement(expression, namespace: CompiledCatalogNamespace) {
       // module.exports.messages = { message: "Translation" }
       exportExpression = t.memberExpression(
         t.identifier("module"),
-        t.identifier("exports")
+        t.identifier("exports"),
       )
     } else if (matches) {
       // window.i18nMessages = { messages: { message: "Translation" }}
       exportExpression = t.memberExpression(
         t.identifier(matches[1]),
-        t.identifier(matches[2])
+        t.identifier(matches[2]),
       )
     } else {
       throw new Error(`Invalid namespace param: "${namespace}"`)
@@ -98,10 +123,12 @@ function buildExportStatement(expression, namespace: CompiledCatalogNamespace) {
       t.assignmentExpression(
         "=",
         exportExpression,
-        t.objectExpression([
-          t.objectProperty(t.identifier("messages"), expression),
-        ])
-      )
+        t.objectExpression(
+          Object.keys(exports).map((identifier) => {
+            return t.objectProperty(t.identifier(identifier), exports[identifier])
+          }),
+        ),
+      ),
     )
   }
 }

--- a/packages/cli/src/lingui-compile.ts
+++ b/packages/cli/src/lingui-compile.ts
@@ -54,6 +54,8 @@ function command(config: LinguiConfig, options) {
         sourceLocale: config.sourceLocale,
       })
 
+      const plurals = catalog.getPluralRule(locale)
+
       if (!options.allowEmpty) {
         const missingMsgIds = R.pipe(R.pickBy(R.isNil), R.keys)(messages)
 
@@ -85,7 +87,7 @@ function command(config: LinguiConfig, options) {
         const namespace = options.typescript
           ? "ts"
           : options.namespace || config.compileNamespace
-        const compiledCatalog = createCompiledCatalog(locale, messages, {
+        const compiledCatalog = createCompiledCatalog(locale, messages, plurals, {
           strict: false,
           namespace,
           pseudoLocale: config.pseudoLocale,

--- a/packages/loader/src/webpackLoader.ts
+++ b/packages/loader/src/webpackLoader.ts
@@ -66,13 +66,14 @@ export default function (source) {
     sourceLocale: config.sourceLocale,
   })
 
+
   // In production we don't want untranslated strings. It's better to use message
   // keys as a last resort.
   // In development, however, we want to catch missing strings with `missing` parameter
   // of I18nProvider (React) or setupI18n (core) and therefore we need to get
   // empty translations if missing.
   const strict = process.env.NODE_ENV !== "production"
-  return createCompiledCatalog(locale, messages, {
+  return createCompiledCatalog(locale, messages, catalog.getPluralRule(locale), {
     strict,
     namespace: config.compileNamespace,
     pseudoLocale: config.pseudoLocale,

--- a/packages/snowpack-plugin/src/index.ts
+++ b/packages/snowpack-plugin/src/index.ts
@@ -51,7 +51,7 @@ function extractLinguiMessages(snowpackConfig?, linguiConfig: LinguiConfigOpts =
         return acc
       }, {})
 
-      const compiled = createCompiledCatalog(locale, messages, {
+      const compiled = createCompiledCatalog(locale, messages, catalog.getPluralRule(locale), {
         strict,
         namespace: config.compileNamespace,
         pseudoLocale: config.pseudoLocale,

--- a/packages/snowpack-plugin/test/__snapshots__/index.ts.snap
+++ b/packages/snowpack-plugin/test/__snapshots__/index.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`snowpack-plugin should return compiled catalog 1`] = `/*eslint-disable*/module.exports={messages:JSON.parse("{\\"Hello World\\":\\"Hello World\\",\\"My name is {name}\\":[\\"My name is \\",[\\"name\\"]]}")};`;
+exports[`snowpack-plugin should return compiled catalog 1`] = `/*eslint-disable*/module.exports={messages:JSON.parse("{\\"Hello World\\":\\"Hello World\\",\\"My name is {name}\\":[\\"My name is \\",[\\"name\\"]]}"),plurals:function en(n,ord){var s=String(n).split("."),v0=!s[1],t0=Number(s[0])==n,n10=t0&&s[0].slice(-1),n100=t0&&s[0].slice(-2);if(ord)return n10==1&&n100!=11?"one":n10==2&&n100!=12?"two":n10==3&&n100!=13?"few":"other";return n==1&&v0?"one":"other"}};`;
 
 exports[`snowpack-plugin should return error if import doesn't contain extension 1`] = `@lingui/snowpack-plugin: File extension is mandatory, for ex: import('./locales/en/messages.po')`;
 


### PR DESCRIPTION
## Description
This PR adds support for emiting plural rule (what `make-plural/plurals` is currently used for) into compiled catalog. 
This allows users to avoid installing and importing `make-plural/plurals` in theirs code and use only catalogs instead. 

Following official [documentation](https://lingui.js.org/guides/dynamic-loading-catalogs.html#final-i18n-loader-helper) preferred way to setup is: 

```typescript
import { i18n } from '@lingui/core';
import { en, cs } from 'make-plural/plurals'

i18n.loadLocaleData({
  en: { plurals: en },
  cs: { plurals: cs },
})

export async function dynamicActivate(locale: string) {
  const { messages } = await import(`./locales/${locale}/messages`)
  i18n.load(locale, messages)
  i18n.activate(locale)
}
```

Which is in fact will always load plurals functions for locales which are currently not used on the page. 

After this change, user would be able to write like this: 
```typescript
import { i18n } from "@lingui/core"

export async function dynamicActivate(locale: string) {
  const { messages, plurals } = await import(`./locales/${locale}/messages`)
  i18n.load(locale, messages)

  i18n.loadLocaleData(locale, {
    plurals
  })

  i18n.activate(locale)
}
```

## Notes

1. I'm taking the plural function from `make-plural/plurals` and serialize it into the string. Then when compiling catalogs into AST I convert stringified function into AST and inject to the output file. 

Compilation now produces: 

```typescript
module.exports = {
    messages: {"Hello": "Alohà"},
    plurals: (n, ord) => {
        return n == 1 ? "one" : "other"
    }
}
```