### PR TITLE
fix(macro types): mark `other` as required for ChoiceOptions

### DIFF
--- a/packages/macro/__typetests__/index.test-d.tsx
+++ b/packages/macro/__typetests__/index.test-d.tsx
@@ -143,6 +143,9 @@ expectType<string>(
   })
 )
 
+// @ts-expect-error: other is required
+expectType<string>(plural(5, { one: "test" }))
+
 ///////////////////
 //// Select Ordinal
 ///////////////////

--- a/packages/macro/index.d.ts
+++ b/packages/macro/index.d.ts
@@ -13,7 +13,7 @@ export type ChoiceOptions = {
   many?: string
 
   /** Catch-all option */
-  other?: string
+  other: string
   /** Exact match form, corresponds to =N rule */
   [digit: `${number}`]: string
 }


### PR DESCRIPTION
# Description

`other` should be required for choice macros, and looks like we do have it as required for `SelectOptions`, `SelectChoiceProps`  and `PluralChoiceProps`, just not `ChoiceOptions` which is probably not intended.

and ICU message without `other` may be invalid:

![image](https://user-images.githubusercontent.com/121891361/225695638-202e72e4-6d19-4c9e-99d7-18e2e8997a60.png)



## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
