### PR TITLE
fix: hanging cli commands

### DIFF
--- a/packages/cli/src/lingui-compile.ts
+++ b/packages/cli/src/lingui-compile.ts
@@ -244,5 +244,7 @@ if (require.main === module) {
     }
 
     console.log("Done!")
+
+    process.exit(0)
   }
 }

--- a/packages/cli/src/lingui-extract-template.ts
+++ b/packages/cli/src/lingui-extract-template.ts
@@ -73,5 +73,7 @@ if (require.main === module) {
     configPath: program.config || process.env.LINGUI_CONFIG,
   }).then(() => {
     if (!result) process.exit(1)
+
+    process.exit(0)
   })
 }

--- a/packages/cli/src/lingui-extract.ts
+++ b/packages/cli/src/lingui-extract.ts
@@ -228,10 +228,14 @@ if (require.main === module) {
     // for ex: lingui extract src/app, this will extract only files included in src/app
     extract(program.args).then((result) => {
       if (!result) process.exit(1)
+
+      process.exit(0)
     })
   } else {
     extract().then((result) => {
       if (!result) process.exit(1)
+
+      process.exit(0)
     })
   }
 }


### PR DESCRIPTION
# Description

Currently, cli `commander` commands do not exit on some OS'es like Windows. This PR solves that, non-obtrusively.

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Fixes the issue described in details in [this Discord thread](https://discord.com/channels/974702239358783608/1082246193939230730/1082246360742514718).

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
