### PR TITLE
feat(macro): support JSX macro inside conditional expressions

### DIFF
--- a/packages/macro/src/macroJsx.test.ts
+++ b/packages/macro/src/macroJsx.test.ts
@@ -1,12 +1,28 @@
-import { parseExpression as _parseExpression } from "@babel/parser"
 import * as types from "@babel/types"
 import MacroJSX, { normalizeWhitespace } from "./macroJsx"
-import { JSXElement } from "@babel/types"
+import { transformSync } from "@babel/core"
+import type { NodePath } from "@babel/traverse"
+import type { JSXElement } from "@babel/types"
 
-const parseExpression = (expression: string) =>
-  _parseExpression(expression, {
-    plugins: ["jsx"],
-  }) as JSXElement
+const parseExpression = (expression: string) => {
+  let path: NodePath<JSXElement>
+
+  transformSync(expression, {
+    filename: "unit-test.js",
+    plugins: [
+      {
+        visitor: {
+          JSXElement: (d) => {
+            path = d
+            d.stop()
+          },
+        },
+      },
+    ],
+  })
+
+  return path
+}
 
 function createMacro() {
   return new MacroJSX({ types }, { stripNonEssentialProps: false })
@@ -302,20 +318,22 @@ describe("jsx macro", () => {
         }),
         format: "plural",
         options: {
-          one: {
-            type: "arg",
-            name: "gender",
-            value: expect.objectContaining({
+          one: [
+            {
+              type: "arg",
               name: "gender",
-              type: "Identifier",
-            }),
-            format: "select",
-            options: {
-              male: "he",
-              female: "she",
-              other: "they",
+              value: expect.objectContaining({
+                name: "gender",
+                type: "Identifier",
+              }),
+              format: "select",
+              options: {
+                male: "he",
+                female: "she",
+                other: "they",
+              },
             },
-          },
+          ],
         },
       })
     })
