### PR TITLE
fix: fix type mismatch between formatter and conf/CatalogFormatter

### DIFF
--- a/packages/conf/__typetests__/index.test-d.tsx
+++ b/packages/conf/__typetests__/index.test-d.tsx
@@ -5,6 +5,7 @@ import {
   LinguiConfig,
 } from "@lingui/conf"
 import { expectAssignable } from "tsd"
+import { formatter } from "@lingui/format-po"
 
 // only required props
 expectAssignable<LinguiConfig>({
@@ -59,6 +60,12 @@ expectAssignable<LinguiConfig>({
       ) => {},
     },
   ],
+})
+
+// formatter
+expectAssignable<LinguiConfig>({
+  locales: ["en", "pl"],
+  format: formatter({ printLinguiId: true }),
 })
 
 // runtimeConfigModule

--- a/packages/conf/package.json
+++ b/packages/conf/package.json
@@ -38,6 +38,7 @@
     "/dist"
   ],
   "devDependencies": {
+    "@lingui/format-po": "4.0.0-next.3",
     "@lingui/jest-mocks": "*",
     "tsd": "^0.26.1",
     "unbuild": "^1.1.2"

--- a/packages/conf/src/types.ts
+++ b/packages/conf/src/types.ts
@@ -62,12 +62,12 @@ export type CatalogFormatter = {
   templateExtension?: string
   parse(
     content: string,
-    ctx: { locale: string | null; sourceLocale: string; filename: string }
+    ctx: { locale: string; sourceLocale: string; filename: string }
   ): Promise<CatalogType> | CatalogType
   serialize(
     catalog: CatalogType,
     ctx: {
-      locale: string | null
+      locale: string
       sourceLocale: string
       filename: string
       existing: string | null

--- a/packages/format-po/src/po.ts
+++ b/packages/format-po/src/po.ts
@@ -149,7 +149,7 @@ export function formatter(options: PoFormatterOptions = {}) {
 
     serialize(
       catalog: CatalogType,
-      ctx: { locale: string; existing: string }
+      ctx: { locale: string; existing: string | null }
     ): string {
       let po: PO
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2686,6 +2686,7 @@ __metadata:
   resolution: "@lingui/conf@workspace:packages/conf"
   dependencies:
     "@babel/runtime": ^7.20.13
+    "@lingui/format-po": 4.0.0-next.3
     "@lingui/jest-mocks": "*"
     chalk: ^4.1.0
     cosmiconfig: ^8.0.0


### PR DESCRIPTION
# Description

fix type mismatch: 

![image](https://user-images.githubusercontent.com/121891361/226775737-49037303-b22b-46ca-ae32-a5391eb7c4ca.png)

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
