### PR TITLE
test(): properly resolve path to macro in tests

### DIFF
--- a/packages/babel-plugin-extract-messages/test/index.ts
+++ b/packages/babel-plugin-extract-messages/test/index.ts
@@ -42,7 +42,13 @@ function testCase(testName, assertion) {
         configFile: false,
         plugins: [
           "@babel/plugin-syntax-jsx",
-          "macros",
+          ["macros", {
+            // macro plugin uses package `resolve` to find a path of macro file
+            // this will not follow jest pathMapping and will resolve path from ./build
+            // instead of ./src which makes testing & developing hard.
+            // here we override resolve and provide correct path for testing
+            resolvePath: (source: string) => require.resolve(source)
+          }],
           [
             plugin,
             {

--- a/packages/macro/test/index.ts
+++ b/packages/macro/test/index.ts
@@ -34,7 +34,15 @@ describe("macro", function () {
     filename: "<filename>",
     configFile: false,
     presets: [],
-    plugins: ["@babel/plugin-syntax-jsx", "macros"],
+    plugins: [
+      "@babel/plugin-syntax-jsx",
+      ["macros", {
+      // macro plugin uses package `resolve` to find a path of macro file
+      // this will not follow jest pathMapping and will resolve path from ./build
+      // instead of ./src which makes testing & developing hard.
+      // here we override resolve and provide correct path for testing
+      resolvePath: (source: string) => require.resolve(source)
+    }]]
   }
 
   // return function, so we can test exceptions


### PR DESCRIPTION
During working on latest PRs i noticed that macro in tests resolved from './build' instead of "./src" that makes development tricky. This PR fixes this behaviour. 
