### PR TITLE
fix(cli): catalogsMergePath doesn't merge catalogs

### DIFF
--- a/packages/cli/src/lingui-compile.ts
+++ b/packages/cli/src/lingui-compile.ts
@@ -116,12 +116,18 @@ function command(config: LinguiConfig, options) {
 
     if (doMerge) {
       const compileCatalog = getCatalogForMerge(config)
+      const namespace = options.namespace || config.compileNamespace
       const compiledCatalog = createCompiledCatalog(locale, mergedCatalogs, {
         strict: false,
-        namespace: options.namespace || config.compileNamespace,
+        namespace: namespace,
         pseudoLocale: config.pseudoLocale,
+        compilerBabelOptions: config.compilerBabelOptions
       })
-      const compiledPath = compileCatalog.writeCompiled(locale, compiledCatalog)
+      const compiledPath = compileCatalog.writeCompiled(
+        locale,
+        compiledCatalog,
+        namespace
+      )
       options.verbose && console.log(chalk.green(`${locale} ⇒ ${compiledPath}`))
     }
   })

--- a/packages/cli/src/lingui-compile.ts
+++ b/packages/cli/src/lingui-compile.ts
@@ -7,7 +7,7 @@ import * as plurals from "make-plural"
 
 import { getConfig, LinguiConfig } from "@lingui/conf"
 
-import { getCatalogs } from "./api/catalog"
+import { getCatalogForMerge, getCatalogs } from "./api/catalog"
 import { createCompiledCatalog } from "./api/compile"
 import { helpRun } from "./api/help"
 import { getFormat } from "./api"
@@ -113,6 +113,17 @@ function command(config: LinguiConfig, options) {
           console.error(chalk.green(`${locale} ⇒ ${compiledPath}`))
       }
     })
+
+    if (doMerge) {
+      const compileCatalog = getCatalogForMerge(config)
+      const compiledCatalog = createCompiledCatalog(locale, mergedCatalogs, {
+        strict: false,
+        namespace: options.namespace || config.compileNamespace,
+        pseudoLocale: config.pseudoLocale,
+      })
+      const compiledPath = compileCatalog.writeCompiled(locale, compiledCatalog)
+      options.verbose && console.log(chalk.green(`${locale} ⇒ ${compiledPath}`))
+    }
   })
   return true
 }


### PR DESCRIPTION
This PR fixes #1233.
Previously, the catalogs were not merge even if `catalogsMergePath` option was provided in the configuration. The `getCatalogForMerge()` function was never called from the code (it was used only in tests).