@@ -332,7 +350,7 @@ describe("jsx macro", () => {
         />`
       )
       const tokens = macro.tokenizeNode(exp)
-      expect(tokens).toMatchObject({
+      expect(tokens[0]).toMatchObject({
         format: "select",
         name: "gender",
         options: {

--- a/packages/macro/src/macroJsx.ts
+++ b/packages/macro/src/macroJsx.ts
@@ -1,5 +1,6 @@
 import * as babelTypes from "@babel/types"
 import {
+  ConditionalExpression,
   Expression,
   JSXAttribute,
   JSXElement,
@@ -283,6 +284,10 @@ export default class MacroJSX {
           ]
         })
       }
+      if (exp.isConditionalExpression()) {
+        return [this.tokenizeConditionalExpression(exp)]
+      }
+
       if (exp.isJSXElement()) {
         return this.tokenizeNode(exp)
       }
@@ -407,6 +412,25 @@ export default class MacroJSX {
       type: "arg",
       name: this.expressionToArgument(path),
       value: path.node as Expression,
+    }
+  }
+
+  tokenizeConditionalExpression = (
+    exp: NodePath<ConditionalExpression>
+  ): ArgToken => {
+    exp.traverse({
+      JSXElement: (el) => {
+        if (this.isI18nComponent(el) || this.isChoiceComponent(el)) {
+          this.replacePath(el)
+          el.skip()
+        }
+      },
+    })
+
+    return {
+      type: "arg",
+      name: this.expressionToArgument(exp),
+      value: exp.node,
     }
   }
 

--- a/packages/macro/src/macroJsx.ts
+++ b/packages/macro/src/macroJsx.ts
@@ -1,13 +1,12 @@
-import * as R from "ramda"
 import * as babelTypes from "@babel/types"
 import {
   Expression,
-  Identifier,
   JSXAttribute,
   JSXElement,
   JSXExpressionContainer,
   JSXIdentifier,
   JSXSpreadAttribute,
+  Literal,
   Node,
   StringLiteral,
 } from "@babel/types"
@@ -18,14 +17,15 @@ import ICUMessageFormat, {
   ElementToken,
   TextToken,
   Token,
-  Tokens,
 } from "./icu"
-import { makeCounter, zip } from "./utils"
+import { makeCounter } from "./utils"
 import { COMMENT, CONTEXT, ID, MESSAGE } from "./constants"
 
 const pluralRuleRe = /(_[\d\w]+|zero|one|two|few|many|other)/
 const jsx2icuExactChoice = (value: string) =>
   value.replace(/_(\d+)/, "=$1").replace(/_(\w+)/, "$1")
+
+type JSXChildPath = NodePath<JSXElement["children"][number]>
 
 // replace whitespace before/after newline with single space
 const keepSpaceRe = /\s*(?:\r\n|\r|\n)+\s*/g
@@ -82,7 +82,7 @@ export default class MacroJSX {
   }
 
   replacePath = (path: NodePath) => {
-    const tokens = this.tokenizeNode(path.node)
+    const tokens = this.tokenizeNode(path)
 
     const messageFormat = new ICUMessageFormat()
     const {
@@ -93,7 +93,7 @@ export default class MacroJSX {
     const message = normalizeWhitespace(messageRaw)
 
     const { attributes, id, comment, context } = this.stripMacroAttributes(
-      path.node as JSXElement
+      path as NodePath<JSXElement>
     )
 
     if (!id && !message) {
@@ -172,11 +172,11 @@ export default class MacroJSX {
       this.types.jsxOpeningElement(
         this.types.jsxIdentifier("Trans"),
         attributes,
-        /*selfClosing*/ true
+        true
       ),
-      /*closingElement*/ null,
-      /*children*/ [],
-      /*selfClosing*/ true
+      null,
+      [],
+      true
     )
     newNode.loc = path.node.loc
 
@@ -191,17 +191,17 @@ export default class MacroJSX {
     }
   }
 
-  stripMacroAttributes = (node: JSXElement) => {
-    const { attributes } = node.openingElement
+  stripMacroAttributes = (path: NodePath<JSXElement>) => {
+    const { attributes } = path.node.openingElement
     const id = attributes.filter(this.attrName([ID]))[0]
     const message = attributes.filter(this.attrName([MESSAGE]))[0]
     const comment = attributes.filter(this.attrName([COMMENT]))[0]
     const context = attributes.filter(this.attrName([CONTEXT]))[0]
 
     let reserved = [ID, MESSAGE, COMMENT, CONTEXT]
-    if (this.isI18nComponent(node)) {
+    if (this.isI18nComponent(path)) {
       // no reserved prop names
-    } else if (this.isChoiceComponent(node)) {
+    } else if (this.isChoiceComponent(path)) {
       reserved = [
         ...reserved,
         "_\\w+",
@@ -226,87 +226,84 @@ export default class MacroJSX {
     }
   }
 
-  tokenizeNode = (node: Node): Tokens => {
-    if (this.isI18nComponent(node)) {
+  tokenizeNode = (path: NodePath): Token[] => {
+    if (this.isI18nComponent(path)) {
       // t
-      return this.tokenizeTrans(node)
-    } else if (this.isChoiceComponent(node)) {
+      return this.tokenizeTrans(path)
+    } else if (this.isChoiceComponent(path)) {
       // plural, select and selectOrdinal
-      return this.tokenizeChoiceComponent(node)
-    } else if (this.types.isJSXElement(node)) {
-      return this.tokenizeElement(node)
+      return [this.tokenizeChoiceComponent(path)]
+    } else if (path.isJSXElement()) {
+      return [this.tokenizeElement(path)]
     } else {
-      return this.tokenizeExpression(node)
+      return [this.tokenizeExpression(path)]
     }
   }
 
-  tokenizeTrans = (node: JSXElement): Token[] => {
-    return R.flatten(
-      node.children.map((child) => this.tokenizeChildren(child)).filter(Boolean)
-    )
+  tokenizeTrans = (path: NodePath<JSXElement>): Token[] => {
+    return path
+      .get("children")
+      .flatMap((child) => this.tokenizeChildren(child))
+      .filter(Boolean)
   }
 
-  tokenizeChildren = (node: JSXElement["children"][number]): Tokens => {
-    if (this.types.isJSXExpressionContainer(node)) {
-      const exp = node.expression
+  tokenizeChildren = (path: JSXChildPath): Token[] => {
+    if (path.isJSXExpressionContainer()) {
+      const exp = path.get("expression") as NodePath<Expression>
 
-      if (this.types.isStringLiteral(exp)) {
+      if (exp.isStringLiteral()) {
         // Escape forced newlines to keep them in message.
-        return {
-          type: "text",
-          value: exp.value.replace(/\n/g, "\\n"),
-        }
-      } else if (this.types.isTemplateLiteral(exp)) {
-        const tokenize = R.pipe(
-          // Don"t output tokens without text.
-          R.evolve({
-            quasis: R.map((text: babelTypes.TemplateElement) => {
-              // if it's an unicode we keep the cooked value because it's the parsed value by babel (without unicode chars)
-              // This regex will detect if a string contains unicode chars, when they're we should interpolate them
-              // why? because platforms like react native doesn't parse them, just doing a JSON.parse makes them UTF-8 friendly
-              const value = /\\u[a-fA-F0-9]{4}|\\x[a-fA-F0-9]{2}/g.test(
-                text.value.raw
-              )
-                ? text.value.cooked
-                : text.value.raw
-              if (value === "") return null
-
-              return this.tokenizeText(this.clearBackslashes(value))
-            }),
-            expressions: R.map((exp: babelTypes.Expression) =>
-              this.types.isCallExpression(exp)
-                ? this.tokenizeNode(exp)
-                : this.tokenizeExpression(exp)
-            ),
-          }),
-          (exp) => zip(exp.quasis, exp.expressions),
-          R.flatten,
-          R.filter(Boolean)
-        )
-
-        return tokenize(exp)
-      } else if (this.types.isJSXElement(exp)) {
-        return this.tokenizeNode(exp)
-      } else {
-        return this.tokenizeExpression(exp)
+        return [this.tokenizeText(exp.node.value.replace(/\n/g, "\\n"))]
       }
-    } else if (this.types.isJSXElement(node)) {
-      return this.tokenizeNode(node)
-    } else if (this.types.isJSXSpreadChild(node)) {
+      if (exp.isTemplateLiteral()) {
+        const expressions = exp.get("expressions") as NodePath<Expression>[]
+
+        return exp.get("quasis").flatMap(({ node: text }, i) => {
+          // if it's an unicode we keep the cooked value because it's the parsed value by babel (without unicode chars)
+          // This regex will detect if a string contains unicode chars, when they're we should interpolate them
+          // why? because platforms like react native doesn't parse them, just doing a JSON.parse makes them UTF-8 friendly
+          const value = /\\u[a-fA-F0-9]{4}|\\x[a-fA-F0-9]{2}/g.test(
+            text.value.raw
+          )
+            ? text.value.cooked
+            : text.value.raw
+
+          let argTokens: Token[] = []
+          const currExp = expressions[i]
+
+          if (currExp) {
+            argTokens = currExp.isCallExpression()
+              ? this.tokenizeNode(currExp)
+              : [this.tokenizeExpression(currExp)]
+          }
+
+          return [
+            ...(value ? [this.tokenizeText(this.clearBackslashes(value))] : []),
+            ...argTokens,
+          ]
+        })
+      }
+      if (exp.isJSXElement()) {
+        return this.tokenizeNode(exp)
+      }
+      return [this.tokenizeExpression(exp)]
+    } else if (path.isJSXElement()) {
+      return this.tokenizeNode(path)
+    } else if (path.isJSXSpreadChild()) {
       // just do nothing
-    } else if (this.types.isJSXText(node)) {
-      return this.tokenizeText(node.value)
+    } else if (path.isJSXText()) {
+      return [this.tokenizeText(path.node.value)]
     } else {
       // impossible path
       // return this.tokenizeText(node.value)
     }
   }
 
-  tokenizeChoiceComponent = (node: JSXElement): Token => {
-    const element = node.openingElement
-    const format = this.getJsxTagName(node).toLowerCase()
-    const props = element.attributes.filter(
-      this.attrName(
+  tokenizeChoiceComponent = (path: NodePath<JSXElement>): Token => {
+    const element = path.get("openingElement")
+    const format = this.getJsxTagName(path.node).toLowerCase()
+    const props = element.get("attributes").filter((attr) => {
+      return this.attrName(
         [
           ID,
           COMMENT,
@@ -319,8 +316,8 @@ export default class MacroJSX {
           "components",
         ],
         true
-      )
-    )
+      )(attr.node)
+    })
 
     const token: Token = {
       type: "arg",
@@ -332,41 +329,52 @@ export default class MacroJSX {
       },
     }
 
-    for (const attr of props) {
-      if (this.types.isJSXSpreadAttribute(attr)) {
+    for (const _attr of props) {
+      if (_attr.isJSXSpreadAttribute()) {
         continue
       }
 
-      if (this.types.isJSXNamespacedName(attr.name)) {
+      const attr = _attr as NodePath<JSXAttribute>
+
+      if (this.types.isJSXNamespacedName(attr.node.name)) {
         continue
       }
 
-      const name = attr.name.name
+      const name = attr.node.name.name
+      const value = attr.get("value") as
+        | NodePath<Literal>
+        | NodePath<JSXExpressionContainer>
 
       if (name === "value") {
-        const exp = this.types.isLiteral(attr.value)
-          ? attr.value
-          : (attr.value as JSXExpressionContainer).expression
+        const exp = value.isLiteral() ? value : value.get("expression")
+
         token.name = this.expressionToArgument(exp)
-        token.value = exp as Expression
+        token.value = exp.node as Expression
       } else if (format !== "select" && name === "offset") {
         // offset is static parameter, so it must be either string or number
-        token.options.offset = this.types.isStringLiteral(attr.value)
-          ? attr.value.value
-          : ((attr.value as JSXExpressionContainer).expression as StringLiteral)
-              .value
+        token.options.offset =
+          value.isStringLiteral() || value.isNumericLiteral()
+            ? (value.node.value as string)
+            : (
+                (value as NodePath<JSXExpressionContainer>).get(
+                  "expression"
+                ) as NodePath<StringLiteral>
+              ).node.value
       } else {
-        let value: ArgToken["options"][number]
+        let option: ArgToken["options"][number]
 
-        if (this.types.isStringLiteral(attr.value)) {
-          value = (attr.value.extra.raw as string).replace(/(["'])(.*)\1/, "$2")
+        if (value.isStringLiteral()) {
+          option = (value.node.extra.raw as string).replace(
+            /(["'])(.*)\1/,
+            "$2"
+          )
         } else {
-          value = this.tokenizeChildren(attr.value)
+          option = this.tokenizeChildren(value as JSXChildPath)
         }
         if (pluralRuleRe.test(name)) {
-          token.options[jsx2icuExactChoice(name)] = value
+          token.options[jsx2icuExactChoice(name)] = option
         } else {
-          token.options[name] = value
+          token.options[name] = option
         }
       }
     }
@@ -374,30 +382,31 @@ export default class MacroJSX {
     return token
   }
 
-  tokenizeElement = (node: JSXElement): ElementToken => {
+  tokenizeElement = (path: NodePath<JSXElement>): ElementToken => {
     // !!! Important: Calculate element index before traversing children.
     // That way outside elements are numbered before inner elements. (...and it looks pretty).
     const name = this.elementIndex()
-    const children = R.flatten(
-      node.children.map((child) => this.tokenizeChildren(child)).filter(Boolean)
-    )
-
-    node.children = []
-    node.openingElement.selfClosing = true
 
     return {
       type: "element",
       name,
-      value: node,
-      children,
+      value: {
+        ...path.node,
+        children: [],
+        openingElement: {
+          ...path.node.openingElement,
+          selfClosing: true,
+        },
+      },
+      children: this.tokenizeTrans(path),
     }
   }
 
-  tokenizeExpression = (node: Expression | Node): ArgToken => {
+  tokenizeExpression = (path: NodePath<Expression | Node>): ArgToken => {
     return {
       type: "arg",
-      name: this.expressionToArgument(node),
-      value: node as Expression,
+      name: this.expressionToArgument(path),
+      value: path.node as Expression,
     }
   }
 
@@ -408,10 +417,8 @@ export default class MacroJSX {
     }
   }
 
-  expressionToArgument(exp: Expression | Node): string {
-    return this.types.isIdentifier(exp)
-      ? exp.name
-      : String(this.expressionIndex())
+  expressionToArgument(path: NodePath<Expression | Node>): string {
+    return path.isIdentifier() ? path.node.name : String(this.expressionIndex())
   }
 
   /**
@@ -422,27 +429,23 @@ export default class MacroJSX {
     return value.replace(/\\`/g, "`")
   }
 
