### PR TITLE
fix(build): Revert typescript update

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "strip-ansi": "^6.0.0",
     "swc-node": "^1.0.0",
     "ts-jest": "^26.4.1",
-    "typescript": "^4.9.4",
+    "typescript": "^4.0.3",
     "yalc": "^1.0.0-pre.45"
   },
   "workspaces": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -83,7 +83,7 @@
     "@types/papaparse": "^5.2.3",
     "@types/plurals-cldr": "^1.0.1",
     "mockdate": "^3.0.2",
-    "typescript": "^4.9.4"
+    "typescript": "^4.0.3"
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12665,10 +12665,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.9.4:
-  version "4.9.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.4.tgz#a2a3d2756c079abda241d75f149df9d561091e78"
-  integrity sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==
+typescript@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.3.tgz#153bbd468ef07725c1df9c77e8b453f8d36abba5"
+  integrity sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==
 
 uglify-js@^3.1.4:
   version "3.11.5"


### PR DESCRIPTION
This PR reverts the update of the Typescript package made in #1357 which caused the following error in the `create-react-app` example when running the `react-scripts start` command:

> `TypeError: Cannot assign to read only property 'jsx' of object **'#<Object>'`


This shows we need to have stronger integration tests put in place.