### PR TITLE
fix: do not remount children of I18nProvider

### DIFF
--- a/packages/react/src/I18nProvider.test.tsx
+++ b/packages/react/src/I18nProvider.test.tsx
@@ -107,10 +107,8 @@ describe("I18nProvider", () => {
 
     const { container } = render(
       <I18nProvider i18n={i18n}>
-        <>
-          <CurrentLocaleStatic />
-          <CurrentLocaleContextConsumer />
-        </>
+        <CurrentLocaleStatic />
+        <CurrentLocaleContextConsumer />
       </I18nProvider>
     )
 

--- a/packages/react/src/I18nProvider.test.tsx
+++ b/packages/react/src/I18nProvider.test.tsx
@@ -122,7 +122,7 @@ describe("I18nProvider", () => {
         return <span data-testid="dynamic">2_{i18n.locale}</span>
       }
 
-      const { container, debug } = render(
+      const { container } = render(
         <I18nProvider
           i18n={i18n}
           forceRenderOnLocaleChange={forceRenderOnLocaleChange}
@@ -133,7 +133,7 @@ describe("I18nProvider", () => {
           </>
         </I18nProvider>
       )
-      debug()
+
       // First render — locale isn't activated
       expect(container.textContent).toEqual(textContentBeforeActivate)
 

--- a/packages/react/src/I18nProvider.test.tsx
+++ b/packages/react/src/I18nProvider.test.tsx
@@ -90,8 +90,8 @@ describe("I18nProvider", () => {
       textContentDynamicAfterActivate: "2_cs",
     },
   ])(
-    "A component that is not consuming i18n context will not re-render on locale change.",
-    // "A component that consumes i18n context will re-render on locale change, only if forceRenderOnLocaleChange is true.",
+    "A component that is not consuming i18n context will not re-render on locale change." +
+      "A component that consumes i18n context will re-render on locale change, only if forceRenderOnLocaleChange is true.",
     ({
       forceRenderOnLocaleChange,
       textContentBeforeActivate,

--- a/packages/react/src/I18nProvider.test.tsx
+++ b/packages/react/src/I18nProvider.test.tsx
@@ -140,20 +140,20 @@ describe("I18nProvider", () => {
         i18n.activate("cs")
       })
 
-      // After loading and activating locale, only CurrentLocaleContextConsumer re-rendered.
+      // After loading and activating locale, components are re-rendered if forceRenderOnLocaleChange is true
       expect(getByTestId("static").textContent).toBe(
         textContentStaticAfterActivate
       )
       expect(getByTestId("dynamic").textContent).toBe(
         textContentDynamicAfterActivate
       )
-      expect(staticRenderCount).toBe(1)
 
       /*
-       * when forceRenderOnLocaleChange is false, components are rendered only once and then do not re-rendered
+       * when forceRenderOnLocaleChange is false, components are rendered only once and then do not re-render
        * when forceRenderOnLocaleChange is true, initial render skips rendering children because no locale is active.
        * Later, loading messages & locale activation are batched into 1 render.
        * */
+      expect(staticRenderCount).toBe(1)
       expect(dynamicRenderCount).toBe(1)
     }
   )
@@ -173,13 +173,13 @@ describe("I18nProvider", () => {
         renderCount++
         return <span data-testid="child">{i18n.locale}</span>
       }
+
       /**
        * Note that we're doing exactly what the description says:
        * but to simulate the equivalent situation, we pass our own mock subscriber
-       * to i18n.on("change", ...) and then we call i18n.activate("cs") ourselves
+       * to i18n.on("change", ...) and in it we call i18n.activate("cs") ourselves
        * so that the condition in useEffect() is met and the component re-renders
        * */
-
       const mockSubscriber = jest.fn(() => {
         i18n.load("cs", {})
         i18n.activate("cs")

--- a/packages/react/src/I18nProvider.tsx
+++ b/packages/react/src/I18nProvider.tsx
@@ -8,11 +8,10 @@ export type I18nContext = {
 }
 
 export type I18nProviderProps = I18nContext & {
-  forceRenderOnLocaleChange?: boolean
   children?: React.ReactNode
 }
 
-const LinguiContext = React.createContext<I18nContext>(null)
+export const LinguiContext = React.createContext<I18nContext>(null)
 
 export function useLingui(): I18nContext {
   const context = React.useContext<I18nContext>(LinguiContext)
@@ -29,7 +28,6 @@ export function useLingui(): I18nContext {
 export const I18nProvider: FunctionComponent<I18nProviderProps> = ({
   i18n,
   defaultComponent,
-  forceRenderOnLocaleChange = true,
   children,
 }) => {
   const latestKnownLocale = React.useRef<string | undefined>(i18n.locale)
@@ -62,9 +60,6 @@ export const I18nProvider: FunctionComponent<I18nProviderProps> = ({
    * we need to trigger re-rendering of LinguiContext.Consumers.
    */
   React.useEffect(() => {
-    if (!forceRenderOnLocaleChange) {
-      return
-    }
     const updateContext = () => {
       latestKnownLocale.current = i18n.locale
       setContext(makeContext())
@@ -79,12 +74,14 @@ export const I18nProvider: FunctionComponent<I18nProviderProps> = ({
       updateContext()
     }
     return unsubscribe
-  }, [makeContext, forceRenderOnLocaleChange])
+  }, [makeContext])
 
-  if (forceRenderOnLocaleChange && !latestKnownLocale.current) {
-    console.log(
-      "I18nProvider did not render. A call to i18n.activate still needs to happen or forceRenderOnLocaleChange must be set to false."
-    )
+  if (!latestKnownLocale.current) {
+    process.env.NODE_ENV === "development" &&
+      console.log(
+        "I18nProvider rendered `null`. A call to `i18n.activate` needs to happen in order for translations to be activated and for the I18nProvider to render." +
+          "This is not an error but an informational message logged only in development."
+      )
     return null
   }
 

--- a/packages/react/src/I18nProvider.tsx
+++ b/packages/react/src/I18nProvider.tsx
@@ -81,7 +81,12 @@ export const I18nProvider: FunctionComponent<I18nProviderProps> = ({
     return unsubscribe
   }, [makeContext, forceRenderOnLocaleChange])
 
-  if (forceRenderOnLocaleChange && !latestKnownLocale.current) return null
+  if (forceRenderOnLocaleChange && !latestKnownLocale.current) {
+    console.log(
+      "I18nProvider did not render. A call to i18n.activate still needs to happen or forceRenderOnLocaleChange must be set to false."
+    )
+    return null
+  }
 
   return (
     <LinguiContext.Provider value={context}>{children}</LinguiContext.Provider>

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,4 +1,4 @@
-export { I18nProvider, useLingui } from "./I18nProvider"
+export { I18nProvider, useLingui, LinguiContext } from "./I18nProvider"
 
 export type { I18nProviderProps, I18nContext } from "./I18nProvider"
 

--- a/website/docs/ref/react.md
+++ b/website/docs/ref/react.md
@@ -198,5 +198,5 @@ import { Trans } from '@lingui/react';
    id="my.plural.msg"
    message="{count, plural, =1 {car} other {cars}}"
    values={{ count: cars.length }}
-></Trans>
+/>
 ```

--- a/website/docs/ref/react.md
+++ b/website/docs/ref/react.md
@@ -7,7 +7,7 @@ Components from `@lingui/react` wrap the vanilla JS API from `@lingui/core`. Rea
 All i18n components render translation as text without a wrapping tag. This can be customized in two different ways:
 
 -   globally: using `defaultComponent` prop on [`I18nProvider`](#i18nprovider) component
--   locally: using `render` prop or `component` on i18 components
+-   locally: using `render` prop or `component` on i18n components
 
 #### Global Configuration
 
@@ -56,16 +56,22 @@ To get more control over the rendering of translation, use instead the `render` 
 
 ## Lingui Context
 
-Message catalogs and the active locale are passed to the context in [`I18nProvider`](#i18nprovider). Use [`useLingui`](#uselingui) hook to access Lingui context.
+Message catalogs and the active locale are passed via context in [`I18nProvider`](#i18nprovider). Use the [`useLingui`](#uselingui) hook to access the Lingui context.
+
+Lingui context object is exported from the package (`import { LinguiContext } from '@lingui/react'`). It is not expected that you would need it, but it enables advanced scenarios if the behavior of `I18nProvider` doesn't fit your needs.
 
 ### I18nProvider
 
-| Prop name                   | Type                  | Description                                                               |
-| --------------------------- | --------------------- |---------------------------------------------------------------------------|
-| `I18n`                      | `i18n`                | The i18n instance (usually the one imported from `@lingui/core`)          |
-| `children`                  | `React.ReactNode`     | React Children node                                                       |
-| `defaultComponent`          | `React.ComponentType` | A React component for rendering <Trans\> within this component (optional) |
-| `forceRenderOnLocaleChange` | `boolean`             | Force re-render when locale changes (default: true)                       |
+`I18nProvider` provides Lingui context to all components in the subtree. It should be rendered as top-level component of your application.
+
+`I18nProvider` renders its children only after a locale is activated. This ensures that the components consuming `i18n` have access to the translations.
+Additionally, it subscribes to change events emitted by the `i18n` object and re-renders all components consuming the Lingui context when messages are updated or when a new locale is activated.
+
+| Prop name          | Type                  | Description                                                               |
+|--------------------|-----------------------|---------------------------------------------------------------------------|
+| `i18n`             | `I18n`                | The i18n instance (usually the one imported from `@lingui/core`)          |
+| `children`         | `React.ReactNode`     | React Children node                                                       |
+| `defaultComponent` | `React.ComponentType` | A React component within which translation strings will be rendered (optional) |
 
 `defaultComponent` has the same meaning as `component` in other i18n components. [`Rendering of translations`](#rendering-translations) is explained at the beginning of this document.
 
@@ -89,35 +95,6 @@ const DefaultI18n = ({ isTranslated, children }) => (
 const App = () => {
    return (
       <I18nProvider i18n={i18n} defaultComponent={DefaultI18n}>
-         // rest of the app
-      </I18nProvider>
-   );
-}
-```
-
-`forceRenderOnLocaleChange` is true by default and it ensures that:
-
-> -   Children of `I18nProvider` aren't rendered before locales are loaded.
-> -   When locale changes, the components consuming `i18n` context are re-rendered.
-
-Disable `forceRenderOnLocaleChange` when you have specific needs to handle initial state before locales are loaded and when locale changes.
-
-`I18nProvider` should live above all other i18n components. A good place is as a top-level application component. However, if the `locale` is stored in a `redux` store, this component should be inserted below `react-redux/Provider`:
-
-``` jsx
-import React from 'react';
-import { I18nProvider } from '@lingui/react';
-import { i18n } from '@lingui/core';
-import { messages as messagesEn } from './locales/en/messages.js';
-
-i18n.load({
-   en: messagesEn,
-});
-i18n.activate('en');
-
-const App = () => {
-   return (
-      <I18nProvider i18n={i18n}>
          // rest of the app
       </I18nProvider>
    );
@@ -155,7 +132,7 @@ This section is intended for reference purposes.
 
 :::important
 
-Import [`Trans`](/docs/ref/macro.md#jsxmacro-Trans) macro instead of [`Trans`](#trans) component if you use macros:
+Import [`Trans`](/docs/ref/macro.md#trans) macro instead of [`Trans`](#trans) component if you use macros:
 
 ``` jsx
 import { Trans } from "@lingui/macro"

--- a/website/docs/ref/react.md
+++ b/website/docs/ref/react.md
@@ -9,11 +9,11 @@ All i18n components render translation as text without a wrapping tag. This can 
 -   globally: using `defaultComponent` prop on [`I18nProvider`](#i18nprovider) component
 -   locally: using `render` prop or `component` on i18n components
 
-#### Global Configuration
+### Global Configuration
 
 Default rendering component can be set using `defaultComponent` prop in [`I18nProvider`](#i18nprovider). The main use case for this is rendering translations in `<Text>` component in React Native.
 
-#### Local Configuration
+### Local Configuration
 
 | Prop name   | Type                                      | Description                                    |
 |-------------| ----------------------------------------- |------------------------------------------------|
@@ -163,7 +163,7 @@ It's also possible to use `Trans` component directly without macros. In that cas
 />
 ```
 
-#### Plurals
+### Plurals
 
 If you cannot use [@lingui/macro](/docs/ref/macro.md) for some reason, you can render plurals using the plain Trans component like this:
 

--- a/website/docs/ref/react.md
+++ b/website/docs/ref/react.md
@@ -1,6 +1,6 @@
 # React API Reference
 
-Components from `@lingui/react` wrap the vanilla JS API from `lingui-i18n`. React components handle changes of active language or interpolated variables better than low-level API and also take care of re-rendering when wrapped inside pure components.
+Components from `@lingui/react` wrap the vanilla JS API from `@lingui/core`. React components handle changes of active language or interpolated variables better than low-level API and also take care of re-rendering when locale or messages change.
 
 ## General Concepts
 
@@ -15,21 +15,19 @@ All i18n components render translation as a text without a wrapping tag. This ca
 
 Default rendering component can be set using `defaultComponent` prop in [`I18nProvider`](#i18nprovider). The main use case for this is rendering translations in `<Text>` component in React Native.
 
-~~It's possible to pass in either a string for built-in elements (`span`, `h1`)~~, React elements or React classes. This prop has the same type as `render` and `component` prop on i18n components described below.
-
 #### Local Configuration
 
-| Prop name   | Type                                      | Description                                  |
-|-------------| ----------------------------------------- | -------------------------------------------- |
-| `className` | string                                    | Class name to be added to `<span>` element   |
-| `render`    | *Function(props) -> Element \| Component* | Custom wrapper rendered as function          |
-| `component` | Component, `null`                         | Custom wrapper element to render translation |
+| Prop name   | Type                                      | Description                                    |
+|-------------| ----------------------------------------- |------------------------------------------------|
+| `className` | string                                    | Class name to be added to `<span>` element     |
+| `render`    | *Function(props) -> Element \| Component*                                     | Custom wrapper rendered as function          |
+| `component` | Component, `null`                         | Custom wrapper component to render translation |
 
 `className` is used only for built-in components (when *render* is string).
 
 `Function(props)` props returns the translation, an id, and a message.
 
-When `component` is **React.Element** ~~or **string** (built-in tags)~~, it is rendered with the `translation` passed in as its child:
+`component` is rendered with the `translation` passed in as its child:
 
 ``` jsx
 import { Text } from "react-native";
@@ -48,7 +46,7 @@ To get more control over the rendering of translation, use instead the `render` 
 // renders as <Icon label="Sign in" />
 ```
 
-`render` or `component` also accepts `null` value to render string without wrapping component. This can be used to override custom `defaultComponent` config.
+`render` or `component` also accepts `null` value to render string without a wrapping component. This can be used to override custom `defaultComponent` config.
 
 ``` jsx
 <Trans render={null}>Heading</Trans>;
@@ -99,7 +97,7 @@ It's also possible to use `Trans` component directly without macros. In that cas
 
 #### Plurals
 
-If you cannot use [@lingui/macro](/docs/ref/macro.md) for some reason(maybe you compile your code using just TS instead of babel), you can render plurals using the plain Trans component like this:
+If you cannot use [@lingui/macro](/docs/ref/macro.md) for some reason, you can render plurals using the plain Trans component like this:
 
 ``` jsx
 import React from 'react';
@@ -154,10 +152,8 @@ const App = () => {
 
 `forceRenderOnLocaleChange` is true by default and it ensures that:
 
-> -   Children of `I18nProvider` aren't rendered before locales are
->     loaded.
-> -   When locale changes, the whole element tree below `I18nProvider`
->     is re-rendered.
+> -   Children of `I18nProvider` aren't rendered before locales are loaded.
+> -   When locale changes, the components consuming `i18n` context are re-rendered.
 
 Disable `forceRenderOnLocaleChange` when you have specific needs to handle initial state before locales are loaded and when locale changes.
 

--- a/website/docs/ref/react.md
+++ b/website/docs/ref/react.md
@@ -193,7 +193,8 @@ import React from 'react';
 import { Trans } from '@lingui/react';
 
 <Trans
-   id="{count, plural, =1 {car} other {cars}}"
+   id="my.plural.msg"
+   message="{count, plural, =1 {car} other {cars}}"
    values={{ count: cars.length }}
 ></Trans>
 ```

--- a/website/docs/ref/react.md
+++ b/website/docs/ref/react.md
@@ -18,7 +18,7 @@ Default rendering component can be set using `defaultComponent` prop in [`I18nPr
 | Prop name   | Type                                      | Description                                    |
 |-------------| ----------------------------------------- |------------------------------------------------|
 | `className` | string                                    | Class name to be added to `<span>` element     |
-| `render`    | *Function(props) -> Element \| Component*                                     | Custom wrapper rendered as function          |
+| `render`    | *Function(props) -> Element \| Component* | Custom wrapper rendered as function          |
 | `component` | Component, `null`                         | Custom wrapper component to render translation |
 
 `className` is used only for built-in components (when *render* is string).

--- a/website/docs/ref/react.md
+++ b/website/docs/ref/react.md
@@ -167,19 +167,21 @@ import { Trans } from "@lingui/macro"
 ```
 :::
 
-It's also possible to use `Trans` component directly without macros. In that case, `id` is the message being translated. `values` and `components` are arguments and components used for formatting translation:
+It's also possible to use `Trans` component directly without macros. In that case, `id` identifies the message being translated. `values` and `components` are arguments and components used for formatting translation:
 
 ``` jsx
-<Trans id="Hello World" />;
+<Trans id="my.message" message="Hello World"/>
 
 <Trans
-  id="Hello {name}"
+  id="greeting"
+  message="Hello {name}"
   values={{ name: 'Arthur' }}
-/>;
+/>
 
 // number of tag corresponds to index in `components` prop
 <Trans
-  id="Read <link>Description</link> below."
+  id="link"
+  message="Read <link>Description</link> below."
   components={{ link: <a href="/docs" /> }}
 />
 ```

--- a/website/docs/releases/migration-4.md
+++ b/website/docs/releases/migration-4.md
@@ -23,13 +23,16 @@ module.exports = {
 
 ### I18nProvider no longer remounts its children on locale change
 
-Previously, the `I18nProvider` remounted its children on locale change. This ensured that the whole app was re-rendered with the new locale and all strings were rendered correctly translated.
-Apart from not being very performant, this approach had the drawback that the state of the app was lost - all components were re-mounted and their state was reset. This is not a standard behavior of React Context providers and could cause some confusion.
+Previously, the `I18nProvider` remounted its children on locale change. This had the effect that the whole app was re-rendered with the new locale and all strings were rendered correctly translated.
+Apart from not being very performant, this approach had the drawback that the state of the app was lost - all components were re-mounted and their state was reset. This is not a standard behavior for React Context providers and could cause some confusion.
 
 In v4, the `I18nProvider` no longer remounts its children on locale change. Instead, when locale changes, the context value provided by `I18nProvider` is updated and all components that consume the provided React Context are re-rendered with the new locale.
-This includes components provided by Lingui, such as `Trans` or `Plural` and also custom components that use the `useLingui` hook.
+This includes components provided by Lingui, such as `Trans` or `Plural` and also custom components that use the `useLingui` hook. This should result in a more predictable behavior.
 
-This is the default behavior, but you can disable it by setting `forceRenderOnLocaleChange={false}`.
+If the changes to the `I18nProvider` pose a problem to you, please open an issue and explain what the problem is. Additionally, you can keep using the [v3 implementation](https://github.com/lingui/js-lingui/blob/31dcab5a9a8f88bfa8b3a2c7cd12aa2d908a1d80/packages/react/src/I18nProvider.tsx#L58) by copying it into your code base and using that instead.
+
+No migration steps are necessary for components provided by Lingui, such as `Trans` or `Plural`. However, if you rendered translations in React components using the `t` macro, you need to be sure that the `useLingui` hook is called in the component, as seen [here](/ref/react#uselingui).
+
 
 ### Hash-based message ID generation and Context feature
 

--- a/website/docs/releases/migration-4.md
+++ b/website/docs/releases/migration-4.md
@@ -21,6 +21,16 @@ module.exports = {
 }
 ```
 
+### I18nProvider no longer remounts its children on locale change
+
+Previously, the `I18nProvider` remounted its children on locale change. This ensured that the whole app was re-rendered with the new locale and all strings were rendered correctly translated.
+Apart from not being very performant, this approach had the drawback that the state of the app was lost - all components were re-mounted and their state was reset. This is not a standard behavior of React Context providers and could cause some confusion.
+
+In v4, the `I18nProvider` no longer remounts its children on locale change. Instead, when locale changes, the context value provided by `I18nProvider` is updated and all components that consume the provided React Context are re-rendered with the new locale.
+This includes components provided by Lingui, such as `Trans` or `Plural` and also custom components that use the `useLingui` hook.
+
+This is the default behavior, but you can disable it by setting `forceRenderOnLocaleChange={false}`.
+
 ### Hash-based message ID generation and Context feature
 
 The previous implementation had a flaw: there is an original message in the bundle at least 2 times + 1 translation.

--- a/website/docs/releases/migration-4.md
+++ b/website/docs/releases/migration-4.md
@@ -33,7 +33,6 @@ If the changes to the `I18nProvider` pose a problem to you, please open an issue
 
 No migration steps are necessary for components provided by Lingui, such as `Trans` or `Plural`. However, if you rendered translations in React components using the `t` macro, you need to be sure that the `useLingui` hook is called in the component, as seen [here](/ref/react#uselingui).
 
-
 ### Hash-based message ID generation and Context feature
 
 The previous implementation had a flaw: there is an original message in the bundle at least 2 times + 1 translation.

--- a/website/docs/releases/migration-4.md
+++ b/website/docs/releases/migration-4.md
@@ -31,7 +31,7 @@ This includes components provided by Lingui, such as `Trans` or `Plural` and als
 
 If the changes to the `I18nProvider` pose a problem to you, please open an issue and explain what the problem is. Additionally, you can keep using the [v3 implementation](https://github.com/lingui/js-lingui/blob/31dcab5a9a8f88bfa8b3a2c7cd12aa2d908a1d80/packages/react/src/I18nProvider.tsx#L58) by copying it into your code base and using that instead.
 
-No migration steps are necessary for components provided by Lingui, such as `Trans` or `Plural`. However, if you rendered translations in React components using the `t` macro, you need to be sure that the `useLingui` hook is called in the component, as seen [here](/ref/react#uselingui).
+No migration steps are necessary for components provided by Lingui, such as `Trans` or `Plural`. However, if you rendered translations in React components using the `t` macro, you need to be sure that the `useLingui` hook is called in the component, as seen [here](/docs/ref/react.md#uselingui).
 
 ### Hash-based message ID generation and Context feature
 

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -196,7 +196,7 @@ const sidebar = [
   {
     type: 'category',
     label: 'Releases',
-    items: ['releases/migration-3', 'releases/migration-4'],
+    items: ['releases/migration-4', 'releases/migration-3'],
   },
 ];
 


### PR DESCRIPTION
# Description

fixes #1136 

While working on #1426 I noticed the issue reported in #1136. Using a custom key in the I18nProvider results in remounting of the whole app which is not a standard practice in React providers.

If someone needs to do remounting, I would suggest they implement this themselves, but the lingui/react library should not do this out of the box. The PR removes the usage of `key` prop altogether.

Breaking changes:

Previously the whole app would re-mount when calling `activate()` or `load()` and this will no longer be the case. If someone uses translations in their components using just 

```
t`some string` 
```

then those occurrences will not re-render. This, I believe, is correct behavior. We need to document how to make those places re-render - ~~I'm not really sure myself~~ using the useLingui hook .

In version 2 you could do

```
i18n._(t`this will be translated`)
``` 

- what is the equivalent of it for version 4?

Thanks for reviewing! 🙂 

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
