### PR TITLE
feat(macro): support renamed identifiers in macro

### DIFF
--- a/packages/macro/src/macroJs.test.ts
+++ b/packages/macro/src/macroJs.test.ts
@@ -6,7 +6,11 @@ import { CallExpression } from "@babel/types"
 function createMacro() {
   return new MacroJs(
     { types },
-    { i18nImportName: "i18n", stripNonEssentialProps: false }
+    {
+      i18nImportName: "i18n",
+      stripNonEssentialProps: false,
+      nameMap: new Map<string, string>(),
+    }
   )
 }
 

--- a/packages/macro/src/macroJsx.test.ts
+++ b/packages/macro/src/macroJsx.test.ts
@@ -25,7 +25,10 @@ const parseExpression = (expression: string) => {
 }
 
 function createMacro() {
-  return new MacroJSX({ types }, { stripNonEssentialProps: false })
+  return new MacroJSX(
+    { types },
+    { stripNonEssentialProps: false, nameMap: new Map() }
+  )
 }
 
 describe("jsx macro", () => {

--- a/packages/macro/test/js-defineMessage.ts
+++ b/packages/macro/test/js-defineMessage.ts
@@ -22,6 +22,29 @@ const cases: TestCase[] = [
     `,
   },
   {
+    name: "defineMessage macro could be renamed",
+    input: `
+        import { defineMessage as defineMessage2, plural as plural2 } from '@lingui/macro';
+        const message = defineMessage2({
+          comment: "Description",
+          message: plural2(value, { one: "book", other: "books" })
+        })
+    `,
+    expected: `
+        import { i18n } from "@lingui/core";
+        const message =
+          /*i18n*/
+          {
+            values: {
+              value: value,
+            },
+            message: "{value, plural, one {book} other {books}}",
+            id: "SlmyxX",
+            comment: "Description",
+          };
+    `,
+  },
+  {
     name: "should left string message intact",
     input: `
         import { defineMessage } from '@lingui/macro';

--- a/packages/macro/test/js-plural.ts
+++ b/packages/macro/test/js-plural.ts
@@ -26,6 +26,30 @@ const cases: TestCase[] = [
       `,
   },
   {
+    name: "plural macro could be renamed",
+    input: `
+        import { plural as plural2 } from '@lingui/macro'
+        const a = plural2(count, {
+          "one": \`# book\`,
+          other: "# books"
+        });
+      `,
+    expected: `
+        import { i18n } from "@lingui/core";
+       const a = i18n._(
+          /*i18n*/
+          {
+            id: "esnaQO",
+            message: "{count, plural, one {# book} other {# books}}",
+            values: {
+              count: count,
+            },
+          }
+        );
+
+      `,
+  },
+  {
     name: "Macro with offset and exact matches",
     input: `
         import { plural } from '@lingui/macro'

--- a/packages/macro/test/js-t.ts
+++ b/packages/macro/test/js-t.ts
@@ -19,6 +19,23 @@ const cases: TestCase[] = [
     `,
   },
   {
+    name: "t`` macro could be renamed",
+    input: `
+        import { t as t2 } from '@lingui/macro';
+        const a = t2\`Expression assignment\`;
+    `,
+    expected: `
+        import { i18n } from "@lingui/core";
+        const a = i18n._(
+          /*i18n*/
+          {
+            id: "mjnlP0",
+            message: "Expression assignment",
+          }
+        );
+    `,
+  },
+  {
     name: "Macro is used in expression assignment, with custom lingui instance",
     input: `
         import { t } from '@lingui/macro';

--- a/packages/macro/test/jsx-plural.ts
+++ b/packages/macro/test/jsx-plural.ts
@@ -29,6 +29,28 @@ const cases: TestCase[] = [
       `,
   },
   {
+    stripId: true,
+    name: "Plural macro could be renamed",
+    input: `
+        import { Plural as Plural2 } from '@lingui/macro';
+        <Plural2
+          value={count}
+          one={"..."}
+          other={"..."}
+        />;
+      `,
+    expected: `
+        import { Trans } from "@lingui/react";
+        <Trans
+          id={"<stripped>"}
+          message={"{count, plural, one {...} other {...}}"}
+          values={{
+            count: count,
+          }}
+        />;
+      `,
+  },
+  {
     name: "Should preserve reserved props: `comment`, `context`, `render`, `id`",
     input: `
         import { Plural } from '@lingui/macro';

--- a/packages/macro/test/jsx-trans.ts
+++ b/packages/macro/test/jsx-trans.ts
@@ -81,6 +81,18 @@ const cases: TestCase[] = [
       `,
   },
   {
+    stripId: true,
+    name: "Trans macro could be renamed",
+    input: `
+        import { Trans as Trans2 } from '@lingui/macro';
+        <Trans2>Hello World</Trans2>;
+      `,
+    expected: `
+        import { Trans } from "@lingui/react";
+        <Trans id={"<stripped>"} message={"Hello World"} />;
+      `,
+  },
+  {
     name: "Macro without children is noop",
     input: `
         import { Trans } from '@lingui/macro';


### PR DESCRIPTION
# Description

Support for all macros.: 

```ts
import { t as t2 } from '@lingui/macro';
const a = t2`Message`;
```

Looks like this is a rare case, because no one has raised the issue so far. But that is quite common case if code after other transpiler would be passed to lingui (custom extractor case)

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
