### PR TITLE
fix(vite-plugin): change default export to named export

### DIFF
--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -21,7 +21,7 @@ npm install --save-dev @lingui/vite-plugin
 
 ```ts
 import { UserConfig } from 'vite';
-import lingui from '@lingui/vite-plugin'
+import { lingui } from '@lingui/vite-plugin'
 
 const config: UserConfig = {
   plugins: [lingui()]

--- a/packages/vite-plugin/index.js
+++ b/packages/vite-plugin/index.js
@@ -1,1 +1,1 @@
-export { default } from "./src"
+export { default, lingui } from "./src"

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -2,9 +2,8 @@
   "name": "@lingui/vite-plugin",
   "version": "3.17.1",
   "description": "Vite plugin for Lingui message catalogs",
-  "main": "./build/cjs/index.js",
-  "module": "./build/esm/index.js",
-  "types": "./build/esm/index.d.ts",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
   "license": "MIT",
   "keywords": [
     "vite-plugin",
@@ -18,10 +17,7 @@
     "translation"
   ],
   "scripts": {
-    "clean": "rimraf ./build",
-    "build:esm": "tsc --module esnext --outDir ./build/esm",
-    "build:cjs": "tsc --module commonjs --outDir ./build/cjs",
-    "build": "yarn clean && yarn build:esm && yarn build:cjs"
+    "build": "rimraf ./build && tsc"
   },
   "repository": {
     "type": "git",
@@ -29,18 +25,6 @@
   },
   "bugs": {
     "url": "https://github.com/lingui/js-lingui/issues"
-  },
-  "exports": {
-    ".": {
-      "require": {
-        "types": "./build/cjs/index.d.ts",
-        "default": "./build/cjs/index.js"
-      },
-      "import": {
-        "types": "./build/esm/index.d.ts",
-        "default": "./build/esm/index.js"
-      }
-    }
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -15,7 +15,7 @@ type LinguiConfigOpts = {
   skipValidation?: boolean
 }
 
-export default function lingui(linguiConfig: LinguiConfigOpts = {}): Plugin {
+export function lingui(linguiConfig: LinguiConfigOpts = {}): Plugin {
   const config = getConfig(linguiConfig)
 
   return {
@@ -56,3 +56,5 @@ export default function lingui(linguiConfig: LinguiConfigOpts = {}): Plugin {
     },
   }
 }
+
+export default lingui

--- a/packages/vite-plugin/test/index.ts
+++ b/packages/vite-plugin/test/index.ts
@@ -1,9 +1,9 @@
 import path from "path"
-import vitePlugin from "../src"
+import { lingui } from "../src"
 
 describe("vite-plugin", () => {
   it("should return compiled catalog", async () => {
-    const p = vitePlugin({
+    const p = lingui({
       configPath: path.resolve(__dirname, ".linguirc"),
     })
     const result = await (p.transform as any)(

--- a/packages/vite-plugin/tsconfig.json
+++ b/packages/vite-plugin/tsconfig.json
@@ -5,7 +5,6 @@
     "sourceMap": true,
     "noEmit": false,
     "declaration": true,
-    "moduleResolution": "Node",
     "outDir": "./build",
     "esModuleInterop": true,
     "resolveJsonModule": true

--- a/website/docs/ref/vite-plugin.md
+++ b/website/docs/ref/vite-plugin.md
@@ -18,7 +18,7 @@ Simply add `@lingui/vite-plugin` inside your `vite.config.ts`:
 
 ```ts title="vite.config.ts"
 import { UserConfig } from 'vite';
-import lingui from '@lingui/vite-plugin'
+import { lingui } from '@lingui/vite-plugin'
 
 const config: UserConfig = {
   plugins: [lingui()]


### PR DESCRIPTION
# Description

I don't see a way to fix that other than change default export to named.

if i make vite-plugin package true ESM, it requires other packages also being ESM (lingui/conf + lingue/cli/api)
and that's not possible for many different reasons
Usually, when you use transpires, they insert an "interop" for all default imports. That interop actually checking if there a "default" property.
Native nodejs ESM loader obviously doesn't have it. So commonjs modules transpiled from ESM source is not supported by node in aspects of default exports. 

it's a common issue in other packages as well. So to normally work with native ESM you either should be fully ESM itself, or not use default export as a workaround.

Now package exports both, default and named exports. I also updated documentation to use named export. 

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Fixes https://github.com/lingui/js-lingui/issues/1449

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
