### PR TITLE
docs(config): encourage user to use js config instead of json

### DIFF
--- a/website/docs/tools/introduction.md
+++ b/website/docs/tools/introduction.md
@@ -37,16 +37,18 @@ Instead of manually sending and receiving many emails and fixing the inconsisten
 
 ## Configure your project
 
-To synchronize your current application with an online tool, you just have to add these lines at the end of your `.linguirc` configuration file:
+To synchronize your current application with an online tool, you just have to add these lines at the end of your `lingui.config.js` configuration file:
 
-```js title=".linguirc"
-{
+```js title="lingui.config.js"
+/** @type {import('@lingui/conf').LinguiConfig} */
+module.exports = {
   [...]
-  "service": {
-    "name": "ToolName",
-    "apiKey": "abcdefghijklmnopqrstuvwxyz012345"
+  service: {
+    name: "ToolName",
+    apiKey: "abcdefghijklmnopqrstuvwxyz012345"
   }
 }
+
 ```
 
 The synchronization will then be part of the [`extract`](/docs/ref/cli.md#extract) command.

--- a/website/docs/tutorials/react.md
+++ b/website/docs/tutorials/react.md
@@ -156,14 +156,15 @@ No locales defined!
 Add 'locales' to your configuration. See https://lingui.dev/ref/conf#locales
 ```
 
-We need here to fix the configuration. Create a `.linguirc` file:
+We need here to fix the configuration. Create a `lingui.config.js` file:
 
-```json title=".linguirc"
-{
-  "locales": ["cs", "en"],
-  "catalogs": [{
-    "path": "src/locales/{locale}/messages",
-    "include": ["src"]
+```js title="lingui.config.js"
+/** @type {import('@lingui/conf').LinguiConfig} */
+module.exports = {
+  locales: ["cs", "en"],
+  catalogs: [{
+    path: "src/locales/{locale}/messages",
+    include: ["src"]
   }]
 }
 ```

--- a/website/docs/tutorials/setup-cra.md
+++ b/website/docs/tutorials/setup-cra.md
@@ -25,17 +25,18 @@
     npm install --save @lingui/macro @lingui/react
     ```
 
-3.  Create `.linguirc` file with LinguiJS configuration in root of your project (next to `package.json`):
+3.  Create `lingui.config.js` file with LinguiJS configuration in root of your project (next to `package.json`):
 
-    ``` json title=".linguirc"
-    {
-       "locales": ["en", "cs", "fr"],
-       "sourceLocale": "en",
-       "catalogs": [{
-          "path": "src/locales/{locale}/messages",
-          "include": ["src"]
+    ```js title="lingui.config.js"
+    /** @type {import('@lingui/conf').LinguiConfig} */
+    module.exports = {
+       locales: ["en", "cs", "fr"],
+       sourceLocale: "en",
+       catalogs: [{
+          path: "src/locales/{locale}/messages",
+          include: ["src"]
        }],
-       "format": "po"
+       format: "po"
     }
     ```
 

--- a/website/docs/tutorials/setup-react.md
+++ b/website/docs/tutorials/setup-react.md
@@ -38,16 +38,17 @@ This setup guide is for any project which uses React.
     If you use any preset, check first if it contains `macros` plugin. These presets already includes `macros` plugin: `react-scripts`
     :::
 
-3.  Create `.linguirc` file with LinguiJS configuration in root of your project (next to `package.json`). Replace `src` with a directory name where you have source files:
+3.  Create `lingui.config.js` file with LinguiJS configuration in root of your project (next to `package.json`). Replace `src` with a directory name where you have source files:
 
-    ```json title=".linguirc"
-    {
-       "locales": ["en", "cs", "fr"],
-       "catalogs": [{
-          "path": "src/locales/{locale}/messages",
-          "include": ["src"]
+    ```js title="lingui.config.js"
+    /** @type {import('@lingui/conf').LinguiConfig} */
+    module.exports = {
+       locales: ["en", "cs", "fr"],
+       catalogs: [{
+          path: "src/locales/{locale}/messages",
+          include: ["src"]
        }],
-       "format": "po"
+       format: "po"
     }
     ```
 


### PR DESCRIPTION
# Description

JS Config is better than json in almost every aspect. Let's encourage user's to use this type of configs instead of `.linguirc`

**Benefits:**
1. Syntax highlighting out of the box, without need to setup your IDE (`.linguirc` has a custom extension, so it would be plain text by default, not a json)
2. Autocomplete, thanks to typescript types and jsdoc comment
3. Support comments
4. Can be dynamically produced. For example list of locales could be reused from nextjs config. 
5. It's flexible for every setup. 

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
