### PR TITLE
chore(tests): collect coverage from all files, not only included in tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
-const { pathsToModuleNameMapper } = require('ts-jest/utils');
-const tsConfig = require( './tsconfig.json');
+const { pathsToModuleNameMapper } = require("ts-jest/utils")
+const tsConfig = require("./tsconfig.json")
 
 /**
  * @type {import('jest').Config}
@@ -12,6 +12,12 @@ module.exports = {
   testURL: "http://localhost",
 
   collectCoverage: true,
+  collectCoverageFrom: [
+    "**/*.{ts,tsx}",
+    "!**/*.d.ts",
+    "!**/node_modules/**",
+    "!**/build/**",
+  ],
   coverageDirectory: "<rootDir>/coverage/",
   coveragePathIgnorePatterns: [
     "node_modules",
@@ -25,11 +31,11 @@ module.exports = {
   coverageReporters: ["html", "lcov", "text"],
   modulePathIgnorePatterns: ["/build"],
   moduleNameMapper: pathsToModuleNameMapper(tsConfig.compilerOptions.paths, {
-    prefix: '<rootDir>/',
+    prefix: "<rootDir>/",
   }),
 
   reporters: ["default", "jest-junit"],
-  setupFiles: ['set-tz/utc'],
+  setupFiles: ["set-tz/utc"],
   setupFilesAfterEnv: [require.resolve("./scripts/jest/env.js")],
   snapshotSerializers: [
     "jest-serializer-html",


### PR DESCRIPTION
# Description

By default Jest collect coverage only from files which included in compilation. This produce inaccurate coverage. This change brings collecting coverage from all files.

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Chore
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
