### PR TITLE
refactor: getTranslations, prepare for hash-based ids

### DIFF
--- a/packages/cli/src/api/__snapshots__/catalog.test.ts.snap
+++ b/packages/cli/src/api/__snapshots__/catalog.test.ts.snap
@@ -7,13 +7,6 @@ Object {
 }
 `;
 
-exports[`Catalog POT Flow Should merge source messages from template if provided 1`] = `
-Object {
-  Hello World: Cześć świat,
-  Test String: Test String,
-}
-`;
-
 exports[`Catalog collect should extract messages from source files 1`] = `
 Object {
   Component A: Object {

--- a/packages/cli/src/api/catalog.test.ts
+++ b/packages/cli/src/api/catalog.test.ts
@@ -12,6 +12,7 @@ import {
   cleanObsolete,
   order,
   normalizeRelativePath,
+  CatalogProps,
 } from "./catalog"
 import { createCompiledCatalog } from "./compile"
 
@@ -144,32 +145,6 @@ describe("Catalog", () => {
   })
 
   describe("POT Flow", () => {
-    it("Should merge source messages from template if provided", () => {
-      const catalog = new Catalog(
-        {
-          name: "messages",
-          path: path.resolve(
-            __dirname,
-            path.join("fixtures", "pot-template", "{locale}")
-          ),
-          include: [],
-          exclude: [],
-        },
-        mockConfig({
-          locales: ["en", "pl"],
-        })
-      )
-
-      const translations = catalog.getTranslations("pl", {
-        sourceLocale: "en",
-        fallbackLocales: {
-          default: "en",
-        },
-      })
-
-      expect(translations).toMatchSnapshot()
-    })
-
     it("Should get translations from template if locale file not presented", () => {
       const catalog = new Catalog(
         {
@@ -664,13 +639,13 @@ describe("Catalog", () => {
       },
     })
 
-    const fileContent = (format) =>
+    const fileContent = (format: string) =>
       fs
         .readFileSync("./en/messages." + (format === "po" ? "po" : "json"))
         .toString()
         .trim()
 
-    const catalogConfig = {
+    const catalogConfig: CatalogProps = {
       name: "messages",
       path: "{locale}/messages",
       include: [],
@@ -1018,7 +993,7 @@ describe("getCatalogForMerge", () => {
     try {
       getCatalogForMerge(config)
     } catch (e) {
-      expect(e.message).toBe(
+      expect((e as Error).message).toBe(
         'Remove trailing slash from "locales/{locale}/bad/path/". Catalog path isn\'t a directory, but translation file without extension. For example, catalog path "locales/{locale}/bad/path" results in translation file "locales/en/bad/path.po".'
       )
     }
@@ -1032,7 +1007,7 @@ describe("getCatalogForMerge", () => {
     try {
       getCatalogForMerge(config)
     } catch (e) {
-      expect(e.message).toBe(
+      expect((e as Error).message).toBe(
         "Invalid catalog path: {locale} variable is missing"
       )
     }

--- a/packages/cli/src/api/getTranslationsForCatalog.test.ts
+++ b/packages/cli/src/api/getTranslationsForCatalog.test.ts
@@ -1,0 +1,341 @@
+import { getTranslationsForCatalog } from "./getTranslationsForCatalog"
+import { AllCatalogsType, Catalog, CatalogType } from "./catalog"
+
+function getCatalogStub(
+  catalogs: AllCatalogsType,
+  template: CatalogType = {}
+): Catalog {
+  const catalogStub: Partial<Catalog> = {
+    readAll(): AllCatalogsType {
+      return catalogs
+    },
+
+    readTemplate(): CatalogType {
+      return template
+    },
+  }
+
+  return catalogStub as Catalog
+}
+
+function lang(
+  locale: string,
+  messages: Array<(locale: string) => CatalogType>
+) {
+  return {
+    [locale]: messages.reduce((acc, msgFn) => {
+      return {
+        ...acc,
+        ...msgFn(locale),
+      }
+    }, {}),
+  }
+}
+
+function message(id: string, source: string, noTranslation = false) {
+  return (locale: string): CatalogType => ({
+    [id]: {
+      message: source,
+      translation: noTranslation ? null : `${locale}: translation: ${source}`,
+    },
+  })
+}
+
+describe("getTranslationsForCatalog", () => {
+  it("Should return translated catalog if all translation exists", () => {
+    // prettier-ignore
+    const catalogStub = getCatalogStub({
+      ...lang("pl", [
+        message("hashid1", "Lorem")
+      ])
+    })
+
+    const missingSpy = jest.fn()
+    const actual = getTranslationsForCatalog(catalogStub, "pl", {
+      sourceLocale: "en",
+      fallbackLocales: {},
+      onMissing: missingSpy,
+    })
+
+    expect(missingSpy).not.toBeCalled()
+    expect(actual).toStrictEqual({
+      hashid1: "pl: translation: Lorem",
+    })
+  })
+
+  it("Should fallback to fallbackLocales.default", () => {
+    // prettier-ignore
+    const catalogStub = getCatalogStub({
+      ...lang("pl", [
+        message("hashid1", "Lorem"),
+        message("hashid2", "Ipsum")
+      ]),
+      ...lang("ru", [
+        message("hashid1", "Lorem"),
+        message("hashid2", "Ipsum", true)
+      ])
+    })
+
+    const missingSpy = jest.fn()
+    const actual = getTranslationsForCatalog(catalogStub, "ru", {
+      sourceLocale: "en",
+      fallbackLocales: {
+        default: "pl",
+      },
+      onMissing: missingSpy,
+    })
+
+    expect(missingSpy).not.toBeCalled()
+
+    expect(actual).toStrictEqual({
+      hashid1: "ru: translation: Lorem",
+      hashid2: "pl: translation: Ipsum",
+    })
+  })
+
+  it("Should fallback to single fallbackLocales", () => {
+    // prettier-ignore
+    const catalogStub = getCatalogStub({
+      ...lang("pl", [
+        message("hashid1", "Lorem"),
+        message("hashid2", "Ipsum")
+      ]),
+      ...lang("ru", [
+        message("hashid1", "Lorem"),
+        message("hashid2", "Ipsum", true)
+      ])
+    })
+
+    const missingSpy = jest.fn()
+    const actual = getTranslationsForCatalog(catalogStub, "ru", {
+      sourceLocale: "en",
+      fallbackLocales: {
+        ru: "pl",
+      },
+      onMissing: missingSpy,
+    })
+
+    expect(missingSpy).not.toBeCalled()
+
+    expect(actual).toStrictEqual({
+      hashid1: "ru: translation: Lorem",
+      hashid2: "pl: translation: Ipsum",
+    })
+  })
+
+  it("Should fallback to multiple fallbacks and then to default", () => {
+    // prettier-ignore
+    const catalogStub = getCatalogStub({
+      ...lang("pl", [
+        message("hashid1", "Lorem"),
+        message("hashid2", "Ipsum"),
+        message("hashid3", "Dolor")
+      ]),
+      ...lang("es", [
+        message("hashid1", "Lorem"),
+        message("hashid2", "Ipsum"),
+        message("hashid3", "Dolor", true),
+        message("hashid4", "Sit")
+      ]),
+      ...lang("de", [
+        message("hashid1", "Lorem"),
+        message("hashid2", "Ipsum", true),
+        message("hashid3", "Dolor", true)
+      ]),
+      ...lang("ru", [
+        message("hashid1", "Lorem"),
+        message("hashid2", "Ipsum", true),
+        message("hashid3", "Dolor", true),
+
+        // this is not present in first fallback locale DE, but present in next ES
+        message("hashid4", "Sit", true)
+      ])
+    })
+
+    const missingSpy = jest.fn()
+    const actual = getTranslationsForCatalog(catalogStub, "ru", {
+      sourceLocale: "en",
+      fallbackLocales: {
+        ru: ["de", "es"],
+        default: "pl",
+      },
+      onMissing: missingSpy,
+    })
+
+    expect(missingSpy).not.toBeCalled()
+    expect(actual).toStrictEqual({
+      hashid1: "ru: translation: Lorem",
+      // this fallback to de -> es
+      hashid2: "es: translation: Ipsum",
+      // this fallback to de -> es -> default
+
+      hashid3: "pl: translation: Dolor",
+      // this fallback to de -> es
+      hashid4: "es: translation: Sit",
+    })
+  })
+
+  it(
+    "Should fallback to source messages and don't call onMissing" +
+      " when target locale == sourceLocale",
+    () => {
+      // prettier-ignore
+      const catalogStub = getCatalogStub({
+      ...lang("en", [
+        message("hashid1", "Lorem", true),
+        message("hashid2", "Ipsum")
+      ])
+    })
+
+      const missingSpy = jest.fn()
+      const actual = getTranslationsForCatalog(catalogStub, "en", {
+        sourceLocale: "en",
+        fallbackLocales: {},
+        onMissing: missingSpy,
+      })
+
+      expect(missingSpy).not.toBeCalled()
+      expect(actual).toStrictEqual({
+        hashid1: "Lorem",
+        hashid2: "en: translation: Ipsum",
+      })
+    }
+  )
+
+  it("Should fallback to source locale if no other fallbacks and report missing", () => {
+    // prettier-ignore
+    const catalogStub = getCatalogStub({
+      ...lang("en", [
+        message("hashid1", "Lorem", true)
+      ]),
+
+      ...lang("pl", [
+        message("hashid1", "", true)
+      ])
+    })
+
+    const missingSpy = jest.fn()
+    const actual = getTranslationsForCatalog(catalogStub, "pl", {
+      sourceLocale: "en",
+      fallbackLocales: {},
+      onMissing: missingSpy,
+    })
+
+    expect(missingSpy).toBeCalledWith({
+      id: "hashid1",
+      source: "Lorem",
+    })
+    expect(actual).toStrictEqual({
+      hashid1: "Lorem",
+    })
+  })
+
+  it("Should add keys from source locale", () => {
+    // prettier-ignore
+    const catalogStub = getCatalogStub({
+      ...lang("en", [
+        message("hashid1", "Lorem", true),
+        message("hashid2", "Ipsum", true),
+        message("hashid3", "Dolor", true),
+        message("hashid4", "Sit", true)
+      ]),
+      ...lang("pl", [
+        message("hashid1", "Lorem"),
+        message("hashid2", "Ipsum")
+      ])
+    })
+
+    const missingSpy = jest.fn()
+    const actual = getTranslationsForCatalog(catalogStub, "pl", {
+      sourceLocale: "en",
+      fallbackLocales: {},
+      onMissing: missingSpy,
+    })
+
+    expect(actual).toStrictEqual({
+      hashid1: "pl: translation: Lorem",
+      hashid2: "pl: translation: Ipsum",
+      hashid3: "Dolor",
+      hashid4: "Sit",
+    })
+    expect(missingSpy).toBeCalledTimes(2)
+  })
+
+  it("Should not fail if sourceLocale is not set", () => {
+    // prettier-ignore
+    const catalogStub = getCatalogStub({
+      ...lang("en", [
+        message("hashid1", "Lorem", true),
+        message("hashid2", "Ipsum", true),
+        message("hashid3", "Dolor", true),
+        message("hashid4", "Sit", true)
+      ]),
+      ...lang("pl", [
+        message("hashid1", "Lorem"),
+        message("hashid2", "Ipsum")
+      ])
+    })
+
+    const missingSpy = jest.fn()
+    const actual = getTranslationsForCatalog(catalogStub, "pl", {
+      sourceLocale: null,
+      fallbackLocales: {},
+      onMissing: missingSpy,
+    })
+
+    expect(actual).toStrictEqual({
+      hashid1: "pl: translation: Lorem",
+      hashid2: "pl: translation: Ipsum",
+    })
+    expect(missingSpy).toBeCalledTimes(0)
+  })
+
+  it("Should add keys from template", () => {
+    // prettier-ignore
+    const catalogStub = getCatalogStub({
+      ...lang("pl", [
+        message("hashid1", "Lorem"),
+        message("hashid2", "Ipsum")
+      ])
+    }, lang("tpl", [
+      message("hashid1", "Lorem", true),
+      message("hashid2", "Ipsum", true),
+      message("hashid3", "Dolor", true),
+      message("hashid4", "Sit", true)
+    ]).tpl)
+
+    const missingSpy = jest.fn()
+    const actual = getTranslationsForCatalog(catalogStub, "pl", {
+      sourceLocale: "en",
+      fallbackLocales: {},
+      onMissing: missingSpy,
+    })
+
+    expect(actual).toStrictEqual({
+      hashid1: "pl: translation: Lorem",
+      hashid2: "pl: translation: Ipsum",
+      hashid3: "Dolor",
+      hashid4: "Sit",
+    })
+    expect(missingSpy).toBeCalledTimes(2)
+  })
+
+  it("Should not fail if catalog for requested locale does not exists", () => {
+    // prettier-ignore
+    const catalogStub = getCatalogStub({}, lang("tpl", [
+      message("hashid1", "Lorem", true),
+    ]).tpl)
+
+    const missingSpy = jest.fn()
+    const actual = getTranslationsForCatalog(catalogStub, "pl", {
+      sourceLocale: "en",
+      fallbackLocales: {},
+      onMissing: missingSpy,
+    })
+
+    expect(actual).toStrictEqual({
+      hashid1: "Lorem",
+    })
+    expect(missingSpy).toBeCalledTimes(1)
+  })
+})

--- a/packages/cli/src/api/getTranslationsForCatalog.ts
+++ b/packages/cli/src/api/getTranslationsForCatalog.ts
@@ -1,0 +1,105 @@
+import { AllCatalogsType, Catalog, CatalogType, MessageType } from "./catalog"
+import { FallbackLocales } from "@lingui/conf"
+
+export type TranslationMissingEvent = {
+  source: string
+  id: string
+}
+export type GetTranslationsOptions = {
+  sourceLocale: string
+  fallbackLocales: FallbackLocales
+  onMissing?: (message: TranslationMissingEvent) => void
+}
+
+export function getTranslationsForCatalog(
+  catalog: Catalog,
+  locale: string,
+  options: GetTranslationsOptions
+) {
+  const catalogs = catalog.readAll()
+  const template = catalog.readTemplate() || {}
+
+  const sourceLocaleCatalog = catalogs[options.sourceLocale] || {}
+
+  const input = { ...template, ...sourceLocaleCatalog, ...catalogs[locale] }
+
+  return Object.keys(input).reduce<{ [id: string]: string }>((acc, key) => {
+    acc[key] = getTranslation(catalogs, input[key], locale, key, options)
+    return acc
+  }, {})
+}
+
+function sourceLocaleFallback(catalog: CatalogType, key: string) {
+  if (!catalog?.[key]) {
+    return null
+  }
+
+  return catalog[key].translation || catalog[key].message
+}
+
+function getTranslation(
+  catalogs: AllCatalogsType,
+  msg: MessageType,
+  locale: string,
+  key: string,
+  options: GetTranslationsOptions
+) {
+  const { fallbackLocales, sourceLocale, onMissing } = options
+
+  const getTranslation = (_locale: string) => {
+    const localeCatalog = catalogs[_locale]
+    return localeCatalog?.[key]?.translation
+  }
+
+  const getMultipleFallbacks = (_locale: string) => {
+    const fL = fallbackLocales && fallbackLocales?.[_locale]
+
+    // some probably the fallback will be undefined, so just search by locale
+    if (!fL) return null
+
+    if (Array.isArray(fL)) {
+      for (const fallbackLocale of fL) {
+        if (catalogs[fallbackLocale] && getTranslation(fallbackLocale)) {
+          return getTranslation(fallbackLocale)
+        }
+      }
+    } else {
+      return getTranslation(fL)
+    }
+  }
+
+  // target locale -> fallback locales -> fallback locales default ->
+  // ** (following fallbacks would emit `missing` warning) **
+  // -> source locale translation -> source locale message
+  // -> template message
+  // ** last resort **
+  // -> id
+
+  let translation =
+    // Get translation in target locale
+    getTranslation(locale) ||
+    // We search in fallbackLocales as dependent of each locale
+    getMultipleFallbacks(locale) ||
+    // Get translation in fallbackLocales.default (if any)
+    (fallbackLocales?.default && getTranslation(fallbackLocales.default)) ||
+    (sourceLocale &&
+      sourceLocale === locale &&
+      sourceLocaleFallback(catalogs[sourceLocale], key))
+
+  if (!translation) {
+    onMissing &&
+      onMissing({
+        id: key,
+        source:
+          msg.message || sourceLocaleFallback(catalogs[sourceLocale], key),
+      })
+  }
+
+  return (
+    translation ||
+    (sourceLocale && sourceLocaleFallback(catalogs[sourceLocale], key)) ||
+    // take from template
+    msg.message ||
+    key
+  )
+}

--- a/packages/cli/src/test/__snapshots__/compile.test.ts.snap
+++ b/packages/cli/src/test/__snapshots__/compile.test.ts.snap
@@ -5,21 +5,21 @@ Error: Invalid locale abra (missing plural rules)!
 
 `;
 
-exports[`CLI Command: Compile allowEmpty = false Should show error and stop compilation of catalog  if message doesnt have a translation (with template) 1`] = `
-Object {
-  en: /*eslint-disable*/module.exports={messages:JSON.parse("{\\"Hello World\\":\\"Hello World\\"}")};,
-  pl: undefined,
-}
-`;
-
-exports[`CLI Command: Compile allowEmpty = false Should show error and stop compilation of catalog  if message doesnt have a translation (with template) 2`] = `
+exports[`CLI Command: Compile allowEmpty = false Should show error and stop compilation of catalog if message doesnt have a translation (no template) 1`] = `
 Error: Failed to compile catalog for locale pl!
 Missing 1 translation(s)
 
 `;
 
-exports[`CLI Command: Compile allowEmpty = false Should show error and stop compilation of catalog if message doesnt have a translation (no template) 1`] = `
-Error: Failed to compile catalog for locale pl!
+exports[`CLI Command: Compile allowEmpty = false Should show error and stop compilation of catalog if message doesnt have a translation (with template) 1`] = `
+Object {
+  en: undefined,
+  pl: undefined,
+}
+`;
+
+exports[`CLI Command: Compile allowEmpty = false Should show error and stop compilation of catalog if message doesnt have a translation (with template) 2`] = `
+Error: Failed to compile catalog for locale en!
 Missing 1 translation(s)
 
 `;

--- a/packages/conf/src/types.ts
+++ b/packages/conf/src/types.ts
@@ -44,7 +44,7 @@ export type CatalogConfig = {
 
 type LocaleObject = {
   [locale: string]: string[] | string
-  default: string
+  default?: string
 }
 
 export type FallbackLocales = LocaleObject

--- a/packages/snowpack-plugin/src/index.ts
+++ b/packages/snowpack-plugin/src/index.ts
@@ -51,16 +51,11 @@ function extractLinguiMessages(
       )
 
       const { locale, catalog } = fileCatalog
-      const catalogs = catalog.readAll()
 
-      const messages = Object.keys(catalogs[locale]).reduce((acc, key) => {
-        acc[key] = catalog.getTranslation(catalogs, locale, key, {
-          fallbackLocales: config.fallbackLocales,
-          sourceLocale: config.sourceLocale,
-        })
-
-        return acc
-      }, {})
+      const messages = catalog.getTranslations(locale, {
+        fallbackLocales: config.fallbackLocales,
+        sourceLocale: config.sourceLocale,
+      })
 
       const compiled = createCompiledCatalog(locale, messages, {
         strict,

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -31,16 +31,11 @@ export default function lingui(linguiConfig: LinguiConfigOpts = {}): Plugin {
         )
 
         const { locale, catalog } = fileCatalog
-        const catalogs = catalog.readAll()
 
-        const messages = Object.keys(catalogs[locale]).reduce((acc, key) => {
-          acc[key] = catalog.getTranslation(catalogs, locale, key, {
-            fallbackLocales: config.fallbackLocales,
-            sourceLocale: config.sourceLocale,
-          })
-
-          return acc
-        }, {})
+        const messages = catalog.getTranslations(locale, {
+          fallbackLocales: config.fallbackLocales,
+          sourceLocale: config.sourceLocale,
+        })
 
         const compiled = createCompiledCatalog(locale, messages, {
           strict: false,


### PR DESCRIPTION
# Description

https://github.com/lingui/js-lingui/pull/1440#issuecomment-1434353740

> Yesterday I thought that i was close to finish this task, but inverting logic with explicit-id flag revealed many issues in the other part of code which should be fixed to get this merged.
>
> Many of them due to the fact that while compiling catalogs lingui operates with only key and translation, where key is a natural language string. Many places in the code works based on that assumptions, and in many places there is a fallback to the "key" if no translation found.
>
> With new hashbased id, key is always a hash, and this fallback just doesn't work. Instead, i should change the logic to operate with id, source string, translation, and in case there are no translation fallback to source string first and to id as last resort.
>
> Unfortunately, there is complicated fallbacks logic, which is not fully covered by tests, so i need to refactor this first.

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
