### PR TITLE
fix: allow passing any expression as custom i18n instance

### DIFF
--- a/packages/macro/src/macroJs.ts
+++ b/packages/macro/src/macroJs.ts
@@ -66,7 +66,7 @@ export default class MacroJs {
       message,
       values,
     }: { message: ParsedResult["message"]; values: ParsedResult["values"] },
-    linguiInstance?: babelTypes.Identifier
+    linguiInstance?: babelTypes.Expression
   ) => {
     const properties: ObjectProperty[] = [
       this.createIdProperty(message),
@@ -100,7 +100,7 @@ export default class MacroJs {
     if (
       this.types.isCallExpression(path.node) &&
       this.types.isTaggedTemplateExpression(path.parentPath.node) &&
-      this.types.isIdentifier(path.node.arguments[0]) &&
+      this.types.isExpression(path.node.arguments[0]) &&
       this.isLinguiIdentifier(path.node.callee, "t")
     ) {
       // Use the first argument as i18n instance instead of the default i18n instance
@@ -123,7 +123,7 @@ export default class MacroJs {
     if (
       this.types.isCallExpression(path.node) &&
       this.types.isCallExpression(path.parentPath.node) &&
-      this.types.isIdentifier(path.node.arguments[0]) &&
+      this.types.isExpression(path.node.arguments[0]) &&
       this.isLinguiIdentifier(path.node.callee, "t")
     ) {
       const i18nInstance = path.node.arguments[0]
@@ -189,7 +189,7 @@ export default class MacroJs {
    */
   replaceTAsFunction = (
     path: NodePath<CallExpression>,
-    linguiInstance?: babelTypes.Identifier
+    linguiInstance?: babelTypes.Expression
   ) => {
     const descriptor = this.processDescriptor(path.node.arguments[0])
     path.replaceWith(this.createI18nCall(descriptor, linguiInstance))
@@ -423,7 +423,7 @@ export default class MacroJs {
 
   createI18nCall(
     messageDescriptor: ObjectExpression,
-    linguiInstance?: Identifier
+    linguiInstance?: Expression
   ) {
     return this.types.callExpression(
       this.types.memberExpression(

--- a/packages/macro/test/js-t.ts
+++ b/packages/macro/test/js-t.ts
@@ -222,6 +222,24 @@ const cases: TestCase[] = [
       `,
   },
   {
+    name: "Support template strings in t macro message, with custom i18n instance object property",
+    input: `
+        import { t } from '@lingui/macro'
+        const msg = t(global.i18n)({ message: \`Hello \${name}\` })
+      `,
+    expected: `const msg = global.i18n._(
+        /*i18n*/
+        {
+          values: {
+            name: name,
+          },
+          message: "Hello {name}",
+          id: "OVaF9k",
+        }
+      );
+    `,
+  },
+  {
     name: "Should generate different id when context provided",
     input: `
         import { t } from '@lingui/macro'


### PR DESCRIPTION
# Description

Currently passing a custom i18n instance to the `t` macro only supports passing identifier, although any expression should be valid.

For example this currently crashes during extraction:

```ts
t(context.intl)`Hello`;
```

This changes the check from `isIdentifier` to `isExpression` so we can support function calls or member properties.

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
