### PR TITLE
fix(conf): lazy load cosmiconfig's TypeScriptLoader

### DIFF
--- a/packages/conf/package.json
+++ b/packages/conf/package.json
@@ -34,5 +34,17 @@
   ],
   "devDependencies": {
     "ts-node": "^10.9.1"
+  },
+  "peerDependencies": {
+    "ts-node": ">=10",
+    "typescript": ">=4"
+  },
+  "peerDependenciesMeta": {
+    "ts-node": {
+      "optional": true
+    },
+    "typescript": {
+      "optional": true
+    }
   }
 }

--- a/packages/conf/src/index.ts
+++ b/packages/conf/src/index.ts
@@ -2,9 +2,8 @@ import type { GeneratorOptions } from "@babel/core"
 import path from "path"
 import fs from "fs"
 import chalk from "chalk"
-import { cosmiconfigSync } from "cosmiconfig"
+import { cosmiconfigSync, type LoaderSync } from "cosmiconfig"
 import { multipleValidOptions, validate } from "jest-validate"
-import { TypeScriptLoader } from "cosmiconfig-typescript-loader";
 
 export type CatalogFormat = "lingui" | "minimal" | "po" | "csv"
 
@@ -102,6 +101,19 @@ export const defaultConfig: LinguiConfig = {
 
 function configExists(path) {
   return path && fs.existsSync(path)
+}
+
+function TypeScriptLoader(): LoaderSync {
+  let loaderInstance: LoaderSync
+  return (filepath, content) => {
+    if (!loaderInstance) {
+      const { TypeScriptLoader } =
+        require("cosmiconfig-typescript-loader") as typeof import("cosmiconfig-typescript-loader")
+      loaderInstance = TypeScriptLoader()
+    }
+
+    return loaderInstance(filepath, content)
+  }
 }
 
 export function getConfig({


### PR DESCRIPTION
# Description

This PR is attempt to fix: https://github.com/lingui/js-lingui/issues/1401

[cosmiconfig-typescript-loader](https://github.com/Codex-/cosmiconfig-typescript-loader/blob/main/lib/loader.ts) written in the way that it doesn't matter do you really load a Typescript file in config or not, once this loader is added to cosmiconfig it requires ts-node and typescript. This is indeed unwanted behavior because some of the users may not have them and may not want to use them at all. 

This PR changes 2 things: 

1. Lazy load the loader, once cosmiconfig discovered a config with ts extension
2. Add peerDependecies on `typescript` and `ts-node` for the `@lingui/conf` package. And also i marked them as optional. 

Why this happened? Why our test didn't catch this? 

It's because node modules resolution system works like that. 
Take 'examples/create-react-app' as an example. It has it's own pacakge.json and own `node_modules`. 
Furthermore, it doesn't list `ts-node` in this file, and indeed `node_modules` folder doesn't have this dependency. So why this project doesn't fall with that change? 

It's because we have another `node_modules` folder on the root level of monorepo and node found this module there. 

- root
  - node_modules <-- from here
  - examples
      - create-react-app
          - node_modules
          - package.json

     
## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
