### PR TITLE
docs: Fix syntax of extracted comments in PO files

### DIFF
--- a/docs/ref/catalog-formats.rst
+++ b/docs/ref/catalog-formats.rst
@@ -25,7 +25,7 @@ The advantages of this format are:
 .. code-block:: po
 
    #: src/App.js:3
-   #  Comment for translators
+   #. Comment for translators
    msgid "messageId"
    msgstr "Translated Message"
 
@@ -53,28 +53,32 @@ This is how the regular PO format exports plurals:
 
 With `po-gettext`, plural messages are exported in the following way, depending on wheter an explicit ID is set:
 
-.. code-block:: po
+1. Message **with custom ID "my_message"** that is pluralized on property "someCount".
 
-   # Message with custom ID "my_message" that is pluralized on property "someCount".
-   #
-   # Notice that 'msgid_plural' was generad by appending a '_plural' suffix.
-   #. js-lingui:pluralize_on=someCount
-   msgid "my_message"
-   msgid_plural "my_message_plural"
-   msgstr[0] "Singular case"
-   msgstr[1] "Case number {someCount}"
+   Notice that 'msgid_plural' was generad by appending a '_plural' suffix.
 
-   # Message without custom ID that is pluralized on property "anotherCount".
-   #
-   # Notice how 'msgid' and 'msgid_plural' were extracted from original message.
-   #
-   # To allow matching this PO item to the appropriate catalog entry when deserializing,
-   # the original ICU message is also stored in the generated comment.
-   #. js-lingui:icu=%7BanotherCount%2C+plural%2C+one+%7BSingular+case%7D+other+%7BCase+number+%7BanotherCount%7D%7D%7D&pluralize_on=anotherCount
-   msgid "Singular case"
-   msgid_plural "Case number {anotherCount}"
-   msgstr[0] "Singular case"
-   msgstr[1] "Case number {anotherCount}"
+   .. code-block:: po
+
+      #. js-lingui:pluralize_on=someCount
+      msgid "my_message"
+      msgid_plural "my_message_plural"
+      msgstr[0] "Singular case"
+      msgstr[1] "Case number {someCount}"
+
+2. Message **without custom ID** that is pluralized on property "anotherCount".
+
+   Notice how 'msgid' and 'msgid_plural' were extracted from original message.
+
+   To allow matching this PO item to the appropriate catalog entry when deserializing,
+   the original ICU message is also stored in the generated comment.
+
+   .. code-block:: po
+
+      #. js-lingui:icu=%7BanotherCount%2C+plural%2C+one+%7BSingular+case%7D+other+%7BCase+number+%7BanotherCount%7D%7D%7D&pluralize_on=anotherCount
+      msgid "Singular case"
+      msgid_plural "Case number {anotherCount}"
+      msgstr[0] "Singular case"
+      msgstr[1] "Case number {anotherCount}"
 
 Note that this format comes with several caveats and should therefore only be used if using ICU plurals in PO files is
 not an option:


### PR DESCRIPTION
This PR fixes docs, particularly syntax of extracted comments in PO files in the Catalog Formats section. It was incorrectly showing that comments for translators would be prefixed with `# ` instead of `#. `
Also, I have visually broken up a section in the same file to be more legible.