### PR TITLE
feat: change default orderBy to `message`

### DIFF
--- a/packages/cli/test/extract-po-format/expected/en.po
+++ b/packages/cli/test/extract-po-format/expected/en.po
@@ -7,6 +7,18 @@ msgstr ""
 "X-Generator: @lingui/cli\n"
 "Language: en\n"
 
+#. this is a comment
+#. js-lingui-id: f9Atdk
+#: fixtures/file-b.tsx:6
+msgid "Hello this is JSX Translation"
+msgstr "Hello this is JSX Translation"
+
+#. js-lingui-id: 6qYmGe
+#: fixtures/file-b.tsx:11
+msgctxt "my context"
+msgid "Hello this is JSX Translation"
+msgstr "Hello this is JSX Translation"
+
 #. js-lingui-id: 1nGWAC
 #: fixtures/file-a.ts:4
 msgid "Hello world"
@@ -18,29 +30,17 @@ msgctxt "custom context"
 msgid "Hello world"
 msgstr "Hello world"
 
-#. js-lingui-id: 6qYmGe
-#: fixtures/file-b.tsx:11
-msgctxt "my context"
-msgid "Hello this is JSX Translation"
-msgstr "Hello this is JSX Translation"
-
 #. js-lingui-id: BcXPt3
 #: fixtures/file-a.ts:16
 msgid "Message in descriptor"
 msgstr "Message in descriptor"
 
-#: fixtures/file-a.ts:11
-#, explicit-id
-msgid "custom.id"
-msgstr "This message has custom id"
-
-#. this is a comment
-#. js-lingui-id: f9Atdk
-#: fixtures/file-b.tsx:6
-msgid "Hello this is JSX Translation"
-msgstr "Hello this is JSX Translation"
-
 #: fixtures/file-b.tsx:15
 #, explicit-id
 msgid "jsx.custom.id"
 msgstr "This JSX element has custom id"
+
+#: fixtures/file-a.ts:11
+#, explicit-id
+msgid "custom.id"
+msgstr "This message has custom id"

--- a/packages/cli/test/extract-po-format/expected/pl.po
+++ b/packages/cli/test/extract-po-format/expected/pl.po
@@ -7,6 +7,18 @@ msgstr ""
 "X-Generator: @lingui/cli\n"
 "Language: pl\n"
 
+#. this is a comment
+#. js-lingui-id: f9Atdk
+#: fixtures/file-b.tsx:6
+msgid "Hello this is JSX Translation"
+msgstr ""
+
+#. js-lingui-id: 6qYmGe
+#: fixtures/file-b.tsx:11
+msgctxt "my context"
+msgid "Hello this is JSX Translation"
+msgstr ""
+
 #. js-lingui-id: 1nGWAC
 #: fixtures/file-a.ts:4
 msgid "Hello world"
@@ -18,29 +30,17 @@ msgctxt "custom context"
 msgid "Hello world"
 msgstr ""
 
-#. js-lingui-id: 6qYmGe
-#: fixtures/file-b.tsx:11
-msgctxt "my context"
-msgid "Hello this is JSX Translation"
-msgstr ""
-
 #. js-lingui-id: BcXPt3
 #: fixtures/file-a.ts:16
 msgid "Message in descriptor"
 msgstr ""
 
-#: fixtures/file-a.ts:11
-#, explicit-id
-msgid "custom.id"
-msgstr ""
-
-#. this is a comment
-#. js-lingui-id: f9Atdk
-#: fixtures/file-b.tsx:6
-msgid "Hello this is JSX Translation"
-msgstr ""
-
 #: fixtures/file-b.tsx:15
 #, explicit-id
 msgid "jsx.custom.id"
+msgstr ""
+
+#: fixtures/file-a.ts:11
+#, explicit-id
+msgid "custom.id"
 msgstr ""

