### PR TITLE
fix(conf): proper typings for LinguiConfig['runtimeConfigModule']

### DIFF
--- a/packages/conf/index.d.ts
+++ b/packages/conf/index.d.ts
@@ -49,7 +49,10 @@ export declare type LinguiConfig = {
     orderBy: OrderBy;
     pseudoLocale: string;
     rootDir: string;
-    runtimeConfigModule: [string, string?];
+    runtimeConfigModule: [source: string, identifier?: string] | {
+        i18n?: [source: string, identifier?: string]
+        Trans?: [source: string, identifier?: string]
+    };
     sourceLocale: string;
     service: CatalogService;
 };
@@ -77,7 +80,7 @@ export declare const configValidation: {
         orderBy: OrderBy;
         pseudoLocale: string;
         rootDir: string;
-        runtimeConfigModule: [string, string?];
+        runtimeConfigModule: LinguiConfig['runtimeConfigModule'];
         sourceLocale: string;
         service: CatalogService;
     };

--- a/packages/macro/src/index.ts
+++ b/packages/macro/src/index.ts
@@ -6,7 +6,7 @@ import MacroJSX from "./macroJsx"
 
 const config = getConfig({ configPath: process.env.LINGUI_CONFIG })
 
-const getSymbolSource = (name: string) => {
+const getSymbolSource = (name: 'i18n' | 'Trans'): [source: string, identifier?: string] => {
   if (Array.isArray(config.runtimeConfigModule)) {
     if (name === "i18n") {
       return config.runtimeConfigModule
@@ -14,9 +14,7 @@ const getSymbolSource = (name: string) => {
       return ["@lingui/react", name]
     }
   } else {
-    if (
-      Object.prototype.hasOwnProperty.call(config.runtimeConfigModule, name)
-    ) {
+    if (config.runtimeConfigModule[name]) {
       return config.runtimeConfigModule[name]
     } else {
       return ["@lingui/react", name]


### PR DESCRIPTION
https://lingui.js.org/ref/conf.html#id12

runtimeConfigModule should accepts or tuple or object with properties, this PR fixing typings to reflect this