### PR TITLE
refactor(cli): make getFormats asynchronous, prepare for ESM

### DIFF
--- a/packages/cli/src/api/catalog.test.ts
+++ b/packages/cli/src/api/catalog.test.ts
@@ -17,6 +17,7 @@ import {
 } from "../tests"
 import { AllCatalogsType } from "./types"
 import { extractFromFiles } from "./catalog/extractFromFiles"
+import { FormatterWrapper, getFormat } from "./formats"
 
 export const fixture = (...dirs: string[]) =>
   path.resolve(__dirname, path.join("fixtures", ...dirs)) +
@@ -35,6 +36,12 @@ function mockConfig(config: Partial<LinguiConfig> = {}) {
 }
 
 describe("Catalog", () => {
+  let format: FormatterWrapper
+
+  beforeAll(async () => {
+    format = await getFormat("po", {})
+  })
+
   afterEach(() => {
     mockFs.restore()
   })
@@ -51,6 +58,7 @@ describe("Catalog", () => {
             fixture("collect/componentB"),
           ],
           exclude: [],
+          format,
         },
         mockConfig({
           locales: ["en", "cs"],
@@ -75,6 +83,7 @@ describe("Catalog", () => {
             fixture("collect/componentB"),
           ],
           exclude: [],
+          format,
         },
         mockConfig({
           locales: ["en", "cs"],
@@ -96,6 +105,7 @@ describe("Catalog", () => {
           path: path.join(localeDir, "{locale}"),
           include: [fixture("collect/")],
           exclude: [],
+          format,
         },
         mockConfig({
           locales: ["en", "cs"],
@@ -122,6 +132,7 @@ describe("Catalog", () => {
             fixture("collect/componentB"),
           ],
           exclude: [],
+          format,
         },
         mockConfig({
           locales: ["en", "cs"],
@@ -147,6 +158,7 @@ describe("Catalog", () => {
           ),
           include: [],
           exclude: [],
+          format,
         },
         mockConfig({
           locales: ["en", "pl"],
@@ -213,6 +225,7 @@ describe("Catalog", () => {
           path: "locales/{locale}",
           include: [fixture("collect-syntax-flow/")],
           exclude: [],
+          format,
         },
         mockConfig({
           extractorParserOptions: {
@@ -231,6 +244,7 @@ describe("Catalog", () => {
           path: "locales/{locale}",
           include: [fixture("collect/")],
           exclude: [],
+          format,
         },
         mockConfig()
       )
@@ -246,6 +260,7 @@ describe("Catalog", () => {
           path: "locales/{locale}",
           include: [fixture("collect-inline-sourcemaps/")],
           exclude: [],
+          format,
         },
         mockConfig()
       )
@@ -266,6 +281,7 @@ describe("Catalog", () => {
             fixture("collect/componentB.js"),
           ],
           exclude: [],
+          format,
         },
         mockConfig()
       )
@@ -283,6 +299,7 @@ describe("Catalog", () => {
           path: "locales/{locale}",
           include: [fixture("duplicate-id.js")],
           exclude: [],
+          format,
         },
         mockConfig()
       )
@@ -307,6 +324,7 @@ describe("Catalog", () => {
           path: "locales/{locale}",
           include: [fixture("collect-invalid/")],
           exclude: [],
+          format,
         },
         mockConfig()
       )
@@ -321,7 +339,7 @@ describe("Catalog", () => {
       })
     })
   })
-  it("Catalog.merge should initialize catalogs", () => {
+  it("Catalog.merge should initialize catalogs", async () => {
     const prevCatalogs: AllCatalogsType = { en: null, cs: null }
     const nextCatalog = {
       "custom.id": makeNextMessage({
@@ -331,7 +349,7 @@ describe("Catalog", () => {
     }
 
     expect(
-      makeCatalog({ sourceLocale: "en" }).merge(
+      (await makeCatalog({ sourceLocale: "en" })).merge(
         prevCatalogs,
         nextCatalog,
         defaultMergeOptions
@@ -371,6 +389,7 @@ describe("Catalog", () => {
           path: "locales/{locale}",
           include: [],
           exclude: [],
+          format,
         },
         mockConfig()
       )
@@ -392,6 +411,7 @@ describe("Catalog", () => {
           name: "messages",
           path: "{locale}/messages",
           include: [],
+          format,
         },
         mockConfig()
       )
@@ -415,6 +435,7 @@ describe("Catalog", () => {
           name: "messages",
           path: "{locale}/messages",
           include: [],
+          format,
         },
         mockConfig({ prevFormat: "minimal" })
       )
@@ -436,6 +457,7 @@ describe("Catalog", () => {
             path.join("fixtures", "readAll", "{locale}", "messages")
           ),
           include: [],
+          format,
         },
         mockConfig({
           locales: ["en", "cs"],
@@ -573,6 +595,7 @@ describe("writeCompiled", () => {
         path: path.join(localeDir, "{locale}", "messages"),
         include: [],
         exclude: [],
+        format: await getFormat("po", {}),
       },
       mockConfig()
     )

--- a/packages/cli/src/api/catalog.ts
+++ b/packages/cli/src/api/catalog.ts
@@ -6,7 +6,7 @@ import normalize from "normalize-path"
 
 import { LinguiConfigNormalized, OrderBy } from "@lingui/conf"
 
-import { FormatterWrapper, getFormat } from "./formats"
+import { FormatterWrapper } from "./formats"
 import { CliExtractOptions } from "../lingui-extract"
 import { CliExtractTemplateOptions } from "../lingui-extract-template"
 import { CompiledCatalogNamespace } from "./compile"
@@ -51,6 +51,7 @@ export type CatalogProps = {
   include: Array<string>
   exclude?: Array<string>
   templatePath?: string
+  format: FormatterWrapper
 }
 
 export class Catalog {
@@ -62,14 +63,14 @@ export class Catalog {
   templateFile?: string
 
   constructor(
-    { name, path, include, templatePath, exclude = [] }: CatalogProps,
+    { name, path, include, templatePath, format, exclude = [] }: CatalogProps,
     public config: LinguiConfigNormalized
   ) {
     this.name = name
     this.path = normalizeRelativePath(path)
     this.include = include.map(normalizeRelativePath)
     this.exclude = [this.localeDir, ...exclude.map(normalizeRelativePath)]
-    this.format = getFormat(config.format, config.formatOptions)
+    this.format = format
     this.templateFile =
       templatePath ||
       getTemplatePath(this.format.getTemplateExtension(), this.path)

--- a/packages/cli/src/api/catalog/__snapshots__/getCatalogs.test.ts.snap
+++ b/packages/cli/src/api/catalog/__snapshots__/getCatalogs.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`getCatalogs should warn about missing {name} pattern in catalog path 1`] = `Catalog with path "./locales/{locale}" doesn't have a {name} pattern in it, but one of source directories uses it: "{name}". Either add {name} pattern to "./locales/{locale}" or remove it from all source directories.`;
+exports[`getCatalogs should warn about missing {name} pattern in catalog path 1`] = `[Error: Catalog with path "./locales/{locale}" doesn't have a {name} pattern in it, but one of source directories uses it: "{name}". Either add {name} pattern to "./locales/{locale}" or remove it from all source directories.]`;
 
-exports[`getCatalogs should warn if catalogPath is a directory 1`] = `Remove trailing slash from "./locales/{locale}/". Catalog path isn't a directory, but translation file without extension. For example, catalog path "./locales/{locale}" results in translation file "./locales/en.po".`;
+exports[`getCatalogs should warn if catalogPath is a directory 1`] = `[Error: Remove trailing slash from "./locales/{locale}/". Catalog path isn't a directory, but translation file without extension. For example, catalog path "./locales/{locale}" results in translation file "./locales/en.po".]`;
 
-exports[`getCatalogs should warn if catalogPath is a directory 2`] = `Remove trailing slash from "./locales/{locale}/". Catalog path isn't a directory, but translation file without extension. For example, catalog path "./locales/{locale}" results in translation file "./locales/cs.json".`;
+exports[`getCatalogs should warn if catalogPath is a directory 2`] = `[Error: Remove trailing slash from "./locales/{locale}/". Catalog path isn't a directory, but translation file without extension. For example, catalog path "./locales/{locale}" results in translation file "./locales/en.json".]`;

--- a/packages/cli/src/api/formats/index.ts
+++ b/packages/cli/src/api/formats/index.ts
@@ -2,23 +2,23 @@ import type { CatalogFormat, CatalogFormatter } from "@lingui/conf"
 import { CatalogFormatOptions } from "@lingui/conf"
 import { FormatterWrapper } from "./api/formatterWrapper"
 
-const formats: Record<
-  CatalogFormat,
-  () => (options: CatalogFormatOptions) => CatalogFormatter
-> = {
-  lingui: () => require("./lingui").default,
-  minimal: () => require("./minimal").default,
-  po: () => require("./po").default,
-  csv: () => require("./csv").default,
-  "po-gettext": () => require("./po-gettext").default,
-}
+type CatalogFormatterFactoryFn = (options: any) => CatalogFormatter
+
+const formats: Record<CatalogFormat, () => Promise<CatalogFormatterFactoryFn>> =
+  {
+    lingui: async () => (await import("./lingui")).default,
+    minimal: async () => (await import("./minimal")).default,
+    po: async () => (await import("./po")).default,
+    csv: async () => (await import("./csv")).default,
+    "po-gettext": async () => (await import("./po-gettext")).default,
+  }
 
 export { FormatterWrapper }
 
-export function getFormat(
+export async function getFormat(
   _format: CatalogFormat | CatalogFormatter,
   options: CatalogFormatOptions
-): FormatterWrapper {
+): Promise<FormatterWrapper> {
   if (typeof _format !== "string") {
     return new FormatterWrapper(_format)
   }
@@ -33,5 +33,5 @@ export function getFormat(
     )
   }
 
-  return new FormatterWrapper(format()(options))
+  return new FormatterWrapper((await format())(options))
 }

--- a/packages/cli/src/api/formats/po.ts
+++ b/packages/cli/src/api/formats/po.ts
@@ -48,13 +48,12 @@ export const serialize = (
     // so create a new array with the message's elements.
     item.extractedComments = [...(message.extractedComments || [])]
 
-    item.flags = (message.flags || []).reduce<Record<string, boolean>>(
-      (acc, flag) => {
-        acc[flag] = true
-        return acc
-      },
-      {}
-    )
+    item.flags = ((message.flags || []) as string[]).reduce<
+      Record<string, boolean>
+    >((acc, flag) => {
+      acc[flag] = true
+      return acc
+    }, {})
 
     const _isGeneratedId = isGeneratedId(id, message)
 

--- a/packages/cli/src/api/stats.test.ts
+++ b/packages/cli/src/api/stats.test.ts
@@ -1,14 +1,15 @@
 import { printStats } from "./stats"
 import { defaultMergeOptions, makeCatalog, makeNextMessage } from "../tests"
 import { makeConfig } from "@lingui/conf"
+import { AllCatalogsType } from "./types"
 
 describe("PrintStats", () => {
-  it("should print correct stats for a basic setup", () => {
+  it("should print correct stats for a basic setup", async () => {
     const config = makeConfig({
       locales: ["en", "cs"],
     })
 
-    const prevCatalogs = { en: null, cs: null }
+    const prevCatalogs: AllCatalogsType = { en: null, cs: null }
     const nextCatalog = {
       "custom.id": makeNextMessage({
         message: "Message with custom ID",
@@ -16,7 +17,7 @@ describe("PrintStats", () => {
       "Message with <0>auto-generated</0> ID": makeNextMessage(),
     }
 
-    const catalogs = makeCatalog({ sourceLocale: "en" }).merge(
+    const catalogs = (await makeCatalog({ sourceLocale: "en" })).merge(
       prevCatalogs,
       nextCatalog,
       defaultMergeOptions

--- a/packages/cli/src/extract-experimental/getExperimentalCatalogs.ts
+++ b/packages/cli/src/extract-experimental/getExperimentalCatalogs.ts
@@ -5,9 +5,16 @@ import { Catalog } from "../api/catalog"
 import { resolveTemplatePath } from "./resolveTemplatePath"
 import { getFormat } from "@lingui/cli/api"
 
-export function getExperimentalCatalogs(linguiConfig: LinguiConfigNormalized) {
+export async function getExperimentalCatalogs(
+  linguiConfig: LinguiConfigNormalized
+) {
   const config = linguiConfig.experimental.extractor
   const entryPoints = getEntryPoints(config.entries)
+
+  const format = await getFormat(
+    linguiConfig.format,
+    linguiConfig.formatOptions
+  )
 
   return entryPoints.map((entryPoint) => {
     const catalogPath = resolveCatalogPath(
@@ -18,7 +25,6 @@ export function getExperimentalCatalogs(linguiConfig: LinguiConfigNormalized) {
       ""
     )
 
-    const format = getFormat(linguiConfig.format, linguiConfig.formatOptions)
     const templatePath = resolveTemplatePath(
       entryPoint,
       config.output,
@@ -33,6 +39,7 @@ export function getExperimentalCatalogs(linguiConfig: LinguiConfigNormalized) {
         templatePath,
         include: [],
         exclude: [],
+        format,
       },
       linguiConfig
     )

--- a/packages/cli/src/lingui-extract-experimental.ts
+++ b/packages/cli/src/lingui-extract-experimental.ts
@@ -64,7 +64,10 @@ export default async function command(
 
   let commandSuccess = true
 
-  const format = getFormat(linguiConfig.format, linguiConfig.formatOptions)
+  const format = await getFormat(
+    linguiConfig.format,
+    linguiConfig.formatOptions
+  )
 
   for (const outFile of Object.keys(bundleResult.metafile.outputs)) {
     const messages = await extractFromFiles([outFile], linguiConfig)

--- a/packages/cli/src/lingui-extract-template.ts
+++ b/packages/cli/src/lingui-extract-template.ts
@@ -17,7 +17,7 @@ export default async function command(
   options: Partial<CliExtractTemplateOptions>
 ): Promise<boolean> {
   options.verbose && console.log("Extracting messages from source files…")
-  const catalogs = getCatalogs(config)
+  const catalogs = await getCatalogs(config)
   const catalogStats: { [path: string]: Number } = {}
 
   let commandSuccess = true

--- a/packages/cli/src/tests.ts
+++ b/packages/cli/src/tests.ts
@@ -9,7 +9,7 @@ import {
   MergeOptions,
 } from "./api/catalog"
 import { LinguiConfig, makeConfig } from "@lingui/conf"
-import { ExtractedMessageType, MessageType } from "./api"
+import { ExtractedMessageType, getFormat, MessageType } from "./api"
 
 export async function copyFixture(fixtureDir: string) {
   const tmpDir = await fs.promises.mkdtemp(
@@ -49,15 +49,18 @@ export const defaultMergeOptions: MergeOptions = {
 export const normalizeLineEndings = (str: string) =>
   str.replace(/\r?\n/g, "\r\n")
 
-export const makeCatalog = (config: Partial<LinguiConfig> = {}) => {
+export const makeCatalog = async (_config: Partial<LinguiConfig> = {}) => {
+  const config = makeConfig(_config, { skipValidation: true })
+
   return new Catalog(
     {
       name: "messages",
       path: "{locale}/messages",
       include: [],
       exclude: [],
+      format: await getFormat(config.format, config.formatOptions),
     },
-    makeConfig(config, { skipValidation: true })
+    config
   )
 }
 

--- a/packages/loader/src/webpackLoader.ts
+++ b/packages/loader/src/webpackLoader.ts
@@ -25,7 +25,7 @@ const loader: LoaderDefinitionFunction<LinguiLoaderOptions> = async function (
 
   const { locale, catalog } = getCatalogForFile(
     catalogRelativePath,
-    getCatalogs(config)
+    await getCatalogs(config)
   )
 
   const messages = await catalog.getTranslations(locale, {

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -35,7 +35,7 @@ export function lingui(linguiConfig: LinguiConfigOpts = {}): Plugin {
 
         const fileCatalog = getCatalogForFile(
           catalogRelativePath,
-          getCatalogs(config)
+          await getCatalogs(config)
         )
 
         if (!fileCatalog) {

--- a/packages/vite-plugin/tsconfig.json
+++ b/packages/vite-plugin/tsconfig.json
@@ -8,7 +8,7 @@
     "outDir": "./build",
     "esModuleInterop": true,
     "resolveJsonModule": true,
-    "skipLibCheck": true
+    "types": []
   },
   "include": [
     "src"


### PR DESCRIPTION
# Description

to be able to `import('format')` getFormat() function should be async

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