--- a/packages/cli/test/extract-template-po-format/expected/messages.pot
+++ b/packages/cli/test/extract-template-po-format/expected/messages.pot
@@ -6,6 +6,18 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 
+#. this is a comment
+#. js-lingui-id: f9Atdk
+#: fixtures/file-b.tsx:6
+msgid "Hello this is JSX Translation"
+msgstr ""
+
+#. js-lingui-id: 6qYmGe
+#: fixtures/file-b.tsx:11
+msgctxt "my context"
+msgid "Hello this is JSX Translation"
+msgstr ""
+
 #. js-lingui-id: 1nGWAC
 #: fixtures/file-a.ts:4
 msgid "Hello world"
@@ -17,29 +29,17 @@ msgctxt "custom context"
 msgid "Hello world"
 msgstr ""
 
-#. js-lingui-id: 6qYmGe
-#: fixtures/file-b.tsx:11
-msgctxt "my context"
-msgid "Hello this is JSX Translation"
-msgstr ""
-
 #. js-lingui-id: BcXPt3
 #: fixtures/file-a.ts:16
 msgid "Message in descriptor"
 msgstr ""
 
-#: fixtures/file-a.ts:11
-#, explicit-id
-msgid "custom.id"
-msgstr ""
-
-#. this is a comment
-#. js-lingui-id: f9Atdk
-#: fixtures/file-b.tsx:6
-msgid "Hello this is JSX Translation"
-msgstr ""
-
 #: fixtures/file-b.tsx:15
 #, explicit-id
 msgid "jsx.custom.id"
+msgstr ""
+
+#: fixtures/file-a.ts:11
+#, explicit-id
+msgid "custom.id"
 msgstr ""

--- a/packages/conf/src/__snapshots__/index.test.ts.snap
+++ b/packages/conf/src/__snapshots__/index.test.ts.snap
@@ -49,7 +49,7 @@ exports[`@lingui/conf should return default config 1`] = `
   locales: [
     en-gb,
   ],
-  orderBy: messageId,
+  orderBy: message,
   pseudoLocale: ,
   rootDir: .,
   runtimeConfigModule: {

--- a/packages/conf/src/makeConfig.ts
+++ b/packages/conf/src/makeConfig.ts
@@ -59,7 +59,7 @@ export const defaultConfig: LinguiConfig = {
   format: "po",
   formatOptions: { origins: true, lineNumbers: true },
   locales: [],
-  orderBy: "messageId",
+  orderBy: "message",
   pseudoLocale: "",
   rootDir: ".",
   runtimeConfigModule: ["@lingui/core", "i18n"],

--- a/website/docs/ref/conf.md
+++ b/website/docs/ref/conf.md
@@ -363,17 +363,17 @@ Locale tags which are used in the project. [`extract`](/docs/ref/cli.md#extract)
 
 ## orderBy
 
-Default: `messageId`
+Default: `message`
 
 Order of messages in catalog:
-
-#### messageId
-
-Sort by the message ID, `js-lingui-id` will be used if no custom id provided.
 
 #### message
 
 Sort by source message.
+
+#### messageId
+
+Sort by the message ID, `js-lingui-id` will be used if no custom id provided.
 
 #### origin
 

--- a/website/docs/releases/migration-4.md
+++ b/website/docs/releases/migration-4.md
@@ -60,6 +60,8 @@ Also, we've added a possibility to provide a context for the message. For more d
 
 The context feature affects the message ID generation and adds the `msgctxt` parameter in case of the PO catalog format extraction.
 
+This also affects the `orderBy` with `messageId` as now the generated id is used when custom id is absent. To avoid confusion, we switched the default `orderBy` to use the source message (`message`) instead.
+
 ### Change in generated ICU messages for nested JSX Macros
 
 We have made a small change in how Lingui generates ICU messages for nested JSX Macros. We have removed leading spaces from the texts in all cases.


### PR DESCRIPTION
# Description

more context in https://github.com/lingui/js-lingui/pull/1515#issuecomment-1468275117, in short, we want to switch default orderBy to the newly added `message` (source message) to match (more) with the behavior in v3.

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  // default config change, so would expect some breaking regarding default behavior on v4, but user always have the freedom to change `orderBy`
- [x] Documentation update

Fixes # (issue) n/a

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
