### PR TITLE
refactor(catalog): read template extension from formatter

### DIFF
--- a/packages/cli/src/api/catalog.ts
+++ b/packages/cli/src/api/catalog.ts
@@ -389,7 +389,8 @@ export class Catalog {
   }
 
   get templateFile() {
-    return this.path.replace(LOCALE_SUFFIX_RE, "messages.pot")
+    const ext = this.format.templateExtension || this.format.catalogExtension
+    return this.path.replace(LOCALE_SUFFIX_RE, "messages" + ext)
   }
 
   get localeDir() {

--- a/packages/cli/src/api/catalog.ts
+++ b/packages/cli/src/api/catalog.ts
@@ -80,6 +80,7 @@ export type CatalogProps = {
   path: string
   include: Array<string>
   exclude?: Array<string>
+  templatePath?: string
 }
 
 function mkdirp(dir: string) {
@@ -100,9 +101,10 @@ export class Catalog {
   include: Array<string>
   exclude: Array<string>
   format: CatalogFormatter
+  templateFile?: string
 
   constructor(
-    { name, path, include, exclude = [] }: CatalogProps,
+    { name, path, include, templatePath, exclude = [] }: CatalogProps,
     public config: LinguiConfigNormalized
   ) {
     this.name = name
@@ -110,6 +112,7 @@ export class Catalog {
     this.include = include.map(normalizeRelativePath)
     this.exclude = [this.localeDir, ...exclude.map(normalizeRelativePath)]
     this.format = getFormat(config.format)
+    this.templateFile = templatePath || getTemplatePath(this.format, this.path)
   }
 
   async make(options: MakeOptions): Promise<AllCatalogsType | false> {
@@ -388,11 +391,6 @@ export class Catalog {
     return glob.sync(patterns, { ignore: this.exclude, mark: true })
   }
 
-  get templateFile() {
-    const ext = this.format.templateExtension || this.format.catalogExtension
-    return this.path.replace(LOCALE_SUFFIX_RE, "messages" + ext)
-  }
-
   get localeDir() {
     const localePatternIndex = this.path.indexOf(LOCALE)
     if (localePatternIndex === -1) {
@@ -404,6 +402,11 @@ export class Catalog {
   get locales() {
     return this.config.locales
   }
+}
+
+function getTemplatePath(format: CatalogFormatter, path: string) {
+  const ext = format.templateExtension || format.catalogExtension
+  return path.replace(LOCALE_SUFFIX_RE, "messages" + ext)
 }
 
 /**

--- a/packages/cli/src/api/formats/index.ts
+++ b/packages/cli/src/api/formats/index.ts
@@ -24,6 +24,11 @@ export type CatalogFormatOptionsInternal = {
 
 export type CatalogFormatter = {
   catalogExtension: string
+  /**
+   * Set extension used when extract to template
+   * Omit if the extension is the same as catalogExtension
+   */
+  templateExtension?: string
   write(
     filename: string,
     catalog: CatalogType,

--- a/packages/cli/src/api/formats/po-gettext.ts
+++ b/packages/cli/src/api/formats/po-gettext.ts
@@ -258,6 +258,7 @@ const convertPluralsToICU = (
 
 const poGettext: CatalogFormatter = {
   catalogExtension: ".po",
+  templateExtension: ".pot",
 
   write(filename, catalog: CatalogType, options) {
     let po: PO

--- a/packages/cli/src/api/formats/po.ts
+++ b/packages/cli/src/api/formats/po.ts
@@ -126,6 +126,7 @@ function validateItem(item: POItem): void {
 
 const po: CatalogFormatter = {
   catalogExtension: ".po",
+  templateExtension: ".pot",
 
   write(filename, catalog, options) {
     let po: PO


### PR DESCRIPTION
# Description

Currently extract to template supported only for "po" format. This is limited only by extension ".pot" which is hard-coded. This PR allows formatters to define their own extension for the template file. 

Extracting to template differs from usual extraction only in the absence of merge existing catalogs with incoming. 
So you can extract template in json format, such as `messages.json`

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
