### PR TITLE
feat: clarify the order by `messageId` in v4 and support order by message

### DIFF
--- a/packages/cli/src/api/__snapshots__/catalog.test.ts.snap
+++ b/packages/cli/src/api/__snapshots__/catalog.test.ts.snap
@@ -943,7 +943,6 @@ exports[`order should order messages alphabetically 2`] = `
 ]
 `;
 
-
 exports[`order should order messages by origin 1`] = `
 {
   LabelA: {

--- a/packages/cli/src/api/__snapshots__/catalog.test.ts.snap
+++ b/packages/cli/src/api/__snapshots__/catalog.test.ts.snap
@@ -943,6 +943,68 @@ exports[`order should order messages alphabetically 2`] = `
 ]
 `;
 
+exports[`order should order messages by message 1`] = `
+{
+  msg1: {
+    message: B,
+    obsolete: false,
+    origin: [
+      [
+        file2.js,
+        2,
+      ],
+      [
+        file1.js,
+        2,
+      ],
+    ],
+    translation: B,
+  },
+  msg2: {
+    message: A,
+    obsolete: false,
+    origin: [
+      [
+        file2.js,
+        3,
+      ],
+    ],
+    translation: A,
+  },
+  msg3: {
+    message: D,
+    obsolete: false,
+    origin: [
+      [
+        file2.js,
+        100,
+      ],
+    ],
+    translation: D,
+  },
+  msg4: {
+    message: C,
+    obsolete: false,
+    origin: [
+      [
+        file1.js,
+        1,
+      ],
+    ],
+    translation: C,
+  },
+}
+`;
+
+exports[`order should order messages by message 2`] = `
+[
+  msg2,
+  msg1,
+  msg4,
+  msg3,
+]
+`;
+
 exports[`order should order messages by origin 1`] = `
 {
   LabelA: {

--- a/packages/cli/src/api/__snapshots__/catalog.test.ts.snap
+++ b/packages/cli/src/api/__snapshots__/catalog.test.ts.snap
@@ -943,67 +943,6 @@ exports[`order should order messages alphabetically 2`] = `
 ]
 `;
 
-exports[`order should order messages by message 1`] = `
-{
-  msg1: {
-    message: B,
-    obsolete: false,
-    origin: [
-      [
-        file2.js,
-        2,
-      ],
-      [
-        file1.js,
-        2,
-      ],
-    ],
-    translation: B,
-  },
-  msg2: {
-    message: A,
-    obsolete: false,
-    origin: [
-      [
-        file2.js,
-        3,
-      ],
-    ],
-    translation: A,
-  },
-  msg3: {
-    message: D,
-    obsolete: false,
-    origin: [
-      [
-        file2.js,
-        100,
-      ],
-    ],
-    translation: D,
-  },
-  msg4: {
-    message: C,
-    obsolete: false,
-    origin: [
-      [
-        file1.js,
-        1,
-      ],
-    ],
-    translation: C,
-  },
-}
-`;
-
-exports[`order should order messages by message 2`] = `
-[
-  msg2,
-  msg1,
-  msg4,
-  msg3,
-]
-`;
 
 exports[`order should order messages by origin 1`] = `
 {

--- a/packages/cli/src/api/catalog.test.ts
+++ b/packages/cli/src/api/catalog.test.ts
@@ -553,6 +553,42 @@ describe("order", () => {
     // Jest snapshot order the keys automatically, so test that the key order explicitly
     expect(Object.keys(orderedCatalogs)).toMatchSnapshot()
   })
+
+  it("should order messages by message", () => {
+    const catalog = {
+      msg1: makeNextMessage({
+        message: "B",
+        translation: "B",
+        origin: [
+          ["file2.js", 2],
+          ["file1.js", 2],
+        ],
+      }),
+      msg2: makeNextMessage({
+        message: "A",
+        translation: "A",
+        origin: [["file2.js", 3]],
+      }),
+      msg3: makeNextMessage({
+        message: "D",
+        translation: "D",
+        origin: [["file2.js", 100]],
+      }),
+      msg4: makeNextMessage({
+        message: "C",
+        translation: "C",
+        origin: [["file1.js", 1]],
+      }),
+    }
+
+    const orderedCatalogs = order("message")(catalog)
+
+    // Test that the message content is the same as before
+    expect(orderedCatalogs).toMatchSnapshot()
+
+    // Jest snapshot order the keys automatically, so test that the key order explicitly
+    expect(Object.keys(orderedCatalogs)).toMatchSnapshot()
+  })
 })
 
 describe("writeCompiled", () => {

--- a/packages/cli/src/api/catalog.test.ts
+++ b/packages/cli/src/api/catalog.test.ts
@@ -565,7 +565,7 @@ describe("order", () => {
         ],
       }),
       msg2: makeNextMessage({
-        message: "A",
+        // message is optional.
         translation: "A",
         origin: [["file2.js", 3]],
       }),
@@ -583,11 +583,15 @@ describe("order", () => {
 
     const orderedCatalogs = order("message")(catalog)
 
-    // Test that the message content is the same as before
-    expect(orderedCatalogs).toMatchSnapshot()
-
     // Jest snapshot order the keys automatically, so test that the key order explicitly
-    expect(Object.keys(orderedCatalogs)).toMatchSnapshot()
+    expect(Object.keys(orderedCatalogs)).toMatchInlineSnapshot(`
+      [
+        msg2,
+        msg1,
+        msg4,
+        msg3,
+      ]
+    `)
   })
 })
 

--- a/packages/cli/src/api/catalog.ts
+++ b/packages/cli/src/api/catalog.ts
@@ -342,13 +342,9 @@ export function orderByOrigin<T extends ExtractedCatalogType>(messages: T): T {
 export function orderByMessage<T extends ExtractedCatalogType>(messages: T): T {
   return Object.keys(messages)
     .sort((a, b) => {
-      const aMsg = messages[a].message
-      const bMsg = messages[b].message
-
-      if (aMsg < bMsg) return -1
-      if (aMsg > bMsg) return 1
-
-      return 0
+      const aMsg = messages[a].message || ""
+      const bMsg = messages[b].message || ""
+      return aMsg.localeCompare(bMsg)
     })
     .reduce((acc, key) => {
       ;(acc as any)[key] = messages[key]

--- a/packages/cli/src/api/catalog.ts
+++ b/packages/cli/src/api/catalog.ts
@@ -290,6 +290,7 @@ export function order<T extends ExtractedCatalogType>(
 ): (catalog: T) => T {
   return {
     messageId: orderByMessageId,
+    message: orderByMessage,
     origin: orderByOrigin,
   }[by]
 }
@@ -329,6 +330,23 @@ export function orderByOrigin<T extends ExtractedCatalogType>(messages: T): T {
 
       if (aLineNumber < bLineNumber) return -1
       if (aLineNumber > bLineNumber) return 1
+
+      return 0
+    })
+    .reduce((acc, key) => {
+      ;(acc as any)[key] = messages[key]
+      return acc
+    }, {} as T)
+}
+
+export function orderByMessage<T extends ExtractedCatalogType>(messages: T): T {
+  return Object.keys(messages)
+    .sort((a, b) => {
+      const aMsg = messages[a].message
+      const bMsg = messages[b].message
+
+      if (aMsg < bMsg) return -1
+      if (aMsg > bMsg) return 1
 
       return 0
     })

--- a/packages/conf/src/types.ts
+++ b/packages/conf/src/types.ts
@@ -37,7 +37,7 @@ export type CatalogFormatOptions = {
   disableSelectWarning?: boolean
 }
 
-export type OrderBy = "messageId" | "origin"
+export type OrderBy = "messageId" | "message" | "origin"
 
 export type CatalogConfig = {
   name?: string

--- a/website/docs/ref/conf.md
+++ b/website/docs/ref/conf.md
@@ -373,7 +373,7 @@ Sort by the message ID, `js-lingui-id` will be used if no custom id provided.
 
 #### message
 
-Sort by message.
+Sort by source message.
 
 #### origin
 

--- a/website/docs/ref/conf.md
+++ b/website/docs/ref/conf.md
@@ -369,7 +369,11 @@ Order of messages in catalog:
 
 #### messageId
 
-Sort by the message ID.
+Sort by the message ID, `js-lingui-id` will be used if no custom id provided.
+
+#### message
+
+Sort by message.
 
 #### origin
 


### PR DESCRIPTION
# Description

SInce the hash id support is in, the `messageId` now becomes the `linguiId` when custom id is absent. This is a change of behavior compared to v3, so its worth clarifying in the doc.

And to preserve the v3 behavior as much as we can, I am adding a new orderBy (`message`), so when no custom id is used, the order by `message` should match what `messageId` is expected in v3.

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

Fixes # (issue) https://github.com/lingui/js-lingui/issues/1514

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
