### PR TITLE
refactor(formatter-po): ability to disable lingui-id, make it false by default

### DIFF
--- a/packages/cli/src/api/__snapshots__/catalog.test.ts.snap
+++ b/packages/cli/src/api/__snapshots__/catalog.test.ts.snap
@@ -451,9 +451,7 @@ exports[`Catalog make should merge with existing catalogs 2`] = `
     mY42CM: {
       comments: [],
       context: null,
-      extractedComments: [
-        js-lingui-id: mY42CM,
-      ],
+      extractedComments: [],
       flags: [],
       message: Hello World,
       obsolete: true,
@@ -541,9 +539,7 @@ exports[`Catalog make should merge with existing catalogs 2`] = `
     mY42CM: {
       comments: [],
       context: null,
-      extractedComments: [
-        js-lingui-id: mY42CM,
-      ],
+      extractedComments: [],
       flags: [],
       message: Hello World,
       obsolete: true,

--- a/packages/cli/test/extract-po-format/expected/en.po
+++ b/packages/cli/test/extract-po-format/expected/en.po
@@ -8,29 +8,24 @@ msgstr ""
 "Language: en\n"
 
 #. this is a comment
-#. js-lingui-id: f9Atdk
 #: fixtures/file-b.tsx:6
 msgid "Hello this is JSX Translation"
 msgstr "Hello this is JSX Translation"
 
-#. js-lingui-id: 6qYmGe
 #: fixtures/file-b.tsx:11
 msgctxt "my context"
 msgid "Hello this is JSX Translation"
 msgstr "Hello this is JSX Translation"
 
-#. js-lingui-id: 1nGWAC
 #: fixtures/file-a.ts:4
 msgid "Hello world"
 msgstr "Hello world"
 
-#. js-lingui-id: 2Ps/YQ
 #: fixtures/file-a.ts:6
 msgctxt "custom context"
 msgid "Hello world"
 msgstr "Hello world"
 
-#. js-lingui-id: BcXPt3
 #: fixtures/file-a.ts:16
 msgid "Message in descriptor"
 msgstr "Message in descriptor"

--- a/packages/cli/test/extract-po-format/expected/pl.po
+++ b/packages/cli/test/extract-po-format/expected/pl.po
@@ -8,29 +8,24 @@ msgstr ""
 "Language: pl\n"
 
 #. this is a comment
-#. js-lingui-id: f9Atdk
 #: fixtures/file-b.tsx:6
 msgid "Hello this is JSX Translation"
 msgstr ""
 
-#. js-lingui-id: 6qYmGe
 #: fixtures/file-b.tsx:11
 msgctxt "my context"
 msgid "Hello this is JSX Translation"
 msgstr ""
 
-#. js-lingui-id: 1nGWAC
 #: fixtures/file-a.ts:4
 msgid "Hello world"
 msgstr ""
 
-#. js-lingui-id: 2Ps/YQ
 #: fixtures/file-a.ts:6
 msgctxt "custom context"
 msgid "Hello world"
 msgstr ""
 
-#. js-lingui-id: BcXPt3
 #: fixtures/file-a.ts:16
 msgid "Message in descriptor"
 msgstr ""

--- a/packages/cli/test/extract-template-po-format/expected/messages.pot
+++ b/packages/cli/test/extract-template-po-format/expected/messages.pot
@@ -7,29 +7,24 @@ msgstr ""
 "X-Generator: @lingui/cli\n"
 
 #. this is a comment
-#. js-lingui-id: f9Atdk
 #: fixtures/file-b.tsx:6
 msgid "Hello this is JSX Translation"
 msgstr ""
 
-#. js-lingui-id: 6qYmGe
 #: fixtures/file-b.tsx:11
 msgctxt "my context"
 msgid "Hello this is JSX Translation"
 msgstr ""
 
-#. js-lingui-id: 1nGWAC
 #: fixtures/file-a.ts:4
 msgid "Hello world"
 msgstr ""
 
-#. js-lingui-id: 2Ps/YQ
 #: fixtures/file-a.ts:6
 msgctxt "custom context"
 msgid "Hello world"
 msgstr ""
 
-#. js-lingui-id: BcXPt3
 #: fixtures/file-a.ts:16
 msgid "Message in descriptor"
 msgstr ""

--- a/packages/cli/test/extractor-experimental-clean/expected/about.page.en.po
+++ b/packages/cli/test/extractor-experimental-clean/expected/about.page.en.po
@@ -13,12 +13,10 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#. js-lingui-id: u5PTM8
 #: fixtures/pages/about.page.ts:4
 msgid "about page message"
 msgstr "about page message"
 
-#. js-lingui-id: LGGfGX
 #: fixtures/components/header.ts:3
 msgid "header message"
 msgstr "header message"

--- a/packages/cli/test/extractor-experimental-clean/expected/about.page.pl.po
+++ b/packages/cli/test/extractor-experimental-clean/expected/about.page.pl.po
@@ -13,12 +13,10 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#. js-lingui-id: u5PTM8
 #: fixtures/pages/about.page.ts:4
 msgid "about page message"
 msgstr ""
 
-#. js-lingui-id: LGGfGX
 #: fixtures/components/header.ts:3
 msgid "header message"
 msgstr "translation: header message"

--- a/packages/cli/test/extractor-experimental-clean/expected/index.page.en.po
+++ b/packages/cli/test/extractor-experimental-clean/expected/index.page.en.po
@@ -13,7 +13,6 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#. js-lingui-id: D+XV65
 #: fixtures/pages/index.page.ts:3
 msgid "index page message"
 msgstr "index page message"

--- a/packages/cli/test/extractor-experimental-clean/expected/index.page.pl.po
+++ b/packages/cli/test/extractor-experimental-clean/expected/index.page.pl.po
@@ -13,7 +13,6 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#. js-lingui-id: D+XV65
 #: fixtures/pages/index.page.ts:3
 msgid "index page message"
 msgstr ""

--- a/packages/cli/test/extractor-experimental-template/expected/about.page.messages.pot
+++ b/packages/cli/test/extractor-experimental-template/expected/about.page.messages.pot
@@ -6,22 +6,18 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 
-#. js-lingui-id: u5PTM8
 #: fixtures/pages/about.page.tsx:15
 msgid "about page message"
 msgstr ""
 
-#. js-lingui-id: 1TzdHc
 #: fixtures/components/aliased-module.ts:3
 msgid "aliased module message"
 msgstr ""
 
-#. js-lingui-id: LGGfGX
 #: fixtures/components/header.ts:3
 msgid "header message"
 msgstr ""
 
-#. js-lingui-id: 8Pj7KC
 #: fixtures/pages/about.page.tsx:18
 msgid "JSX: about page message"
 msgstr ""

--- a/packages/cli/test/extractor-experimental-template/expected/index.page.messages.pot
+++ b/packages/cli/test/extractor-experimental-template/expected/index.page.messages.pot
@@ -6,7 +6,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 
-#. js-lingui-id: D+XV65
 #: fixtures/pages/index.page.ts:3
 msgid "index page message"
 msgstr ""

--- a/packages/cli/test/extractor-experimental/expected/about.page.en.po
+++ b/packages/cli/test/extractor-experimental/expected/about.page.en.po
@@ -13,12 +13,10 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#. js-lingui-id: u5PTM8
 #: fixtures/pages/about.page.ts:4
 msgid "about page message"
 msgstr "about page message"
 
-#. js-lingui-id: LGGfGX
 #: fixtures/components/header.ts:3
 msgid "header message"
 msgstr "header message"

--- a/packages/cli/test/extractor-experimental/expected/about.page.pl.po
+++ b/packages/cli/test/extractor-experimental/expected/about.page.pl.po
@@ -13,16 +13,13 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#. js-lingui-id: u5PTM8
 #: fixtures/pages/about.page.ts:4
 msgid "about page message"
 msgstr ""
 
-#. js-lingui-id: LGGfGX
 #: fixtures/components/header.ts:3
 msgid "header message"
 msgstr "translation: header message"
 
-#. js-lingui-id: nPi9F1
 #~ msgid "this should be marked as obsolete"
 #~ msgstr ""

--- a/packages/cli/test/extractor-experimental/expected/index.page.en.po
+++ b/packages/cli/test/extractor-experimental/expected/index.page.en.po
@@ -13,7 +13,6 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#. js-lingui-id: D+XV65
 #: fixtures/pages/index.page.ts:3
 msgid "index page message"
 msgstr "index page message"

--- a/packages/cli/test/extractor-experimental/expected/index.page.pl.po
+++ b/packages/cli/test/extractor-experimental/expected/index.page.pl.po
@@ -13,7 +13,6 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#. js-lingui-id: D+XV65
 #: fixtures/pages/index.page.ts:3
 msgid "index page message"
 msgstr ""

--- a/packages/format-po-gettext/src/__snapshots__/po-gettext.test.ts.snap
+++ b/packages/format-po-gettext/src/__snapshots__/po-gettext.test.ts.snap
@@ -80,7 +80,6 @@ msgid_plural "message_with_id_plural"
 msgstr[0] "Singular case with id"
 msgstr[1] "Case number {someCount} with id"
 
-#. js-lingui-id: WGI12K
 #. js-lingui:icu=%7BanotherCount%2C+plural%2C+one+%7BSingular+case%7D+other+%7BCase+number+%7BanotherCount%7D%7D%7D&pluralize_on=anotherCount
 msgid "Singular case"
 msgid_plural "Case number {anotherCount}"
@@ -94,7 +93,6 @@ msgid_plural "message_with_id_but_without_translation_plural"
 msgstr[0] ""
 msgstr[1] ""
 
-#. js-lingui-id: xZCXAV
 #. js-lingui:icu=%7Bcount%2C+plural%2C+one+%7BSingular+automatic+id+no+translation%7D+other+%7BPlural+%7Bcount%7D+automatic+id+no+translation%7D%7D&pluralize_on=count
 msgid "Singular automatic id no translation"
 msgid_plural "Plural {count} automatic id no translation"

--- a/packages/format-po/README.md
+++ b/packages/format-po/README.md
@@ -54,6 +54,13 @@ export type PoFormatterOptions = {
    * @default true
    */
   lineNumbers?: boolean
+  
+  /**
+   * Print `js-lingui-id: Xs4as` statement in extracted comments section
+   *
+   * @default false
+   */
+  printLinguiId?: boolean
 }
 ```
 

--- a/packages/format-po/src/__snapshots__/po.test.ts.snap
+++ b/packages/format-po/src/__snapshots__/po.test.ts.snap
@@ -36,6 +36,40 @@ exports[`pofile format should correct badly used comments 1`] = `
 }
 `;
 
+exports[`pofile format should not add lingui id more than one time 1`] = `
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2018-08-27 10:00+0000\\n"
+"MIME-Version: 1.0\\n"
+"Content-Type: text/plain; charset=utf-8\\n"
+"Content-Transfer-Encoding: 8bit\\n"
+"X-Generator: @lingui/cli\\n"
+"Language: en\\n"
+
+#. js-lingui-id: Dgzql1
+msgctxt "my context"
+msgid "with generated id"
+msgstr ""
+
+`;
+
+exports[`pofile format should print lingui id if printLinguiId = true 1`] = `
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2018-08-27 10:00+0000\\n"
+"MIME-Version: 1.0\\n"
+"Content-Type: text/plain; charset=utf-8\\n"
+"Content-Transfer-Encoding: 8bit\\n"
+"X-Generator: @lingui/cli\\n"
+"Language: en\\n"
+
+#. js-lingui-id: Dgzql1
+msgctxt "my context"
+msgid "with generated id"
+msgstr ""
+
+`;
+
 exports[`pofile format should read catalog in pofile format 1`] = `
 {
   obsolete: {
@@ -186,7 +220,6 @@ msgctxt "my context"
 msgid "withContext"
 msgstr "Message with context"
 
-#. js-lingui-id: Dgzql1
 msgctxt "my context"
 msgid "with generated id"
 msgstr ""

--- a/packages/format-po/src/po.test.ts
+++ b/packages/format-po/src/po.test.ts
@@ -5,14 +5,10 @@ import { formatter as createFormatter } from "./po"
 import { CatalogType } from "@lingui/conf"
 
 describe("pofile format", () => {
-  afterEach(() => {
-    jest.useRealTimers()
-  })
+  jest.useFakeTimers().setSystemTime(new Date("2018-08-27T10:00Z").getTime())
 
   it("should write catalog in pofile format", () => {
     const format = createFormatter({ origins: true })
-
-    jest.useFakeTimers().setSystemTime(new Date("2018-08-27T10:00Z").getTime())
 
     const catalog: CatalogType = {
       static: {
@@ -108,6 +104,47 @@ describe("pofile format", () => {
     expect(actual).toMatchObject(catalog)
   })
 
+  it("should print lingui id if printLinguiId = true", () => {
+    const format = createFormatter({ origins: true, printLinguiId: true })
+
+    const catalog: CatalogType = {
+      // with generated id
+      Dgzql1: {
+        message: "with generated id",
+        translation: "",
+        context: "my context",
+      },
+    }
+
+    const serialized = format.serialize(catalog, {
+      locale: "en",
+      existing: null,
+    })
+
+    expect(serialized).toMatchSnapshot()
+  })
+
+  it("should not add lingui id more than one time", () => {
+    const format = createFormatter({ origins: true, printLinguiId: true })
+
+    const catalog: CatalogType = {
+      // with generated id
+      Dgzql1: {
+        message: "with generated id",
+        translation: "",
+        context: "my context",
+        extractedComments: ["js-lingui-id: Dgzql1"],
+      },
+    }
+
+    const serialized = format.serialize(catalog, {
+      locale: "en",
+      existing: null,
+    })
+
+    expect(serialized).toMatchSnapshot()
+  })
+
   it("should correct badly used comments", () => {
     const format = createFormatter()
 
@@ -158,7 +195,6 @@ describe("pofile format", () => {
 
   it("should not include lineNumbers if lineNumbers option is false", () => {
     const format = createFormatter({ origins: true, lineNumbers: false })
-    jest.useFakeTimers().setSystemTime(new Date("2018-08-27T10:00Z").getTime())
 
     const catalog: CatalogType = {
       static: {
@@ -211,7 +247,6 @@ describe("pofile format", () => {
 
   it("should not include lineNumbers if lineNumbers option is false and already excluded", () => {
     const format = createFormatter({ origins: true, lineNumbers: false })
-    jest.useFakeTimers().setSystemTime(new Date("2018-08-27T10:00Z").getTime())
 
     const catalog: CatalogType = {
       static: {

--- a/packages/format-po/src/po.ts
+++ b/packages/format-po/src/po.ts
@@ -28,6 +28,13 @@ export type PoFormatterOptions = {
    * @default true
    */
   lineNumbers?: boolean
+
+  /**
+   * Print `js-lingui-id: Xs4as` statement in extracted comments section
+   *
+   * @default false
+   */
+  printLinguiId?: boolean
 }
 
 function isGeneratedId(id: string, message: MessageType): boolean {
@@ -68,8 +75,11 @@ const serialize = (catalog: CatalogType, options: PoFormatterOptions) => {
 
     if (_isGeneratedId) {
       item.msgid = message.message
-      if (!item.extractedComments.find((c) => c.includes("js-lingui-id"))) {
-        item.extractedComments.push(`js-lingui-id: ${id}`)
+
+      if (options.printLinguiId) {
+        if (!item.extractedComments.find((c) => c.includes("js-lingui-id"))) {
+          item.extractedComments.push(`js-lingui-id: ${id}`)
+        }
       }
     } else {
       item.flags[EXPLICIT_ID_FLAG] = true


### PR DESCRIPTION
# Description

Newly introduced `js-lingui-id` creates a lot of noise in po files and may cause merge conflicts. This PR makes it optional and disabled by default. All tests snapshots got updated.

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
