### PR TITLE
ci: fix the 'size-limit' workflow (2)

### DIFF
--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -1,9 +1,11 @@
 name: Size Testing
 
 on:
-  pull_request:
-    branches:
-      - '*'
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
 
 jobs:
   size:


### PR DESCRIPTION
The previous PR #1333 probably was a bit incorrect, reverting it back (added the `reopened` type also)