### PR TITLE
refactor: replace `transform` with `transformSync` for typescript extractor

### DIFF
--- a/packages/cli/src/api/extractors/typescript.ts
+++ b/packages/cli/src/api/extractors/typescript.ts
@@ -1,5 +1,5 @@
 import fs from "fs"
-import { transform } from "@babel/core"
+import { transformSync } from "@babel/core"
 import linguiExtractMessages from "@lingui/babel-plugin-extract-messages"
 
 import { projectType } from "../detect"
@@ -47,7 +47,7 @@ const extractor: ExtractorType = {
       plugins.unshift(require.resolve("@babel/plugin-syntax-jsx"))
     }
 
-    transform(stripped.outputText, {
+    transformSync(stripped.outputText, {
       ...babelOptions,
       ...frameworkOptions,
       filename,


### PR DESCRIPTION
# Description

`transform` behaves `synchronously` in Babel 7 just because of the backward-compatibility, according to the doc, this  backward-compatibility will be dropped in Babel 8, so it's recommended to use `transformSync` instead for the same functionality

https://babeljs.io/docs/en/babel-core#transform

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue) - fix for future compatibility
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [] I have added tests that prove my fix is effective or that my feature works
- [] I have added necessary documentation (if appropriate)
