### PR TITLE
Fix param name for `missing` in `setupI18nProps`

### DIFF
--- a/packages/core/src/i18n.ts
+++ b/packages/core/src/i18n.ts
@@ -58,7 +58,7 @@ type setupI18nProps = {
   locales?: Locales
   messages?: AllMessages
   localeData?: AllLocaleData
-  missing?: string | ((message: string, id: string, context: string) => string)
+  missing?: string | ((locale: string, id: string, context: string) => string)
 }
 
 type Events = {

--- a/website/docs/ref/core.md
+++ b/website/docs/ref/core.md
@@ -289,13 +289,13 @@ const i18n = setupI18n({ missing: "🚨" })
 i18n._('missing translation') === "🚨"
 ```
 
-This might be also a function which is called with active language and message ID:
+This might be also a function which is called with active locale and message ID:
 
 ``` jsx
 import { setupI18n } from "@lingui/core"
 
-function missing(language, id) {
-   alert(`Translation in ${language} for ${id} is missing!`)
+function missing(locale, id) {
+   alert(`Translation in ${locale} for ${id} is missing!`)
    return id
 }
 


### PR DESCRIPTION
# Description

`setupI18nProps.missing` will be called with first param as the `locale` if its a function, but the type states `message` which is a bit misleading.

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works

param name change in type and doc change only

- [ ] I have added necessary documentation (if appropriate)