-  /**
-   * Custom matchers
-   */
-  isIdentifier = (node: Node, name: string): node is Identifier => {
-    return this.types.isIdentifier(node, { name })
-  }
-
-  isI18nComponent = (node: Node, name = "Trans"): node is JSXElement => {
+  isI18nComponent = (
+    path: NodePath,
+    name = "Trans"
+  ): path is NodePath<JSXElement> => {
     return (
-      this.types.isJSXElement(node) &&
-      this.types.isJSXIdentifier(node.openingElement.name, {
+      path.isJSXElement() &&
+      this.types.isJSXIdentifier(path.node.openingElement.name, {
         name,
       })
     )
   }
 
-  isChoiceComponent = (node: Node): node is JSXElement => {
+  isChoiceComponent = (path: NodePath): path is NodePath<JSXElement> => {
     return (
-      this.isI18nComponent(node, "Plural") ||
-      this.isI18nComponent(node, "Select") ||
-      this.isI18nComponent(node, "SelectOrdinal")
+      this.isI18nComponent(path, "Plural") ||
+      this.isI18nComponent(path, "Select") ||
+      this.isI18nComponent(path, "SelectOrdinal")
     )
   }
 

--- a/packages/macro/test/jsx-trans.ts
+++ b/packages/macro/test/jsx-trans.ts
@@ -197,6 +197,50 @@ const cases: TestCase[] = [
       `,
   },
   {
+    name: "JSX Macro inside JSX conditional expressions",
+    input: `
+       import { Trans } from '@lingui/macro'
+       ;<Trans>Hello, {props.world ? <Trans>world</Trans> : <Trans>guys</Trans>}</Trans>
+      `,
+    expected: `
+        import { Trans } from '@lingui/react'
+
+        ;<Trans
+            id={"Hello, {0}"}
+            values={{
+              0: props.world ? <Trans id={'world'} /> : <Trans id={'guys'} />
+            }}
+          />
+      `,
+  },
+  {
+    name: "JSX Macro inside JSX multiple nested conditional expressions",
+    input: `
+      import { Trans } from '@lingui/macro'
+        ;<Trans>Hello, {props.world ? <Trans>world</Trans> : (
+          props.b
+            ? <Trans>nested</Trans>
+            : <Trans>guys</Trans>
+        )
+      }</Trans>
+      `,
+    expected: `
+      import { Trans } from "@lingui/react";
+      <Trans
+        id={"Hello, {0}"}
+        values={{
+          0: props.world ? (
+            <Trans id={"world"} />
+          ) : props.b ? (
+            <Trans id={"nested"} />
+          ) : (
+            <Trans id={"guys"} />
+          ),
+        }}
+      />;
+      `,
+  },
+  {
     name: "Elements are replaced with placeholders",
     input: `
         import { Trans } from '@lingui/macro';

--- a/packages/macro/tsconfig.json
+++ b/packages/macro/tsconfig.json
@@ -1,7 +1,10 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "lib": [
+      "ES2019.Array"
+    ],
     "strict": true,
-    "strictNullChecks": false,
+    "strictNullChecks": false
   }
 }


### PR DESCRIPTION
# Description

This PR adding syntax support for `ConditionalExpressions` in JSX Macro: 

```ts
import { Trans } from '@lingui/macro'
<Trans>Hello, {props.world ? <Trans>world</Trans> : <Trans>guys</Trans>}</Trans>
```

To make reviewing easier, i split changes into 2 commits.

- First  commit refactoring JSX macro to operate with babel's `path` instead of `node`
- Second commit fix actual issue. 

We need `path` because babel doesn't allow traversing over plain `node`. And manual traversing wasn't a case here because there might be a syntax which we didn't expect. (multiple nested ternaries or function call which accepts jsx node, etc)

Also issue in SWC version repo: https://github.com/lingui/swc-plugin/issues/16

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

fixes: https://github.com/lingui/js-lingui/issues/1175

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
