### PR TITLE
fix: chain extract on watched file changes

### DIFF
--- a/packages/cli/src/lingui-extract.ts
+++ b/packages/cli/src/lingui-extract.ts
@@ -176,9 +176,14 @@ if (require.main === module) {
 
   const changedPaths = new Set<string>()
   let debounceTimer: NodeJS.Timer
+  let previousExtract = Promise.resolve(true)
   const dispatchExtract = (filePath?: string[]) => {
-    // Skip debouncing if not enabled
-    if (!program.debounce) return extract(filePath)
+    // Skip debouncing if not enabled but still chain them so no racing issue
+    // on deleting the tmp folder.
+    if (!program.debounce) {
+      previousExtract = previousExtract.then(() => extract(filePath))
+      return previousExtract
+    }
 
     filePath?.forEach((path) => changedPaths.add(path))
 


### PR DESCRIPTION
# Description

This avoids a racing when run extract with `--watch` (no debounce) when multiple files changed together (or in a very short period of time)

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Fixes [# 1434](https://github.com/lingui/js-lingui/issues/1434)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works - I did not find any existing tests on watch mode, so just tested manually on `example/js` folder
- [ ] I have added necessary documentation (if appropriate)
