### PR TITLE
chore: use jiti for ts config loading

### DIFF
--- a/packages/conf/package.json
+++ b/packages/conf/package.json
@@ -23,12 +23,12 @@
     "build": "rimraf ./build && tsc"
   },
   "dependencies": {
-    "@babel/runtime": "^7.20.13",
     "@babel/core": "7.20.12",
+    "@babel/runtime": "^7.20.13",
     "chalk": "^4.1.0",
     "cosmiconfig": "^8.0.0",
-    "cosmiconfig-typescript-loader": "^4.3.0",
     "jest-validate": "^29.4.3",
+    "jiti": "^1.17.1",
     "lodash.get": "^4.4.2"
   },
   "files": [
@@ -39,17 +39,5 @@
   "devDependencies": {
     "@lingui/jest-mocks": "*",
     "ts-node": "^10.9.1"
-  },
-  "peerDependencies": {
-    "ts-node": ">=10",
-    "typescript": ">=4"
-  },
-  "peerDependenciesMeta": {
-    "ts-node": {
-      "optional": true
-    },
-    "typescript": {
-      "optional": true
-    }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4788,11 +4788,6 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
-cosmiconfig-typescript-loader@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-4.3.0.tgz#c4259ce474c9df0f32274ed162c0447c951ef073"
-  integrity sha512-NTxV1MFfZDLPiBMjxbHRwSh5LaLcPMwNdCutmnHJCKoVnlvldPWlllonKwrsRJ5pYZBIBGRWWU2tfvzxgeSW5Q==
-
 cosmiconfig@^5.1.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.1.tgz#040f726809c591e77a17c0a3626ca45b4f168b1a"
@@ -7919,6 +7914,11 @@ jest@^29.4.3:
     "@jest/types" "^29.4.3"
     import-local "^3.0.2"
     jest-cli "^29.4.3"
+
+jiti@^1.17.1:
+  version "1.17.1"
+  resolved "https://registry.yarnpkg.com/jiti/-/jiti-1.17.1.tgz#264daa43ee89a03e8be28c3d712ccc4eb9f1e8ed"
+  integrity sha512-NZIITw8uZQFuzQimqjUxIrIcEdxYDFIe/0xYfIlVXTkiBjjyBEvgasj5bb0/cHtPRD/NziPbT312sFrkI5ALpw==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
# Description
 As i mentioned: 

> i've found very promising https://github.com/unjs/jiti and https://github.com/unjs/c12 we should give them a try. These packages powering a Nuxt framework.

Unfortunately we can't use `c12` because it load asynchonously but we can incorporate `jiti` instead of `cosmiconfig-typescript-loader` / `ts-node`. 

Looks like jiti was created for such usecases, where `ts-node` is not. The benefit of using jiti over `ts-node`: 

1. Supports cache (v8, require and hard cache on the file system of transpiled files)
2. Executes only this require in "context" of transpilation. 

The problem with ts-node is that once it registered it starts processing all require calls in the current VM. That caused that not only config with it's dependecies get transpiled but also other code running in the same instance after register call. 

Also all subsequent calls to `TypeScriptLoader` with `ts-node` would cause registering another instance of compiler for require module system and this is end up with [out memory at certain point](https://github.com/lingui/js-lingui/issues/1405). 

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
