### PR TITLE
chore(verdaccio): setup verdaccio integration test on PR + fix execution

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -1,6 +1,9 @@
 name: release-workflow-test
 
 on:
+  pull_request:
+    branches:
+      - '*'
   push:
     branches:
       - main
@@ -28,7 +31,7 @@ jobs:
 
       - name: Publish with Verdaccio
         run: |
-          git checkout ${{ github.head_ref }}
+          git switch -c "pull-request"
           npm i -g {verdaccio,verdaccio-auth-memory,verdaccio-memory}
           mkdir -p $HOME/.config/verdaccio
           cp --verbose .github/verdaccio/config.yaml $HOME/.config/verdaccio/config.yaml

--- a/scripts/verdaccio-release.js
+++ b/scripts/verdaccio-release.js
@@ -12,33 +12,16 @@ async function releaseInVerdaccio() {
   )
   spinner.succeed()
 
-  spinner.start("Versioning packages")
-  const { stdout: actualBranch } = await exec("git rev-parse --abbrev-ref HEAD")
-  await exec(
-    `npx lerna version patch --exact --no-git-tag-version --force-publish --no-private --no-push --yes --allow-branch ${actualBranch}`
-  )
-  spinner.succeed()
-
   spinner.start("Building packages")
   await exec("yarn release:build")
   spinner.succeed()
 
-  spinner.start(
-    "Dont't mark files as changed to let publish, but not create a git history"
-  )
-  await exec("git commit --all -m \"TEMP: verdaccio release\"")
+  spinner.start("Versioning and Publishing packages to local registry")
+  const { stdout: actualBranch } = await exec("git rev-parse --abbrev-ref HEAD")
 
-  spinner.succeed()
-
-  spinner.start("Publishing packages to local registry")
   await exec(
-    `npx lerna publish from-package --force-publish --no-git-tag-version --no-private --no-push --yes --allow-branch ${actualBranch} --registry="http://0.0.0.0:4873"
-  `
-  )
-  spinner.succeed()
-
-  spinner.start("Reverting the changed files from index")
-  await exec("git reset --soft HEAD~1")
+    `npx lerna publish patch --force-publish --no-git-tag-version --no-private --no-push --yes --allow-branch ${actualBranch} --registry="http://0.0.0.0:4873"
+  `)
   spinner.succeed()
 
   console.log()


### PR DESCRIPTION
Using trial & error approach found that if we version & publish in one command we can completely remove manipulation with git state. 

I also enabled this WF for pull requests because it's very nice to have e2e tests run automatically. 

And i'm going in next iterations to extend this script to run tests not only in CRA project but also in rest examples as well
