### PR TITLE
fix: types declaration inside package entrypoints

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,10 +31,12 @@
   },
   "exports": {
     ".": {
+      "types": "./build/index.d.ts",
       "require": "./build/cjs/index.js",
       "import": "./build/esm/index.js"
     },
     "./compile": {
+      "types": "./build/compile.d.ts",
       "require": "./build/cjs/compile.js",
       "import": "./build/esm/compile.js"
     },

--- a/packages/detect-locale/package.json
+++ b/packages/detect-locale/package.json
@@ -31,6 +31,7 @@
   },
   "exports": {
     ".": {
+      "types": "./build/index.d.ts",
       "require": "./build/cjs/index.js",
       "import": "./build/esm/index.js"
     },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -33,6 +33,7 @@
   },
   "exports": {
     ".": {
+      "types": "./build/index.d.ts",
       "require": "./build/cjs/index.js",
       "import": "./build/esm/index.js"
     },

--- a/packages/remote-loader/package.json
+++ b/packages/remote-loader/package.json
@@ -34,6 +34,7 @@
   },
   "exports": {
     ".": {
+      "types": "./build/index.d.ts",
       "require": "./build/cjs/index.js",
       "import": "./build/esm/index.js"
     },


### PR DESCRIPTION
ESM module resolver doesn't fallback to main + module + types when `exports` present, that means types won't be discovered if they're not declared inside `exports`.

Links:
- https://www.typescriptlang.org/docs/handbook/esm-node.html
- https://nodejs.org/api/packages.html