### PR TITLE
fix: exclude pseudo locale during sync 

### DIFF
--- a/packages/cli/src/services/translationIO.ts
+++ b/packages/cli/src/services/translationIO.ts
@@ -4,7 +4,7 @@ import PO from "pofile"
 import https from "https"
 import glob from "glob"
 import { format as formatDate } from "date-fns"
-import { LinguiConfig } from "@lingui/conf"
+import { LinguiConfigNormalized } from "@lingui/conf"
 
 const getCreateHeaders = (language: string) => ({
   "POT-Creation-Date": formatDate(new Date(), "yyyy-MM-dd HH:mmxxxx"),
@@ -15,7 +15,7 @@ const getCreateHeaders = (language: string) => ({
   Language: language,
 })
 
-const getTargetLocales = (config: LinguiConfig) => {
+const getTargetLocales = (config: LinguiConfigNormalized) => {
   const sourceLocale = config.sourceLocale || "en"
   const pseudoLocale = config.pseudoLocale || "pseudo"
   return config.locales.filter(
@@ -24,7 +24,7 @@ const getTargetLocales = (config: LinguiConfig) => {
 }
 
 // Main sync method, call "Init" or "Sync" depending on the project context
-export default function syncProcess(config: LinguiConfig, options) {
+export default function syncProcess(config: LinguiConfigNormalized, options) {
   if (config.format != "po") {
     console.error(
       `\n----------\nTranslation.io service is only compatible with the "po" format. Please update your Lingui configuration accordingly.\n----------`
@@ -60,7 +60,12 @@ export default function syncProcess(config: LinguiConfig, options) {
 
 // Initialize project with source and existing translations (only first time!)
 // Cf. https://translation.io/docs/create-library#initialization
-function init(config: LinguiConfig, options, successCallback, failCallback) {
+function init(
+  config: LinguiConfigNormalized,
+  options,
+  successCallback,
+  failCallback
+) {
   const sourceLocale = config.sourceLocale || "en"
   const targetLocales = getTargetLocales(config)
   const paths = poPathsPerLocale(config)
@@ -131,7 +136,12 @@ function init(config: LinguiConfig, options, successCallback, failCallback) {
 
 // Send all source text from PO to Translation.io and create new PO based on received translations
 // Cf. https://translation.io/docs/create-library#synchronization
-function sync(config: LinguiConfig, options, successCallback, failCallback) {
+function sync(
+  config: LinguiConfigNormalized,
+  options,
+  successCallback,
+  failCallback
+) {
   const sourceLocale = config.sourceLocale || "en"
   const targetLocales = getTargetLocales(config)
   const paths = poPathsPerLocale(config)
@@ -224,7 +234,7 @@ function createPoItemFromSegment(segment) {
 }
 
 function saveSegmentsToTargetPos(
-  config: LinguiConfig,
+  config: LinguiConfigNormalized,
   paths,
   segmentsPerLocale
 ) {
@@ -289,7 +299,7 @@ function saveSegmentsToTargetPos(
   })
 }
 
-function poPathsPerLocale(config: LinguiConfig) {
+function poPathsPerLocale(config: LinguiConfigNormalized) {
   const paths = []
 
   config.locales.forEach((locale) => {


### PR DESCRIPTION
# Description

Looks like we only exclude pseudo while `init` but not `sync`, might be just an oversight, as I was touching it, so I also added the types for the config object.

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Fixes https://github.com/lingui/js-lingui/issues/1454

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works: no tests exists for services yet
- [ ] I have added necessary documentation (if appropriate)
