### PR TITLE
feat(extractor): respect sourcemaps

### DIFF
--- a/packages/babel-plugin-extract-messages/src/index.ts
+++ b/packages/babel-plugin-extract-messages/src/index.ts
@@ -36,7 +36,7 @@ type RawMessage = {
   context?: string
 }
 
-export type Origin = [filename: string, line: number]
+export type Origin = [filename: string, line: number, column?: number]
 
 function collectMessage(
   path: NodePath<any>,
@@ -46,14 +46,17 @@ function collectMessage(
   // prevent from adding undefined msgid
   if (props.id === undefined) return
 
-  const line = path.node.loc ? path.node.loc.start.line : null
+  const node: Node = path.node
+
+  const line = node.loc ? node.loc.start.line : null
+  const column = node.loc ? node.loc.start.column : null
 
   ;(ctx.opts as ExtractPluginOpts).onMessageExtracted({
     id: props.id,
     message: props.message,
     context: props.context,
     comment: props.comment,
-    origin: [ctx.file.opts.filename, line],
+    origin: [ctx.file.opts.filename, line, column],
   })
 }
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -45,12 +45,12 @@
     "build/"
   ],
   "dependencies": {
+    "@babel/core": "^7.20.12",
     "@babel/generator": "^7.20.14",
     "@babel/parser": "^7.20.15",
     "@babel/plugin-syntax-jsx": "^7.18.6",
     "@babel/runtime": "^7.20.13",
     "@babel/types": "^7.20.7",
-    "@babel/core": "^7.20.12",
     "@lingui/babel-plugin-extract-messages": "3.17.1",
     "@lingui/conf": "3.17.1",
     "@lingui/core": "3.17.1",
@@ -61,6 +61,7 @@
     "chokidar": "3.5.1",
     "cli-table": "0.3.6",
     "commander": "^10.0.0",
+    "convert-source-map": "^2.0.0",
     "date-fns": "^2.16.1",
     "glob": "^7.1.4",
     "inquirer": "^7.3.3",
@@ -74,14 +75,16 @@
     "plurals-cldr": "^1.0.4",
     "pofile": "^1.1.4",
     "pseudolocale": "^1.1.0",
-    "ramda": "^0.27.1"
+    "ramda": "^0.27.1",
+    "source-map": "^0.8.0-beta.0"
   },
   "devDependencies": {
+    "@types/convert-source-map": "^2.0.0",
     "@types/micromatch": "^4.0.1",
     "@types/normalize-path": "^3.0.0",
     "@types/papaparse": "^5.2.3",
     "@types/plurals-cldr": "^1.0.1",
-    "mockdate": "^3.0.2",
-    "fs-extra": "^9.0.1"
+    "fs-extra": "^9.0.1",
+    "mockdate": "^3.0.2"
   }
 }

--- a/packages/cli/src/api/catalog.test.ts
+++ b/packages/cli/src/api/catalog.test.ts
@@ -228,6 +228,23 @@ describe("Catalog", () => {
       expect(messages).toMatchSnapshot()
     })
 
