### PR TITLE
refactor: pass config directly to macro

### DIFF
--- a/packages/cli/src/api/catalog.test.ts
+++ b/packages/cli/src/api/catalog.test.ts
@@ -199,10 +199,6 @@ describe("Catalog", () => {
 
   describe("collect", () => {
     it("should support JSX and Typescript", async () => {
-      process.env.LINGUI_CONFIG = path.join(
-        __dirname,
-        "fixtures/collect-typescript-jsx/lingui.config.js"
-      )
       const catalog = new Catalog(
         {
           name: "messages",

--- a/packages/cli/src/api/extractors/index.ts
+++ b/packages/cli/src/api/extractors/index.ts
@@ -1,46 +1,21 @@
 import fs from "fs/promises"
 import babel from "./babel"
+import {
+  ExtractedMessage,
+  ExtractorType,
+  LinguiConfigNormalized,
+} from "@lingui/conf"
 
 const DEFAULT_EXTRACTORS: ExtractorType[] = [babel]
 
-export type ParserOptions = {
-  decoratorsBeforeExport?: boolean
-  flow?: boolean
-}
-
-export type ExtractedMessage = {
-  id: string
-
-  message?: string
-  context?: string
-  origin?: [filename: string, line: number]
-
-  comment?: string
-}
-
 type ExtractOptions = {
   extractors?: ExtractorType[]
-  parserOptions?: ParserOptions
-}
-
-export type ExtractorOptions = {
-  parserOptions?: ParserOptions
-  sourceMaps?: any
-}
-
-export type ExtractorType = {
-  match(filename: string): boolean
-  extract(
-    filename: string,
-    code: string,
-    onMessageExtracted: (msg: ExtractedMessage) => void,
-    options?: ExtractorOptions
-  ): Promise<void> | void
 }
 
 export default async function extract(
   filename: string,
   onMessageExtracted: (msg: ExtractedMessage) => void,
+  linguiConfig: LinguiConfigNormalized,
   options: ExtractOptions
 ): Promise<boolean> {
   const extractorsToExtract = options.extractors ?? DEFAULT_EXTRACTORS
@@ -59,12 +34,15 @@ export default async function extract(
 
     try {
       const file = await fs.readFile(filename)
-      await ext.extract(filename, file.toString(), onMessageExtracted, {
-        parserOptions: options.parserOptions,
-      })
+      await ext.extract(
+        filename,
+        file.toString(),
+        onMessageExtracted,
+        linguiConfig
+      )
       return true
     } catch (e) {
-      console.error(`Cannot process file ${(e as Error).message}`)
+      console.error(`Cannot process file ${filename} ${(e as Error).message}`)
       console.error((e as Error).stack)
       return false
     }

--- a/packages/cli/src/api/extractors/typescript.ts
+++ b/packages/cli/src/api/extractors/typescript.ts
@@ -1,4 +1,4 @@
-import { ExtractorType } from "."
+import { ExtractorType } from "@lingui/conf"
 
 const extractor: ExtractorType = {
   match(filename) {

--- a/packages/cli/src/api/stats.ts
+++ b/packages/cli/src/api/stats.ts
@@ -1,7 +1,7 @@
 import Table from "cli-table"
 import chalk from "chalk"
 
-import { LinguiConfig } from "@lingui/conf"
+import { LinguiConfigNormalized } from "@lingui/conf"
 
 import { CatalogType, AllCatalogsType } from "./catalog"
 
@@ -14,7 +14,10 @@ export function getStats(catalog: CatalogType): CatalogStats {
   ]
 }
 
-export function printStats(config: LinguiConfig, catalogs: AllCatalogsType) {
+export function printStats(
+  config: LinguiConfigNormalized,
+  catalogs: AllCatalogsType
+) {
   const table = new Table({
     head: ["Language", "Total count", "Missing"],
     colAligns: ["left", "middle", "middle"],

--- a/packages/cli/src/lingui-extract-template.ts
+++ b/packages/cli/src/lingui-extract-template.ts
@@ -1,18 +1,17 @@
 import chalk from "chalk"
 import program from "commander"
 
-import { getConfig, LinguiConfig } from "@lingui/conf"
+import { getConfig, LinguiConfigNormalized } from "@lingui/conf"
 
 import { getCatalogs } from "./api/catalog"
 
 export type CliExtractTemplateOptions = {
   verbose: boolean
-  configPath: string
   files?: string[]
 }
 
 export default async function command(
-  config: LinguiConfig,
+  config: LinguiConfigNormalized,
   options: Partial<CliExtractTemplateOptions>
 ): Promise<boolean> {
   // `react-app` babel plugin used by CRA requires either BABEL_ENV or NODE_ENV to be
@@ -61,7 +60,6 @@ if (require.main === module) {
 
   const result = command(config, {
     verbose: program.verbose || false,
-    configPath: program.config || process.env.LINGUI_CONFIG,
   }).then(() => {
     if (!result) process.exit(1)
   })

--- a/packages/cli/src/lingui-extract.ts
+++ b/packages/cli/src/lingui-extract.ts
@@ -13,7 +13,6 @@ export type CliExtractOptions = {
   verbose: boolean
   files?: string[]
   clean: boolean
-  configPath: string
   overwrite: boolean
   locale: string
   prevFormat: string | null
@@ -144,7 +143,6 @@ if (require.main === module) {
       clean: program.watch ? false : program.clean || false,
       overwrite: program.watch || program.overwrite || false,
       locale: program.locale,
-      configPath: program.config || process.env.LINGUI_CONFIG,
       watch: program.watch || false,
       files: filePath?.length ? filePath : undefined,
       prevFormat,

--- a/packages/cli/src/tests.ts
+++ b/packages/cli/src/tests.ts
@@ -28,13 +28,11 @@ export const defaultMakeOptions: MakeOptions = {
   overwrite: false,
   locale: null,
   prevFormat: null,
-  configPath: null,
   orderBy: "messageId",
 }
 
 export const defaultMakeTemplateOptions: MakeTemplateOptions = {
   verbose: false,
-  configPath: null,
   orderBy: "messageId",
 }
 

--- a/packages/conf/src/__snapshots__/index.test.ts.snap
+++ b/packages/conf/src/__snapshots__/index.test.ts.snap
@@ -52,10 +52,12 @@ Object {
   orderBy: messageId,
   pseudoLocale: ,
   rootDir: .,
-  runtimeConfigModule: Array [
-    @lingui/core,
-    i18n,
-  ],
+  runtimeConfigModule: Object {
+    TransImportModule: @lingui/react,
+    TransImportName: Trans,
+    i18nImportModule: @lingui/core,
+    i18nImportName: i18n,
+  },
   service: Object {
     apiKey: ,
     name: ,

--- a/packages/conf/src/migrations/normalizeRuntimeConfigModule.test.ts
+++ b/packages/conf/src/migrations/normalizeRuntimeConfigModule.test.ts
@@ -1,0 +1,62 @@
+import { normalizeRuntimeConfigModule } from "./normalizeRuntimeConfigModule"
+
+describe("normalizeRuntimeConfigModule", () => {
+  it("only i18n specified", () => {
+    const actual = normalizeRuntimeConfigModule({
+      runtimeConfigModule: ["../my-i18n", "myI18n"],
+    })
+
+    expect(actual.runtimeConfigModule).toStrictEqual({
+      TransImportModule: "@lingui/react",
+      TransImportName: "Trans",
+      i18nImportModule: "../my-i18n",
+      i18nImportName: "myI18n",
+    })
+  })
+
+  it("Trans and i18n specified", () => {
+    const actual = normalizeRuntimeConfigModule({
+      runtimeConfigModule: {
+        i18n: ["./custom-i18n", "myI18n"],
+        Trans: ["./custom-trans", "myTrans"],
+      },
+    })
+
+    expect(actual.runtimeConfigModule).toStrictEqual({
+      TransImportModule: "./custom-trans",
+      TransImportName: "myTrans",
+      i18nImportModule: "./custom-i18n",
+      i18nImportName: "myI18n",
+    })
+  })
+
+  it("i18n specified as object", () => {
+    const actual = normalizeRuntimeConfigModule({
+      runtimeConfigModule: {
+        i18n: ["./custom-i18n", "myI18n"],
+      },
+    })
+
+    expect(actual.runtimeConfigModule).toStrictEqual({
+      TransImportModule: "@lingui/react",
+      TransImportName: "Trans",
+      i18nImportModule: "./custom-i18n",
+      i18nImportName: "myI18n",
+    })
+  })
+
+  it("Trans specified as object", () => {
+    const actual = normalizeRuntimeConfigModule({
+      runtimeConfigModule: {
+        Trans: ["./custom-trans", "myTrans"],
+      },
+    })
+
+    expect(actual.runtimeConfigModule).toStrictEqual({
+      TransImportModule: "./custom-trans",
+      TransImportName: "myTrans",
+      i18nImportModule: "@lingui/core",
+      i18nImportName: "i18n",
+    })
+  })
+})

--- a/packages/conf/src/migrations/normalizeRuntimeConfigModule.ts
+++ b/packages/conf/src/migrations/normalizeRuntimeConfigModule.ts
@@ -1,0 +1,41 @@
+import { LinguiConfig, LinguiConfigNormalized } from "../types"
+
+type ModuleSrc = [source: string, identifier?: string]
+
+const getSymbolSource = (
+  defaults: ModuleSrc,
+  config: LinguiConfig["runtimeConfigModule"]
+): ModuleSrc => {
+  const name = defaults[1]
+  if (Array.isArray(config)) {
+    if (name === "i18n") {
+      return config
+    }
+    return defaults
+  }
+
+  return config[name] || defaults
+}
+
+export function normalizeRuntimeConfigModule(
+  config: Pick<LinguiConfig, "runtimeConfigModule">
+) {
+  const [i18nImportModule, i18nImportName] = getSymbolSource(
+    ["@lingui/core", "i18n"],
+    config.runtimeConfigModule
+  )
+  const [TransImportModule, TransImportName] = getSymbolSource(
+    ["@lingui/react", "Trans"],
+    config.runtimeConfigModule
+  )
+
+  return {
+    ...config,
+    runtimeConfigModule: {
+      i18nImportModule,
+      i18nImportName,
+      TransImportModule,
+      TransImportName,
+    } satisfies LinguiConfigNormalized["runtimeConfigModule"],
+  }
+}

--- a/packages/conf/src/migrations/setCldrParentLocales.ts
+++ b/packages/conf/src/migrations/setCldrParentLocales.ts
@@ -7,7 +7,7 @@ export function setCldrParentLocales(
     return {
       ...config,
       fallbackLocales: {} as FallbackLocales,
-    }
+    } as unknown as LinguiConfigNormalized
   }
 
   if (!config.fallbackLocales.default) {
@@ -22,7 +22,7 @@ export function setCldrParentLocales(
     })
   }
 
-  return config as LinguiConfigNormalized
+  return config as unknown as LinguiConfigNormalized
 }
 
 export function getCldrParentLocale(sourceLocale: string) {

--- a/packages/conf/src/types.ts
+++ b/packages/conf/src/types.ts
@@ -1,7 +1,21 @@
 import { GeneratorOptions } from "@babel/core"
-import type { ExtractorOptions } from "@lingui/cli/src/api/extractors"
 
 export type CatalogFormat = "lingui" | "minimal" | "po" | "csv" | "po-gettext"
+
+export type ExtractorCtx = {
+  sourceMaps?: any
+}
+
+export type ExtractorType = {
+  match(filename: string): boolean
+  extract(
+    filename: string,
+    code: string,
+    onMessageExtracted: (msg: ExtractedMessage) => void,
+    linguiConfig: LinguiConfigNormalized,
+    ctx?: ExtractorCtx
+  ): Promise<void> | void
+}
 
 export type ExtractedMessage = {
   id: string
@@ -11,16 +25,6 @@ export type ExtractedMessage = {
   origin?: [filename: string, line: number]
 
   comment?: string
-}
-
-export type ExtractorType = {
-  match(filename: string): boolean
-  extract(
-    filename: string,
-    code: string,
-    onMessageExtracted: (msg: ExtractedMessage) => void,
-    options?: ExtractorOptions
-  ): Promise<void> | void
 }
 
 export type CatalogFormatOptions = {
@@ -82,6 +86,15 @@ export type LinguiConfig = {
   service: CatalogService
 }
 
-export type LinguiConfigNormalized = LinguiConfig & {
+export type LinguiConfigNormalized = Omit<
+  LinguiConfig,
+  "runtimeConfigModule"
+> & {
   fallbackLocales?: FallbackLocales
+  runtimeConfigModule: {
+    i18nImportModule: string
+    i18nImportName: string
+    TransImportModule: string
+    TransImportName: string
+  }
 }

--- a/packages/conf/tsconfig.json
+++ b/packages/conf/tsconfig.json
@@ -12,4 +12,8 @@
   "files": [
     "./src/index.ts"
   ],
+  "exclude": [
+    "build",
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
# Description

Extracted non-related changes from https://github.com/lingui/js-lingui/pull/1440

Before this change config was reading separately in cli and macro. Read issue: https://github.com/lingui/js-lingui/issues/1416

Now config passed down to the macro from cli. This greatly helps in testing, because you can pass config to command and everything work just fine.

Other changes: 

- I extracted normalization for `runtimeConfigModule` into `conf` package and wrote a separate test. So now macro is not responsible for this normalization.


## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Fixes https://github.com/lingui/js-lingui/issues/1416

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
