### PR TITLE
fix(cli): incorrect main entry in package.json

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,13 +18,13 @@
     "name": "Tomáš Ehrlich",
     "email": "tomas.ehrlich@gmail.com"
   },
-  "main": "./build/index.js",
+  "main": "./build/lingui.js",
   "bin": {
     "lingui": "./build/lingui.js"
   },
   "exports": {
     ".": {
-      "require": "./build/index.js"
+      "require": "./build/lingui.js"
     },
     "./api": {
       "require": "./build/api/index.js"


### PR DESCRIPTION
This PR fixes the incorrect `main` entry in `package.json` of `@lingui/cli`. This was [causing Bundlephobia to report ](https://bundlephobia.com/package/@lingui/cli@3.16.0) `EntryPointError` on the new 3.16.0 version of the package.