### PR TITLE
docs(): replace defaults -> message

### DIFF
--- a/docs/misc/react-intl.rst
+++ b/docs/misc/react-intl.rst
@@ -25,7 +25,7 @@ Looking at the low-level API of `LinguiJS`_, there isn't much difference:
 
    <Trans
       id="welcome"
-      defaults={`Hello {name}, you have {unreadCount, number} {unreadCount, plural,
+      message={`Hello {name}, you have {unreadCount, number} {unreadCount, plural,
         one {message}
         other {messages}
       }`}
@@ -62,7 +62,7 @@ In `react-intl`_, this would be translated as:
 
    <Trans
        id='msg.docs'
-       defaults='Read the <0>documentation</0>.'
+       message='Read the <0>documentation</0>.'
        components={[
            <a href="/docs" />
        ]}
@@ -95,7 +95,7 @@ All we need to do is to wrap the message in a :jsxmacro:`Trans` macro:
    </p>
 
 The macro then parses the :jsxmacro:`Trans` macro children and generates
-``defaults`` and ``components`` props automatically in the form described in the previous section.
+``message`` and ``components`` props automatically in the form described in the previous section.
 
 This is extremely useful when adding i18n to an existing project. All we need is to wrap
 all messages in :jsxmacro:`Trans` macro.
@@ -165,7 +165,7 @@ and the final message would be very similar:
 
    <Trans
       id="welcome"
-      defaults={`Hello <0>{name}</0>, you have {unreadCount, number} {unreadCount, plural,
+      message={`Hello <0>{name}</0>, you have {unreadCount, number} {unreadCount, plural,
         one {message}
         other {messages}
       }`}

--- a/docs/ref/catalog-formats.rst
+++ b/docs/ref/catalog-formats.rst
@@ -83,9 +83,9 @@ With `po-gettext`, plural messages are exported in the following way, depending 
 Note that this format comes with several caveats and should therefore only be used if using ICU plurals in PO files is
 not an option:
 
-  - Nested/multiple plurals in one message as shown in :jsmacro:`plural` are not supported as they cannot be expressed 
+  - Nested/multiple plurals in one message as shown in :jsmacro:`plural` are not supported as they cannot be expressed
     with gettext plurals. Messages containing nested/multiple formats will not be output correctly.
-  
+
   - :jsmacro:`select` and :jsmacro:`selectOrdinal` cannot be expressed with gettext plurals, but the original ICU format
     is still saved to the `msgid`/`msgstr` properties. To disable the warning that this might not be the expected
     behavior, include :code:`{ disableSelectWarning: true }` in the :conf:`formatOptions`.
@@ -126,7 +126,7 @@ process catalog data.
    {
       "messageId": {
          "translation": "Translated message",
-         "defaults": "Default message",
+         "message": "Default message",
          "description": "Comment for translators",
          "origin": [["src/App.js", 3]]
       },

--- a/docs/ref/conf.rst
+++ b/docs/ref/conf.rst
@@ -378,7 +378,7 @@ Raw catalog data serialized to JSON:
    {
      "MessageID": {
        "translation": "Translated Message",
-       "defaults": "Default string (from source code)",
+       "message": "Default string (from source code)",
        "origin": [
          ["path/to/src.js", 42]
        ]
@@ -409,7 +409,7 @@ locales
 Default: ``[]``
 
 Locale tags which are used in the project. :cli:`extract` and :cli:`compile`
-writes one catalog for each locale. Each locale should be a valid `BCP-47 code <http://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html>`_ code. If you use a string that is not a BCP-47, make sure to use a BCP-47 when defining plurals in 18n.loadLocaleData. 
+writes one catalog for each locale. Each locale should be a valid `BCP-47 code <http://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html>`_ code. If you use a string that is not a BCP-47, make sure to use a BCP-47 when defining plurals in 18n.loadLocaleData.
 
 For example for `pt-br`: ``i18n.loadLocaleData('pt-br', { plurals: pt })``
 

--- a/docs/ref/core.rst
+++ b/docs/ref/core.rst
@@ -144,7 +144,7 @@ Reference
 
       ``values`` is an object of variables used in translated message.
 
-      ``options.defaults`` is the default translation (optional). This is mostly used when
+      ``options.message`` is the default translation (optional). This is mostly used when
       application doesn't use message IDs in natural language (e.g.: ``msg.id`` or
       ``Component.title``).
 
@@ -159,7 +159,7 @@ Reference
          i18n._("My name is {name}", { name: "Tom" })
 
          // Message with custom messageId
-         i18n._("msg.id", { name: "Tom" }, { defaults: "My name is {name}" })
+         i18n._("msg.id", { name: "Tom" }, { message: "My name is {name}" })
 
    .. js:method:: date(value: string | Date[, format: Intl.DateTimeFormatOptions])
 
@@ -394,7 +394,7 @@ Triggered **after** locale is changed or new catalog is loaded. There are no arg
 missing
 -------
 
-Triggered when a translation is requested with ``i18n._`` that does not exist in the active locale's messages. 
+Triggered when a translation is requested with ``i18n._`` that does not exist in the active locale's messages.
 Information about the locale and message are available from the event.
 
 .. code-block:: js

--- a/docs/tutorials/react.rst
+++ b/docs/tutorials/react.rst
@@ -72,7 +72,7 @@ Setup
 We will directly start translating the ``Inbox`` component, but we need
 to complete one more step to setup our application.
 
-Components needs to read information about current language and message catalogs from ``i18n`` instance. 
+Components needs to read information about current language and message catalogs from ``i18n`` instance.
 Initially, you can use the one created and exported from ``@lingui/core`` and later you can replace with
 your one if such need arise.
 
@@ -136,7 +136,7 @@ macro:
 .. code-block:: jsx
 
    import { Trans } from '@lingui/macro'
-   
+
    <h1><Trans>Message Inbox</Trans></h1>
 
 Macros vs. Components
@@ -188,8 +188,8 @@ We're going to use `CLI` again. Run :cli:`extract` command to extract messages::
 
    Add 'locales' to your configuration. See https://lingui.js.org/ref/conf.html#locales
 
-We need here to fix the configuration. Create a ``.linguirc`` file with 
-   
+We need here to fix the configuration. Create a ``.linguirc`` file with
+
 .. code-block:: json
 
    {
@@ -482,7 +482,7 @@ This will generate:
 
 .. code-block:: jsx
 
-   <h1><Trans id="inbox.title" defaults="Message Inbox" /></h1>
+   <h1><Trans id="inbox.title" message="Message Inbox" /></h1>
 
 In our message catalog, we'll see ``inbox.title`` as message ID, but we also
 get ``Message Inbox`` as default translation for English.
@@ -637,7 +637,7 @@ However, decimal numbers (even ``1.0``) use ``other`` form every time::
 
    There are 0.0 messages in your inbox.
 
-Aren't languages beautiful? 
+Aren't languages beautiful?
 
 Exact forms
 -----------


### PR DESCRIPTION
Signature was changed 2 -> 3, but docs still have `defaults` prop

https://lingui.js.org/releases/migration-3.html#:~:text=.%20The%20third%20parameter%20now%20accepts%20default%20message%20in%20message%20prop%2C%20instead%20of%20defaults