+    it("should respect inline sourcemaps", async () => {
+      const catalog = new Catalog(
+        {
+          name: "messages",
+          path: "locales/{locale}",
+          include: [fixture("collect-inline-sourcemaps/")],
+          exclude: [],
+        },
+        mockConfig()
+      )
+
+      const messages = await catalog.collect()
+      expect(messages[Object.keys(messages)[0]].origin).toStrictEqual([
+        ["../../../../../input.tsx", 5],
+      ])
+    })
+
     it("should extract only files passed on options", async () => {
       const catalog = new Catalog(
         {

--- a/packages/cli/src/api/catalog.ts
+++ b/packages/cli/src/api/catalog.ts
@@ -185,9 +185,12 @@ export class Catalog {
 
           const prev = messages[next.id]
 
-          const filename = path
-            .relative(this.config.rootDir, next.origin[0])
-            .replace(/\\/g, "/")
+          // there might be a case when filename was not mapped from sourcemaps
+          const filename = next.origin[0]
+            ? path
+                .relative(this.config.rootDir, next.origin[0])
+                .replace(/\\/g, "/")
+            : ""
 
           const origin: MessageOrigin = [filename, next.origin[1]]
 

--- a/packages/cli/src/api/fixtures/collect-inline-sourcemaps/componentB.jsx
+++ b/packages/cli/src/api/fixtures/collect-inline-sourcemaps/componentB.jsx
@@ -1,0 +1,3 @@
+import { Trans } from "@lingui/macro"
+;<Trans context="Context1">Some message</Trans>
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiaW5wdXQuanN4Iiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsiaW5wdXQudHN4Il0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBLE9BQU8sRUFBRSxLQUFLLEVBQUUsTUFBTSxlQUFlLENBQUE7QUFJckMsQ0FBQyxLQUFLLENBQUMsT0FBTyxDQUFDLFVBQVUsQ0FBQyxZQUFZLEVBQUUsS0FBSyxDQUFDLENBQUEifQ==

--- a/packages/conf/src/types.ts
+++ b/packages/conf/src/types.ts
@@ -3,6 +3,10 @@ import { GeneratorOptions } from "@babel/core"
 export type CatalogFormat = "lingui" | "minimal" | "po" | "csv" | "po-gettext"
 
 export type ExtractorCtx = {
+  /**
+   * Raw Sourcemaps object to mapping from.
+   * Check the https://github.com/mozilla/source-map#new-sourcemapconsumerrawsourcemap
+   */
   sourceMaps?: any
 }
 
@@ -22,7 +26,7 @@ export type ExtractedMessage = {
 
   message?: string
   context?: string
-  origin?: [filename: string, line: number]
+  origin?: [filename: string, line: number, column?: number]
 
   comment?: string
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2654,6 +2654,11 @@
   resolved "https://registry.yarnpkg.com/@types/braces/-/braces-3.0.1.tgz#5a284d193cfc61abb2e5a50d36ebbc50d942a32b"
   integrity sha512-+euflG6ygo4bn0JHtn4pYqcXwRtLvElQ7/nnjDu7iYG56H0+OhCd7d6Ug0IE3WcFpZozBKW2+80FUbv5QGk5AQ==
 
+"@types/convert-source-map@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/convert-source-map/-/convert-source-map-2.0.0.tgz#a36c2d21963caa18fe32de6cdec3d21a7d2c92b3"
+  integrity sha512-QUm4YOC/ENo0VjPVl2o8HGyTbHHQGDOw8PCg3rXBucYHKyZN/XjXRbPFAV1tB2FvM0/wyFoDct4cTIctzKrQFg==
+
 "@types/eslint@^7.2.13":
   version "7.29.0"
   resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-7.29.0.tgz#e56ddc8e542815272720bb0b4ccc2aff9c3e1c78"
@@ -4576,6 +4581,11 @@ convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.9.0.tgz#7faae62353fb4213366d0ca98358d22e8368b05f"
   integrity sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==
+
+convert-source-map@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
+  integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
 copy-concurrently@^1.0.0:
   version "1.0.5"
@@ -10653,6 +10663,13 @@ source-map@^0.7.3:
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.4.tgz#a9bbe705c9d8846f4e08ff6765acf0f1b0898656"
   integrity sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==
+
+source-map@^0.8.0-beta.0:
+  version "0.8.0-beta.0"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.8.0-beta.0.tgz#d4c1bb42c3f7ee925f005927ba10709e0d1d1f11"
+  integrity sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==
+  dependencies:
+    whatwg-url "^7.0.0"
 
 spdx-correct@^3.0.0:
   version "3.1.1"


### PR DESCRIPTION
# Description

Babel doesn't support inputSourceMaps in parse. It means all location reported in extractor plugin is a source location, not a mapped. In other words sourcemaps have no effect. 

This PR adds support for inlined and explicticly passed (from custom extractor for ex.) sourcemaps. 

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
