### PR TITLE
fix(trans): align render callback and 'component' prop

### DIFF
--- a/packages/core/src/i18n.ts
+++ b/packages/core/src/i18n.ts
@@ -19,7 +19,7 @@ export type Formats = Record<
 export type Values = Record<string, unknown>
 
 /**
- * @deprecated Plurals automatically used from Intl.PluralRules you can safely remove this call. Introduced in v4
+ * @deprecated Plurals automatically used from Intl.PluralRules you can safely remove this call. Deprecated in v4
  */
 export type LocaleData = {
   plurals?: (
@@ -29,7 +29,7 @@ export type LocaleData = {
 }
 
 /**
- * @deprecated Plurals automatically used from Intl.PluralRules you can safely remove this call. Introduced in v4
+ * @deprecated Plurals automatically used from Intl.PluralRules you can safely remove this call. Deprecated in v4
  */
 export type AllLocaleData = Record<Locale, LocaleData>
 
@@ -65,7 +65,7 @@ type setupI18nProps = {
   locales?: Locales
   messages?: AllMessages
   /**
-   * @deprecated Plurals automatically used from Intl.PluralRules you can safely remove this call. Introduced in v4
+   * @deprecated Plurals automatically used from Intl.PluralRules you can safely remove this call. Deprecated in v4
    */
   localeData?: AllLocaleData
   missing?: MissingHandler
@@ -110,7 +110,7 @@ export class I18n extends EventEmitter<Events> {
   }
 
   /**
-   * @deprecated this has no effect. Please remove this from the code. Introduced in v4
+   * @deprecated this has no effect. Please remove this from the code. Deprecated in v4
    */
   get localeData(): LocaleData {
     return this._localeData[this._locale] ?? {}
@@ -125,15 +125,15 @@ export class I18n extends EventEmitter<Events> {
   }
 
   /**
-   * @deprecated Plurals automatically used from Intl.PluralRules you can safely remove this call. Introduced in v4
+   * @deprecated Plurals automatically used from Intl.PluralRules you can safely remove this call. Deprecated in v4
    */
   public loadLocaleData(allLocaleData: AllLocaleData): void
   /**
-   * @deprecated Plurals automatically used from Intl.PluralRules you can safely remove this call. Introduced in v4
+   * @deprecated Plurals automatically used from Intl.PluralRules you can safely remove this call. Deprecated in v4
    */
   public loadLocaleData(locale: Locale, localeData: LocaleData): void
   /**
-   * @deprecated Plurals automatically used from Intl.PluralRules you can safely remove this call. Introduced in v4
+   * @deprecated Plurals automatically used from Intl.PluralRules you can safely remove this call. Deprecated in v4
    */
   loadLocaleData(localeOrAllData, localeData?) {
     if (localeData != null) {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -61,6 +61,7 @@
     "@lingui/core": "4.0.0-next.4"
   },
   "devDependencies": {
+    "@lingui/jest-mocks": "*",
     "@testing-library/react": "^11.0.4",
     "unbuild": "^1.1.2"
   }

--- a/packages/react/src/Trans.test.tsx
+++ b/packages/react/src/Trans.test.tsx
@@ -2,6 +2,7 @@ import * as React from "react"
 import { render } from "@testing-library/react"
 import { Trans, I18nProvider, TransRenderProps } from "@lingui/react"
 import { setupI18n } from "@lingui/core"
+import { mockConsole } from "@lingui/jest-mocks"
 
 describe("Trans component", () => {
   /*
@@ -59,21 +60,21 @@ describe("Trans component", () => {
       <span>{children}</span>
     )
 
-    const consoleErrorSpy = jest.spyOn(console, "error")
-
-    renderWithI18n(
-      // @ts-expect-error TS won't allow passing both `render` and `component` props
-      <Trans
-        render={RenderChildrenInSpan}
-        component={RenderChildrenInSpan}
-        id="Some text"
-      />
-    )
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      expect.stringContaining(
-        "You can't use both `component` and `render` prop at the same time."
+    mockConsole((console) => {
+      renderWithI18n(
+        // @ts-expect-error TS won't allow passing both `render` and `component` props
+        <Trans
+          render={RenderChildrenInSpan}
+          component={RenderChildrenInSpan}
+          id="Some text"
+        />
       )
-    )
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "You can't use both `component` and `render` prop at the same time."
+        )
+      )
+    })
   })
 
   it("should render default string", () => {

--- a/packages/react/src/Trans.test.tsx
+++ b/packages/react/src/Trans.test.tsx
@@ -59,8 +59,7 @@ describe("Trans component", () => {
       <span>{children}</span>
     )
 
-    const originalConsole = console.error
-    console.error = jest.fn()
+    const consoleErrorSpy = jest.spyOn(console, "error")
 
     renderWithI18n(
       // @ts-expect-error TS won't allow passing both `render` and `component` props
@@ -70,12 +69,11 @@ describe("Trans component", () => {
         id="Some text"
       />
     )
-    expect(console.error).toHaveBeenCalledWith(
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
       expect.stringContaining(
         "You can't use both `component` and `render` prop at the same time."
       )
     )
-    console.error = originalConsole
   })
 
   it("should render default string", () => {

--- a/packages/react/src/Trans.test.tsx
+++ b/packages/react/src/Trans.test.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import { render } from "@testing-library/react"
-import { Trans, I18nProvider } from "@lingui/react"
+import { Trans, I18nProvider, TransRenderProps } from "@lingui/react"
 import { setupI18n } from "@lingui/core"
 
 describe("Trans component", function () {
@@ -54,7 +54,7 @@ describe("Trans component", function () {
     console.error = originalConsole
   })
 
-  it("should throw a console.error if using twice props", function () {
+  it("should throw a console.error if using `render` and `component` props at the same time", function () {
     const originalConsole = console.error
     console.error = jest.fn()
 
@@ -184,7 +184,7 @@ describe("Trans component", function () {
       expect(element).toEqual(`<h1 id="Headline">Headline</h1>`)
     })
 
-    it("should render function", function () {
+    it("supports render callback function", function () {
       const spy = jest.fn()
       text(
         <Trans
@@ -201,14 +201,15 @@ describe("Trans component", function () {
         id: "ID",
         message: "Default",
         translation: "Translation",
+        children: "Translation",
         isTranslated: true,
       })
     })
 
     it("should take defaultComponent prop with a custom component", function () {
-      const ComponentFC: React.FunctionComponent = (props: {
-        children?: React.ReactNode
-      }) => {
+      const ComponentFC: React.FunctionComponent<TransRenderProps> = (
+        props
+      ) => {
         return <div>{props.children}</div>
       }
       const span = render(
@@ -220,9 +221,9 @@ describe("Trans component", function () {
     })
 
     it("should ignore defaultComponent when render is null", function () {
-      const ComponentFC: React.FunctionComponent = (props: {
-        children?: React.ReactNode
-      }) => {
+      const ComponentFC: React.FunctionComponent<TransRenderProps> = (
+        props
+      ) => {
         return <div>{props.children}</div>
       }
       const translation = render(
@@ -234,9 +235,9 @@ describe("Trans component", function () {
     })
 
     it("should ignore defaultComponent when component is null", function () {
-      const ComponentFC: React.FunctionComponent = (props: {
-        children?: React.ReactNode
-      }) => {
+      const ComponentFC: React.FunctionComponent<TransRenderProps> = (
+        props
+      ) => {
         return <div>{props.children}</div>
       }
       const translation = render(
@@ -250,7 +251,7 @@ describe("Trans component", function () {
 
   describe("component prop rendering", function () {
     it("should render class component as simple prop", function () {
-      class ClassComponent extends React.Component {
+      class ClassComponent extends React.Component<TransRenderProps> {
         render() {
           return <div>Headline</div>
         }
@@ -259,27 +260,32 @@ describe("Trans component", function () {
       expect(element).toEqual("<div>Headline</div>")
     })
 
-    it("should render functional component as simple prop", function () {
-      const ComponentFC: React.FunctionComponent = (props: {
-        id: any
-        children?: React.ReactNode
-      }) => {
+    it("should render function component as simple prop", function () {
+      const propsSpy = jest.fn()
+      const ComponentFC: React.FunctionComponent<TransRenderProps> = (
+        props
+      ) => {
+        propsSpy(props)
         const [state] = React.useState("value")
         return <div id={props.id}>{state}</div>
       }
+
       const element = html(<Trans component={ComponentFC} id="Headline" />)
-      expect(element).toEqual(`<div>value</div>`)
+      expect(element).toEqual(`<div id="Headline">value</div>`)
+      expect(propsSpy).toHaveBeenCalledWith({
+        id: "Headline",
+        isTranslated: false,
+        message: undefined,
+        translation: "Headline",
+        children: "Headline",
+      })
     })
   })
 
-  describe("I18nProvider defaulComponent accepts render-like props", function () {
-    const DefaultComponent: React.FunctionComponent = (props: {
-      children?: React.ReactNode
-      id: string
-      translation: string
-      message: string
-      isTranslated: boolean
-    }) => (
+  describe("I18nProvider defaultComponent accepts render-like props", function () {
+    const DefaultComponent: React.FunctionComponent<TransRenderProps> = (
+      props
+    ) => (
       <>
         <div data-testid="children">{props.children}</div>
         {props.id && <div data-testid="id">{props.id}</div>}

--- a/packages/react/src/Trans.test.tsx
+++ b/packages/react/src/Trans.test.tsx
@@ -54,13 +54,27 @@ describe("Trans component", function () {
     console.error = originalConsole
   })
 
-  it("should throw a console.error if using `render` and `component` props at the same time", function () {
+  it("should log a console.error if using `render` and `component` props at the same time", function () {
+    const RenderChildrenInSpan = ({ children }: TransRenderProps) => (
+      <span>{children}</span>
+    )
+
     const originalConsole = console.error
     console.error = jest.fn()
 
-    // @ts-expect-error testing the error
-    renderWithI18n(<Trans render="div" component="span" id="Some text" />)
-    expect(console.error).toHaveBeenCalled()
+    renderWithI18n(
+      // @ts-expect-error TS won't allow passing both `render` and `component` props
+      <Trans
+        render={RenderChildrenInSpan}
+        component={RenderChildrenInSpan}
+        id="Some text"
+      />
+    )
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "You can't use both `component` and `render` prop at the same time."
+      )
+    )
     console.error = originalConsole
   })
 

--- a/packages/react/src/Trans.test.tsx
+++ b/packages/react/src/Trans.test.tsx
@@ -3,7 +3,7 @@ import { render } from "@testing-library/react"
 import { Trans, I18nProvider, TransRenderProps } from "@lingui/react"
 import { setupI18n } from "@lingui/core"
 
-describe("Trans component", function () {
+describe("Trans component", () => {
   /*
    * Setup context, define helpers
    */
@@ -31,7 +31,7 @@ describe("Trans component", function () {
    * Tests
    */
 
-  it("should throw error without i18n context", function () {
+  it("should throw error without i18n context", () => {
     const originalConsole = console.error
     console.error = jest.fn()
 
@@ -40,7 +40,7 @@ describe("Trans component", function () {
     console.error = originalConsole
   })
 
-  it("should throw a console.error about deprecated usage of string built-in", function () {
+  it("should throw a console.error about deprecated usage of string built-in", () => {
     const originalConsole = console.error
     console.error = jest.fn()
 
@@ -54,7 +54,7 @@ describe("Trans component", function () {
     console.error = originalConsole
   })
 
-  it("should log a console.error if using `render` and `component` props at the same time", function () {
+  it("should log a console.error if using `render` and `component` props at the same time", () => {
     const RenderChildrenInSpan = ({ children }: TransRenderProps) => (
       <span>{children}</span>
     )
@@ -78,7 +78,7 @@ describe("Trans component", function () {
     console.error = originalConsole
   })
 
-  it("should render default string", function () {
+  it("should render default string", () => {
     expect(text(<Trans id="unknown" />)).toEqual("unknown")
 
     expect(text(<Trans id="unknown" message="Not translated yet" />)).toEqual(
@@ -96,7 +96,7 @@ describe("Trans component", function () {
     ).toEqual("Not translated yet, Dave")
   })
 
-  it("should render translation", function () {
+  it("should render translation", () => {
     const translation = text(
       <Trans id="All human beings are born free and equal in dignity and rights." />
     )
@@ -106,7 +106,7 @@ describe("Trans component", function () {
     )
   })
 
-  it("should render translation from variable", function () {
+  it("should render translation from variable", () => {
     const msg =
       "All human beings are born free and equal in dignity and rights."
     const translation = text(<Trans id={msg} />)
@@ -115,14 +115,14 @@ describe("Trans component", function () {
     )
   })
 
-  it("should render component in variables", function () {
+  it("should render component in variables", () => {
     const translation = html(
       <Trans id="Hello {name}" values={{ name: <strong>John</strong> }} />
     )
     expect(translation).toEqual("Hello <strong>John</strong>")
   })
 
-  it("should render named component in components", function () {
+  it("should render named component in components", () => {
     const translation = html(
       <Trans
         id="Read <named>the docs</named>"
@@ -132,7 +132,7 @@ describe("Trans component", function () {
     expect(translation).toEqual(`Read <a href="/docs">the docs</a>`)
   })
 
-  it("should render nested named components in components", function () {
+  it("should render nested named components in components", () => {
     const translation = html(
       <Trans
         id="Read <link>the <strong>docs</strong></link>"
@@ -144,14 +144,14 @@ describe("Trans component", function () {
     )
   })
 
-  it("should render non-named component in components", function () {
+  it("should render non-named component in components", () => {
     const translation = html(
       <Trans id="Read <0>the docs</0>" components={{ 0: <a href="/docs" /> }} />
     )
     expect(translation).toEqual(`Read <a href="/docs">the docs</a>`)
   })
 
-  it("should render translation inside custom component", function () {
+  it("should render translation inside custom component", () => {
     const Component = (props) => <p className="lead">{props.children}</p>
     const html1 = html(<Trans component={Component} id="Original" />)
     const html2 = html(
@@ -165,7 +165,7 @@ describe("Trans component", function () {
     expect(html2).toEqual('<p class="lead">Původní</p>')
   })
 
-  it("should render custom format", function () {
+  it("should render custom format", () => {
     const translation = text(
       <Trans
         id="msg.currency"
@@ -182,13 +182,13 @@ describe("Trans component", function () {
     expect(translation).toEqual("1,00 €")
   })
 
-  describe("rendering", function () {
-    it("should render a text node with no wrapper element", function () {
+  describe("rendering", () => {
+    it("should render a text node with no wrapper element", () => {
       const txt = html(<Trans id="Some text" />)
       expect(txt).toEqual("Some text")
     })
 
-    it("should render custom element", function () {
+    it("should render custom element", () => {
       const element = html(
         <Trans
           render={({ id, translation }) => <h1 id={id}>{translation}</h1>}
@@ -198,7 +198,7 @@ describe("Trans component", function () {
       expect(element).toEqual(`<h1 id="Headline">Headline</h1>`)
     })
 
-    it("supports render callback function", function () {
+    it("supports render callback function", () => {
       const spy = jest.fn()
       text(
         <Trans
@@ -220,7 +220,7 @@ describe("Trans component", function () {
       })
     })
 
-    it("should take defaultComponent prop with a custom component", function () {
+    it("should take defaultComponent prop with a custom component", () => {
       const ComponentFC: React.FunctionComponent<TransRenderProps> = (
         props
       ) => {
@@ -234,7 +234,7 @@ describe("Trans component", function () {
       expect(span).toEqual(`<div>Some text</div>`)
     })
 
-    it("should ignore defaultComponent when render is null", function () {
+    it("should ignore defaultComponent when render is null", () => {
       const ComponentFC: React.FunctionComponent<TransRenderProps> = (
         props
       ) => {
@@ -248,7 +248,7 @@ describe("Trans component", function () {
       expect(translation).toEqual("Some text")
     })
 
-    it("should ignore defaultComponent when component is null", function () {
+    it("should ignore defaultComponent when component is null", () => {
       const ComponentFC: React.FunctionComponent<TransRenderProps> = (
         props
       ) => {
@@ -263,8 +263,8 @@ describe("Trans component", function () {
     })
   })
 
-  describe("component prop rendering", function () {
-    it("should render class component as simple prop", function () {
+  describe("component prop rendering", () => {
+    it("should render class component as simple prop", () => {
       class ClassComponent extends React.Component<TransRenderProps> {
         render() {
           return <div>Headline</div>
@@ -274,7 +274,7 @@ describe("Trans component", function () {
       expect(element).toEqual("<div>Headline</div>")
     })
 
-    it("should render function component as simple prop", function () {
+    it("should render function component as simple prop", () => {
       const propsSpy = jest.fn()
       const ComponentFC: React.FunctionComponent<TransRenderProps> = (
         props
@@ -296,7 +296,7 @@ describe("Trans component", function () {
     })
   })
 
-  describe("I18nProvider defaultComponent accepts render-like props", function () {
+  describe("I18nProvider defaultComponent accepts render-like props", () => {
     const DefaultComponent: React.FunctionComponent<TransRenderProps> = (
       props
     ) => (
@@ -312,7 +312,7 @@ describe("Trans component", function () {
       </>
     )
 
-    it("should render defaultComponent with Trans props", function () {
+    it("should render defaultComponent with Trans props", () => {
       const markup = render(
         <I18nProvider i18n={i18n} defaultComponent={DefaultComponent}>
           <Trans id="ID" message="Some message" />
@@ -327,7 +327,7 @@ describe("Trans component", function () {
       expect(markup.queryByTestId("is-translated").innerHTML).toEqual("true")
     })
 
-    it("should pass isTranslated: false if no translation", function () {
+    it("should pass isTranslated: false if no translation", () => {
       const markup = render(
         <I18nProvider i18n={i18n} defaultComponent={DefaultComponent}>
           <Trans id="NO_ID" message="Some message" />

--- a/packages/react/src/Trans.tsx
+++ b/packages/react/src/Trans.tsx
@@ -10,6 +10,9 @@ export type TransRenderProps = {
   message?: string | null
   isTranslated: boolean
 }
+type MaximumOneOf<T, K extends keyof T = keyof T> = K extends keyof T
+  ? { [P in K]?: T[K] } & Partial<Record<Exclude<keyof T, K>, never>>
+  : never
 
 export type TransProps = {
   id: string
@@ -18,9 +21,10 @@ export type TransProps = {
   components?: { [key: string]: React.ElementType | any }
   formats?: Record<string, unknown>
   children?: React.ReactNode
+} & MaximumOneOf<{
   component?: React.ComponentType<TransRenderProps>
   render?: (props: TransRenderProps) => React.ReactElement<any, any> | null
-}
+}>
 
 export function Trans(props: TransProps): React.ReactElement<any, any> | null {
   const { i18n, defaultComponent } = useLingui()

--- a/yarn.lock
+++ b/yarn.lock
@@ -2848,6 +2848,7 @@ __metadata:
   dependencies:
     "@babel/runtime": ^7.20.13
     "@lingui/core": 4.0.0-next.4
+    "@lingui/jest-mocks": "*"
     "@testing-library/react": ^11.0.4
     unbuild: ^1.1.2
   peerDependencies:


### PR DESCRIPTION
# Description

The `Trans` component accepts `component` and `render` props that have pretty much the same purpose.

However, when you use the `render` callback, the callback receives 

```
export type TransRenderProps = {
   id: string
   translation: React.ReactNode
   message?: string | null
   isTranslated: boolean
 }
```

and when you use `component`, it only receives `{ children: React.ReactNode }` (where `children = translation`).

To me, it makes sense that these two approaches are unified, and you receive the same information when you use `render` and `component` props.

This PR does just that, without introducing another TS type, which means that the `translation` and `children` are duplicated in the `i18nprops: TransRenderProps` object. I don't think it's a huge deal but we could also introduce separate types for `render` and `component`.

I also removed a few `as` casts to improve type safety

Let me know what you think and I can update the docs as well, as they are not very detailed in describing these props.


## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
