### PR TITLE
refactor(cli): add TS typings remove code duplication in po / po-gettext formats

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -73,7 +73,7 @@
     "papaparse": "^5.3.0",
     "pkg-up": "^3.1.0",
     "plurals-cldr": "^1.0.4",
-    "pofile": "^1.1.0",
+    "pofile": "^1.1.4",
     "pseudolocale": "^1.1.0",
     "ramda": "^0.27.1"
   },

--- a/packages/cli/src/api/formats/index.ts
+++ b/packages/cli/src/api/formats/index.ts
@@ -19,7 +19,7 @@ const formats: Record<CatalogFormat, CatalogFormatter> = {
  * @internal
  */
 export type CatalogFormatOptionsInternal = {
-  locale: string
+  locale?: string
 } & CatalogFormatOptions
 
 export type CatalogFormatter = {

--- a/packages/cli/src/api/formats/po-gettext.test.ts
+++ b/packages/cli/src/api/formats/po-gettext.test.ts
@@ -6,7 +6,7 @@ import path from "path"
 import PO from "pofile"
 
 import { CatalogType } from "../catalog"
-import format from "./po-gettext"
+import format, { serialize } from "./po-gettext"
 
 describe("po-gettext format", () => {
   const dateHeaders = {
@@ -274,7 +274,7 @@ describe("po-gettext format", () => {
     }
 
     mockConsole((console) => {
-      format.serialize(catalog, {})
+      serialize(catalog, {})
 
       expect(console.warn).toHaveBeenCalledWith(
         expect.stringContaining("Nested plurals"),
@@ -324,7 +324,7 @@ msgstr[2] "# dní"
 
     it("should warn", () => {
       mockConsole((console) => {
-        format.serialize(catalog, {})
+        serialize(catalog, {})
 
         expect(console.warn).toHaveBeenCalledWith(
           expect.stringContaining("select"),
@@ -335,7 +335,7 @@ msgstr[2] "# dní"
 
     it("should not warn when disabling the warning in config", () => {
       mockConsole((console) => {
-        format.serialize(catalog, { disableSelectWarning: true })
+        serialize(catalog, { disableSelectWarning: true })
 
         expect(console.warn).not.toHaveBeenCalled()
       })
@@ -352,7 +352,7 @@ msgstr[2] "# dní"
 
     it("should warn", () => {
       mockConsole((console) => {
-        format.serialize(catalog, {})
+        serialize(catalog, {})
 
         expect(console.warn).toHaveBeenCalledWith(
           expect.stringContaining("selectOrdinal"),
@@ -363,7 +363,7 @@ msgstr[2] "# dní"
 
     it("should not warn when disabling the warning in config", () => {
       mockConsole((console) => {
-        format.serialize(catalog, { disableSelectWarning: true })
+        serialize(catalog, { disableSelectWarning: true })
 
         expect(console.warn).not.toHaveBeenCalled()
       })

--- a/packages/cli/src/api/formats/po-gettext.ts
+++ b/packages/cli/src/api/formats/po-gettext.ts
@@ -3,17 +3,17 @@ import fs from "fs"
 import { parse as parseIcu, Select, SelectCase } from "@messageformat/parser"
 import pluralsCldr from "plurals-cldr"
 import PO from "pofile"
-import * as R from "ramda"
 import gettextPlurals from "node-gettext/lib/plurals"
 
 import { CatalogType, MessageType } from "../catalog"
-import { joinOrigin, splitOrigin, writeFileIfChanged } from "../utils"
+import { writeFileIfChanged } from "../utils"
 import type { CatalogFormatOptionsInternal, CatalogFormatter } from "./"
+import { deserialize, serialize as serializePo } from "./po"
 
 // Workaround because pofile doesn't support es6 modules, see https://github.com/rubenv/pofile/pull/38#issuecomment-623119284
-type POItemType = InstanceType<typeof PO.Item>
+type POItem = InstanceType<typeof PO.Item>
 
-function getCreateHeaders(language = "no") {
+function getCreateHeaders(language = "no"): PO["headers"] {
   return {
     "POT-Creation-Date": formatDate(new Date(), "yyyy-MM-dd HH:mmxxxx"),
     "MIME-Version": "1.0",
@@ -51,155 +51,105 @@ const LINE_ENDINGS = /\r?\n/g
 // Prefix that is used to identitify context information used by this module in PO's "extracted comments".
 const CTX_PREFIX = "js-lingui:"
 
-const serialize = (
-  items: CatalogType,
-  options: CatalogFormatOptionsInternal & { disableSelectWarning: boolean }
-) =>
-  R.compose(
-    R.values,
-    R.mapObjIndexed((message: MessageType, key) => {
-      const item = new PO.Item()
-      item.msgid = key
-      item.comments = message.comments || []
+function serializePlurals(
+  item: POItem,
+  message: MessageType,
+  id: string,
+  options: CatalogFormatOptionsInternal
+): POItem {
+  // Depending on whether custom ids are used by the developer, the (potential plural) "original", untranslated ICU
+  // message can be found in `message.message` or in the item's `key` itself.
+  const icuMessage = message.message || id
 
-      // The extractedComments array may be modified in this method, so create a new array with the message's elements.
-      // Destructuring `undefined` is forbidden, so fallback to `[]` if the message has no extracted comments.
-      item.extractedComments = [...(message.extractedComments ?? [])]
+  const _simplifiedMessage = icuMessage.replace(LINE_ENDINGS, " ")
 
-      if (message.context) {
-        item.msgctxt = message.context
+  // Quick check to see if original message is a plural localization.
+  if (ICU_PLURAL_REGEX.test(_simplifiedMessage)) {
+    try {
+      const messageAst = parseIcu(icuMessage)[0] as Select
+
+      // Check if any of the plural cases contain plurals themselves.
+      if (
+        messageAst.cases.some((icuCase) =>
+          icuCase.tokens.some((token) => token.type === "plural")
+        )
+      ) {
+        console.warn(
+          `Nested plurals cannot be expressed with gettext plurals. ` +
+            `Message with key "%s" will not be saved correctly.`,
+          id
+        )
       }
-      if (options.origins !== false) {
-        if (message.origin && options.lineNumbers === false) {
-          item.references = message.origin.map(([path]) => path)
-        } else {
-          item.references = message.origin ? message.origin.map(joinOrigin) : []
-        }
-      }
 
-      // @ts-ignore: Figure out how to set this flag
-      item.obsolete = message.obsolete
-      item.flags = message.flags
-        ? R.fromPairs(message.flags.map((flag) => [flag, true]))
-        : {}
+      // Store placeholder that is pluralized upon to allow restoring ICU format later.
+      const ctx = new URLSearchParams({
+        pluralize_on: messageAst.arg,
+      })
 
-      // Depending on whether custom ids are used by the developer, the (potential plural) "original", untranslated ICU
-      // message can be found in `message.message` or in the item's `key` itself.
-      const icuMessage = message.message || key
+      if (message.message == null) {
+        // For messages without developer-set ID, use first case as `msgid` and the last case as `msgid_plural`.
+        // This does not necessarily make sense for development languages with more than two numbers, but gettext
+        // only supports exactly two plural forms.
+        item.msgid = stringifyICUCase(messageAst.cases[0])
+        item.msgid_plural = stringifyICUCase(
+          messageAst.cases[messageAst.cases.length - 1]
+        )
 
-      const _simplifiedMessage = icuMessage.replace(LINE_ENDINGS, " ")
-
-      // Quick check to see if original message is a plural localization.
-      if (ICU_PLURAL_REGEX.test(_simplifiedMessage)) {
-        try {
-          const messageAst = parseIcu(icuMessage)[0] as Select
-
-          // Check if any of the plural cases contain plurals themselves.
-          if (
-            messageAst.cases.some((icuCase) =>
-              icuCase.tokens.some((token) => token.type === "plural")
-            )
-          ) {
-            console.warn(
-              `Nested plurals cannot be expressed with gettext plurals. ` +
-                `Message with key "%s" will not be saved correctly.`,
-              key
-            )
-          }
-
-          // Store placeholder that is pluralized upon to allow restoring ICU format later.
-          const ctx = new URLSearchParams({
-            pluralize_on: messageAst.arg,
-          })
-
-          if (message.message == null) {
-            // For messages without developer-set ID, use first case as `msgid` and the last case as `msgid_plural`.
-            // This does not necessarily make sense for development languages with more than two numbers, but gettext
-            // only supports exactly two plural forms.
-            item.msgid = stringifyICUCase(messageAst.cases[0])
-            item.msgid_plural = stringifyICUCase(
-              messageAst.cases[messageAst.cases.length - 1]
-            )
-
-            // Since the original msgid is overwritten, store ICU message to allow restoring that ID later.
-            ctx.set("icu", key)
-          } else {
-            // For messages with developer-set ID, append `_plural` to the key to generate `msgid_plural`.
-            item.msgid_plural = key + "_plural"
-          }
-
-          ctx.sort()
-          item.extractedComments.push(CTX_PREFIX + ctx.toString())
-
-          // If there is a translated value, parse that instead of the original message to prevent overriding localized
-          // content with the original message. If there is no translated value, don't touch msgstr, since marking item as
-          // plural (above) already causes `pofile` to automatically generate `msgstr[0]` and `msgstr[1]`.
-          if (message.translation?.length > 0) {
-            try {
-              const ast = parseIcu(message.translation)[0] as Select
-              if (ast.cases == null) {
-                console.warn(
-                  `Found translation without plural cases for key "${key}". ` +
-                    `This likely means that a translated .po file misses multiple msgstr[] entries for the key. ` +
-                    `Translation found: "${message.translation}"`
-                )
-                item.msgstr = [message.translation]
-              } else {
-                item.msgstr = ast.cases.map(stringifyICUCase)
-              }
-            } catch (e) {
-              console.error(`Error parsing translation ICU for key "${key}"`, e)
-            }
-          }
-        } catch (e) {
-          console.error(`Error parsing message ICU for key "${key}":`, e)
-        }
+        // Since the original msgid is overwritten, store ICU message to allow restoring that ID later.
+        ctx.set("icu", id)
       } else {
-        if (
-          !options.disableSelectWarning &&
-          ICU_SELECT_REGEX.test(_simplifiedMessage)
-        ) {
-          console.warn(
-            `ICU 'select' and 'selectOrdinal' formats cannot be expressed natively in gettext format. ` +
-              `Item with key "%s" will be included in the catalog as raw ICU message. ` +
-              `To disable this warning, include '{ disableSelectWarning: true }' in the config's 'formatOptions'`,
-            key
-          )
-        }
-        item.msgstr = [message.translation]
+        // For messages with developer-set ID, append `_plural` to the key to generate `msgid_plural`.
+        item.msgid_plural = id + "_plural"
       }
 
-      return item
-    })
-  )(items)
+      ctx.sort()
+      item.extractedComments.push(CTX_PREFIX + ctx.toString())
 
-const getMessageKey = R.prop<"msgid", string>("msgid")
-const getTranslations = R.prop<"msgstr", string[]>("msgstr")
-const getExtractedComments = R.prop("extractedComments")
-const getTranslatorComments = R.prop("comments")
-const getMessageContext = R.prop("msgctxt")
-const getOrigins = R.prop("references")
-const getFlags = R.compose(
-  R.map(R.trim),
-  R.keys,
-  R.dissoc("obsolete"), // backward-compatibility, remove in 3.x
-  R.prop("flags")
-)
-const isObsolete = R.either(R.path(["flags", "obsolete"]), R.prop("obsolete"))
+      // If there is a translated value, parse that instead of the original message to prevent overriding localized
+      // content with the original message. If there is no translated value, don't touch msgstr, since marking item as
+      // plural (above) already causes `pofile` to automatically generate `msgstr[0]` and `msgstr[1]`.
+      if (message.translation?.length > 0) {
+        const ast = parseIcu(message.translation)[0] as Select
+        if (ast.cases == null) {
+          console.warn(
+            `Found translation without plural cases for key "${id}". ` +
+              `This likely means that a translated .po file misses multiple msgstr[] entries for the key. ` +
+              `Translation found: "${message.translation}"`
+          )
+          item.msgstr = [message.translation]
+        } else {
+          item.msgstr = ast.cases.map(stringifyICUCase)
+        }
+      }
+    } catch (e) {
+      console.error(`Error parsing message ICU for key "${id}":`, e)
+    }
+  } else {
+    if (
+      !options.disableSelectWarning &&
+      ICU_SELECT_REGEX.test(_simplifiedMessage)
+    ) {
+      console.warn(
+        `ICU 'select' and 'selectOrdinal' formats cannot be expressed natively in gettext format. ` +
+          `Item with key "%s" will be included in the catalog as raw ICU message. ` +
+          `To disable this warning, include '{ disableSelectWarning: true }' in the config's 'formatOptions'`,
+        id
+      )
+    }
+    item.msgstr = [message.translation]
+  }
 
-const getTranslationCount = R.compose(R.length, getTranslations)
+  return item
+}
 
-const deserialize: (Object) => Object = R.map(
-  R.applySpec({
-    translation: R.compose(R.head, R.defaultTo([]), getTranslations),
-    extractedComments: R.compose(R.defaultTo([]), getExtractedComments),
-    comments: R.compose(R.defaultTo([]), getTranslatorComments),
-    context: R.compose(R.defaultTo(null), getMessageContext),
-    obsolete: isObsolete,
-    origin: R.compose(R.map(splitOrigin), R.defaultTo([]), getOrigins),
-    flags: getFlags,
-  })
-)
+export const serialize = (
+  catalog: CatalogType,
+  options: CatalogFormatOptionsInternal
+) => {
+  return serializePo(catalog, options, (item, message, id) =>
+    serializePlurals(item, message, id, options)
+  )
+}
 
 /**
  * Returns ICU case labels in the order that gettext lists localized messages, e.g. 0,1,2 => `["one", "two", "other"]`.
@@ -216,109 +166,97 @@ const getPluralCases = (lang: string): string[] | undefined => {
   const [correctLang] = lang.split(/[-_]/g)
   const gettextPluralsInfo = gettextPlurals[correctLang]
 
-  return gettextPluralsInfo?.examples.map((pluralCase) =>
+  return gettextPluralsInfo?.examples.map((pluralCase: any) =>
     pluralsCldr(correctLang, pluralCase.sample)
   )
 }
 
-const convertPluralsToICU = (items: POItemType[], lang?: string) => {
-  // .po plurals are numbered 0-N and need to be mapped to ICU plural classes ("one", "few", "many"...). Different
-  // languages can have different plural classes (some start with "zero", some with "one"), so read that data from CLDR.
-  // `pluralForms` may be `null` if lang is not found. As long as no plural is used, don't report an error.
-  let pluralForms = getPluralCases(lang)
+const convertPluralsToICU = (
+  item: POItem,
+  pluralForms: string[],
+  lang: string
+) => {
+  const translationCount = item.msgstr.length
+  const messageKey = item.msgid
 
-  items.forEach((item) => {
-    const translationCount = getTranslationCount(item)
-    const messageKey = getMessageKey(item)
+  // Messages without multiple translations (= plural cases) need no further processing.
+  if (translationCount <= 1 && !item.msgid_plural) {
+    return
+  }
 
-    // Messages without multiple translations (= plural cases) need no further processing.
-    if (translationCount <= 1 && !item.msgid_plural) {
-      return
-    }
+  // msgid_plural must be set, but its actual value is not important.
+  if (!item.msgid_plural) {
+    console.warn(
+      `Multiple translations for item with key "%s" but missing 'msgid_plural' in catalog "${lang}". This is not supported and the plural cases will be ignored.`,
+      messageKey
+    )
+    return
+  }
 
-    // msgid_plural must be set, but its actual value is not important.
-    if (!item.msgid_plural) {
-      console.warn(
-        `Multiple translations for item with key "%s" but missing 'msgid_plural' in catalog "${lang}". This is not supported and the plural cases will be ignored.`,
-        messageKey
-      )
-      return
-    }
+  const contextComment = item.extractedComments
+    .find((comment) => comment.startsWith(CTX_PREFIX))
+    ?.substr(CTX_PREFIX.length)
+  const ctx = new URLSearchParams(contextComment)
 
-    const contextComment = item.extractedComments
-      .find((comment) => comment.startsWith(CTX_PREFIX))
-      ?.substr(CTX_PREFIX.length)
-    const ctx = new URLSearchParams(contextComment)
+  if (contextComment != null) {
+    item.extractedComments = item.extractedComments.filter(
+      (comment) => !comment.startsWith(CTX_PREFIX)
+    )
+  }
 
-    if (contextComment != null) {
-      item.extractedComments = item.extractedComments.filter(
-        (comment) => !comment.startsWith(CTX_PREFIX)
-      )
-    }
+  // If an original ICU was stored, use that as `msgid` to match the catalog that was originally exported.
+  const storedICU = ctx.get("icu")
+  if (storedICU != null) {
+    item.msgid = storedICU
+  }
 
-    // If an original ICU was stored, use that as `msgid` to match the catalog that was originally exported.
-    const storedICU = ctx.get("icu")
-    if (storedICU != null) {
-      item.msgid = storedICU
-    }
+  // If all translations are empty, ignore item.
+  if (item.msgstr.every((str) => str.length === 0)) {
+    return
+  }
 
-    // If all translations are empty, ignore item.
-    if (item.msgstr.every((str) => str.length === 0)) {
-      return
-    }
+  if (pluralForms == null) {
+    console.warn(
+      `Multiple translations for item with key "%s" in language "${lang}", but no plural cases were found. ` +
+        `This prohibits the translation of .po plurals into ICU plurals. Pluralization will not work for this key.`,
+      messageKey
+    )
+    return
+  }
 
-    if (pluralForms == null) {
-      console.warn(
-        `Multiple translations for item with key "%s" in language "${lang}", but no plural cases were found. ` +
-          `This prohibits the translation of .po plurals into ICU plurals. Pluralization will not work for this key.`,
-        messageKey
-      )
-      return
-    }
+  const pluralCount = pluralForms.length
+  if (translationCount > pluralCount) {
+    console.warn(
+      `More translations provided (${translationCount}) for item with key "%s" in language "${lang}" than there are plural cases available (${pluralCount}). ` +
+        `This will result in not all translations getting picked up.`,
+      messageKey
+    )
+  }
 
-    const pluralCount = pluralForms.length
-    if (translationCount > pluralCount) {
-      console.warn(
-        `More translations provided (${translationCount}) for item with key "%s" in language "${lang}" than there are plural cases available (${pluralCount}). ` +
-          `This will result in not all translations getting picked up.`,
-        messageKey
-      )
-    }
+  // Map each msgstr to a "<pluralform> {<translated_string>}" entry, joined by one space.
+  const pluralClauses = item.msgstr
+    .map((str, index) => pluralForms[index] + " {" + str + "}")
+    .join(" ")
 
-    // Map each msgstr to a "<pluralform> {<translated_string>}" entry, joined by one space.
-    const pluralClauses = item.msgstr
-      .map((str, index) => pluralForms[index] + " {" + str + "}")
-      .join(" ")
+  // Find out placeholder name from item's message context, defaulting to "count".
+  let pluralizeOn = ctx.get("pluralize_on")
+  if (!pluralizeOn) {
+    console.warn(
+      `Unable to determine plural placeholder name for item with key "%s" in language "${lang}" (should be stored in a comment starting with "#. ${CTX_PREFIX}"), assuming "count".`,
+      messageKey
+    )
+    pluralizeOn = "count"
+  }
 
-    // Find out placeholder name from item's message context, defaulting to "count".
-    let pluralizeOn = ctx.get("pluralize_on")
-    if (!pluralizeOn) {
-      console.warn(
-        `Unable to determine plural placeholder name for item with key "%s" in language "${lang}" (should be stored in a comment starting with "#. ${CTX_PREFIX}"), assuming "count".`,
-        messageKey
-      )
-      pluralizeOn = "count"
-    }
-
-    item.msgstr = ["{" + pluralizeOn + ", plural, " + pluralClauses + "}"]
-  })
+  item.msgstr = ["{" + pluralizeOn + ", plural, " + pluralClauses + "}"]
 }
 
-const indexItems = R.indexBy(getMessageKey)
-
-type PoFormatter = {
-  parse: (raw: string) => Object
-  serialize: (
-    catalog: CatalogType,
-    options: Record<string, any>
-  ) => POItemType[]
-}
-
-const poGettext: CatalogFormatter & PoFormatter = {
+const poGettext: CatalogFormatter = {
   catalogExtension: ".po",
 
   write(filename, catalog: CatalogType, options) {
-    let po
+    let po: PO
+
     if (fs.existsSync(filename)) {
       const raw = fs.readFileSync(filename).toString()
       po = PO.parse(raw)
@@ -328,14 +266,12 @@ const poGettext: CatalogFormatter & PoFormatter = {
       if (options.locale === undefined) {
         delete po.headers.Language
       }
-      po.headerOrder = Object.keys(po.headers)
+      // accessing private property
+      ;(po as any).headerOrder = Object.keys(po.headers)
     }
-    po.items = this.serialize(catalog, options)
+    po.items = serialize(catalog, options)
     writeFileIfChanged(filename, po.toString())
   },
-
-  // Mainly exported for easier testing
-  serialize,
 
   read(filename) {
     const raw = fs.readFileSync(filename).toString()
@@ -344,8 +280,15 @@ const poGettext: CatalogFormatter & PoFormatter = {
 
   parse(raw: string) {
     const po = PO.parse(raw)
-    convertPluralsToICU(po.items, po.headers.Language)
-    return deserialize(indexItems(po.items)) as CatalogType
+
+    // .po plurals are numbered 0-N and need to be mapped to ICU plural classes ("one", "few", "many"...). Different
+    // languages can have different plural classes (some start with "zero", some with "one"), so read that data from CLDR.
+    // `pluralForms` may be `null` if lang is not found. As long as no plural is used, don't report an error.
+    let pluralForms = getPluralCases(po.headers.Language)
+
+    return deserialize(po.items, (item) => {
+      convertPluralsToICU(item, pluralForms, po.headers.Language)
+    })
   },
 }
 

--- a/packages/cli/src/api/formats/po.test.ts
+++ b/packages/cli/src/api/formats/po.test.ts
@@ -145,8 +145,9 @@ describe("pofile format", () => {
     mockConsole((console) => {
       const actual = format.read(filename)
       expect(console.warn).toHaveBeenCalledWith(
-        expect.stringContaining("Multiple translations"),
-        "withMultipleTranslation"
+        expect.stringContaining(
+          "Multiple translations for item with key withMultipleTranslation is not supported and it will be ignored."
+        )
       )
       mockFs.restore()
       expect(actual).toMatchSnapshot()

--- a/packages/cli/src/api/utils.ts
+++ b/packages/cli/src/api/utils.ts
@@ -19,7 +19,7 @@ export function prettyOrigin(origins: [filename: string, line?: number][]) {
  *    If unknown commands is passed to CLI, check it agains all available commands
  *    for possible misspelled letter. Output help with suggestions to console.
  */
-export function helpMisspelledCommand(command, availableCommands = []) {
+export function helpMisspelledCommand(command: string, availableCommands = []) {
   const commandNames = availableCommands.map((command) => command.name())
 
   // if no command is supplied, then commander.js shows help automatically
@@ -48,11 +48,15 @@ export function helpMisspelledCommand(command, availableCommands = []) {
   }
 }
 
-export const splitOrigin = (origin) => origin.split(":")
+export const splitOrigin = (origin: string) => {
+  const [file, line] = origin.split(":")
+  return [file, line ? Number(line) : null] as [file: string, line: number]
+}
 
-export const joinOrigin = (origin) => origin.join(":")
+export const joinOrigin = (origin: [file: string, line?: number]): string =>
+  origin.join(":")
 
-export function writeFileIfChanged(filename, newContent) {
+export function writeFileIfChanged(filename: string, newContent: string) {
   if (fs.existsSync(filename)) {
     const raw = fs.readFileSync(filename).toString()
     if (newContent !== raw) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9535,7 +9535,7 @@ plurals-cldr@^1.0.4:
   resolved "https://registry.yarnpkg.com/plurals-cldr/-/plurals-cldr-1.0.4.tgz#534e4784f80679d3b0b39b0fb6cc46645fcf5de8"
   integrity sha512-4nLXqtel7fsCgzi8dvRZvUjfL8SXpP982sKg7b2TgpnR8rDnes06iuQ83trQ/+XdtyMIQkBBbKzX6x97eLfsJQ==
 
-pofile@^1.1.0:
+pofile@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/pofile/-/pofile-1.1.4.tgz#eab7e29f5017589b2a61b2259dff608c0cad76a2"
   integrity sha512-r6Q21sKsY1AjTVVjOuU02VYKVNQGJNQHjTIvs4dEbeuuYfxgYk/DGD2mqqq4RDaVkwdSq0VEtmQUOPe/wH8X3g==


### PR DESCRIPTION
# Description

I want to clean up code and have full typings coverage in the cli before i can start to work on new features.

Rewrite formats to the typescript.  Reduced code duplication between po / po-gettext formats.

No changes in logic.

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
