### PR TITLE
refactor: no `console.error` on informational output

### DIFF
--- a/packages/cli/src/lingui-extract-template.ts
+++ b/packages/cli/src/lingui-extract-template.ts
@@ -29,7 +29,7 @@ export default async function command(
   // safer to introduce a new env variable. LINGUI_EXTRACT=1 during `lingui extract`
   process.env.LINGUI_EXTRACT = "1"
 
-  options.verbose && console.error("Extracting messages from source files…")
+  options.verbose && console.log("Extracting messages from source files…")
   const catalogs = getCatalogs(config)
   const catalogStats: { [path: string]: Number } = {}
 

--- a/packages/cli/src/lingui-extract.ts
+++ b/packages/cli/src/lingui-extract.ts
@@ -37,7 +37,7 @@ export default async function command(
   // safer to introduce a new env variable. LINGUI_EXTRACT=1 during `lingui extract`
   process.env.LINGUI_EXTRACT = "1"
 
-  options.verbose && console.error("Extracting messages from source files…")
+  options.verbose && console.log("Extracting messages from source files…")
 
   const catalogs = getCatalogs(config)
   const catalogStats: { [path: string]: AllCatalogsType } = {}
@@ -61,12 +61,12 @@ export default async function command(
   })
 
   if (!options.watch) {
-    console.error(
+    console.log(
       `(use "${chalk.yellow(
         helpRun("extract")
       )}" to update catalogs with new messages)`
     )
-    console.error(
+    console.log(
       `(use "${chalk.yellow(
         helpRun("compile")
       )}" to compile catalogs for production)`


### PR DESCRIPTION
# Description

I am not sure what are the conventional of using the `console.log` vs `console.error` here, but I think `log` is better in these cases.

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Refactor (non-breaking change to improve code readability etc)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
