### PR TITLE
refactor(cli/catalog): decouple catalog type from Po message shape

### DIFF
--- a/packages/cli/src/api/__snapshots__/catalog.test.ts.snap
+++ b/packages/cli/src/api/__snapshots__/catalog.test.ts.snap
@@ -10,8 +10,8 @@ exports[`Catalog POT Flow Should get translations from template if locale file n
 exports[`Catalog collect should extract messages from source files 1`] = `
 {
   Component A: {
+    comments: [],
     context: undefined,
-    extractedComments: [],
     message: undefined,
     origin: [
       [
@@ -21,8 +21,8 @@ exports[`Catalog collect should extract messages from source files 1`] = `
     ],
   },
   Component B: {
+    comments: [],
     context: undefined,
-    extractedComments: [],
     message: undefined,
     origin: [
       [
@@ -32,12 +32,12 @@ exports[`Catalog collect should extract messages from source files 1`] = `
     ],
   },
   Hello World: {
-    context: undefined,
-    extractedComments: [
+    comments: [
       Comment A,
       Comment A again,
       Hello comment,
     ],
+    context: undefined,
     message: undefined,
     origin: [
       [
@@ -55,8 +55,8 @@ exports[`Catalog collect should extract messages from source files 1`] = `
     ],
   },
   custom.id: {
+    comments: [],
     context: undefined,
-    extractedComments: [],
     message: Message with id,
     origin: [
       [
@@ -71,8 +71,8 @@ exports[`Catalog collect should extract messages from source files 1`] = `
 exports[`Catalog collect should extract only files passed on options 1`] = `
 {
   Component A: {
+    comments: [],
     context: undefined,
-    extractedComments: [],
     message: undefined,
     origin: [
       [
@@ -82,12 +82,12 @@ exports[`Catalog collect should extract only files passed on options 1`] = `
     ],
   },
   Hello World: {
-    context: undefined,
-    extractedComments: [
+    comments: [
       Comment A,
       Comment A again,
       Hello comment,
     ],
+    context: undefined,
     message: undefined,
     origin: [
       [
@@ -105,8 +105,8 @@ exports[`Catalog collect should extract only files passed on options 1`] = `
     ],
   },
   custom.id: {
+    comments: [],
     context: undefined,
-    extractedComments: [],
     message: Message with id,
     origin: [
       [
@@ -123,8 +123,8 @@ exports[`Catalog collect should support Flow syntax if enabled 1`] = `{}`;
 exports[`Catalog collect should support JSX and Typescript 1`] = `
 {
   ID Some: {
+    comments: [],
     context: undefined,
-    extractedComments: [],
     message: Message with id some,
     origin: [
       [
@@ -134,8 +134,8 @@ exports[`Catalog collect should support JSX and Typescript 1`] = `
     ],
   },
   MHrjPM: {
+    comments: [],
     context: undefined,
-    extractedComments: [],
     message: Title,
     origin: [
       [
@@ -145,10 +145,10 @@ exports[`Catalog collect should support JSX and Typescript 1`] = `
     ],
   },
   Nu4oKW: {
-    context: undefined,
-    extractedComments: [
+    comments: [
       description,
     ],
+    context: undefined,
     message: Description,
     origin: [
       [
@@ -158,8 +158,8 @@ exports[`Catalog collect should support JSX and Typescript 1`] = `
     ],
   },
   YikuIL: {
+    comments: [],
     context: Context1,
-    extractedComments: [],
     message: Some message,
     origin: [
       [
@@ -169,8 +169,8 @@ exports[`Catalog collect should support JSX and Typescript 1`] = `
     ],
   },
   d1Kdl3: {
+    comments: [],
     context: undefined,
-    extractedComments: [],
     message: Hi, my name is {name},
     origin: [
       [
@@ -180,8 +180,8 @@ exports[`Catalog collect should support JSX and Typescript 1`] = `
     ],
   },
   esnaQO: {
+    comments: [],
     context: undefined,
-    extractedComments: [],
     message: {count, plural, one {# book} other {# books}},
     origin: [
       [
@@ -191,8 +191,8 @@ exports[`Catalog collect should support JSX and Typescript 1`] = `
     ],
   },
   xDAtGP: {
+    comments: [],
     context: undefined,
-    extractedComments: [],
     message: Message,
     origin: [
       [
@@ -217,10 +217,12 @@ exports[`Catalog make should collect and write catalogs 2`] = `
     Component A: {
       comments: [],
       context: null,
-      extractedComments: [],
-      flags: [
-        explicit-id,
-      ],
+      extra: {
+        flags: [
+          explicit-id,
+        ],
+        translatorComments: [],
+      },
       obsolete: false,
       origin: [
         [
@@ -231,16 +233,18 @@ exports[`Catalog make should collect and write catalogs 2`] = `
       translation: ,
     },
     Hello World: {
-      comments: [],
-      context: null,
-      extractedComments: [
+      comments: [
         Comment A,
         Comment A again,
         Hello comment,
       ],
-      flags: [
-        explicit-id,
-      ],
+      context: null,
+      extra: {
+        flags: [
+          explicit-id,
+        ],
+        translatorComments: [],
+      },
       obsolete: false,
       origin: [
         [
@@ -261,10 +265,12 @@ exports[`Catalog make should collect and write catalogs 2`] = `
     custom.id: {
       comments: [],
       context: null,
-      extractedComments: [],
-      flags: [
-        explicit-id,
-      ],
+      extra: {
+        flags: [
+          explicit-id,
+        ],
+        translatorComments: [],
+      },
       obsolete: false,
       origin: [
         [
@@ -279,10 +285,12 @@ exports[`Catalog make should collect and write catalogs 2`] = `
     Component A: {
       comments: [],
       context: null,
-      extractedComments: [],
-      flags: [
-        explicit-id,
-      ],
+      extra: {
+        flags: [
+          explicit-id,
+        ],
+        translatorComments: [],
+      },
       obsolete: false,
       origin: [
         [
@@ -293,16 +301,18 @@ exports[`Catalog make should collect and write catalogs 2`] = `
       translation: ,
     },
     Hello World: {
-      comments: [],
-      context: null,
-      extractedComments: [
+      comments: [
         Comment A,
         Comment A again,
         Hello comment,
       ],
-      flags: [
-        explicit-id,
-      ],
+      context: null,
+      extra: {
+        flags: [
+          explicit-id,
+        ],
+        translatorComments: [],
+      },
       obsolete: false,
       origin: [
         [
@@ -323,10 +333,12 @@ exports[`Catalog make should collect and write catalogs 2`] = `
     custom.id: {
       comments: [],
       context: null,
-      extractedComments: [],
-      flags: [
-        explicit-id,
-      ],
+      extra: {
+        flags: [
+          explicit-id,
+        ],
+        translatorComments: [],
+      },
       obsolete: false,
       origin: [
         [
@@ -346,8 +358,10 @@ exports[`Catalog make should merge with existing catalogs 1`] = `
     mY42CM: {
       comments: [],
       context: null,
-      extractedComments: [],
-      flags: [],
+      extra: {
+        flags: [],
+        translatorComments: [],
+      },
       message: Hello World,
       obsolete: false,
       origin: [],
@@ -358,8 +372,10 @@ exports[`Catalog make should merge with existing catalogs 1`] = `
     mY42CM: {
       comments: [],
       context: null,
-      extractedComments: [],
-      flags: [],
+      extra: {
+        flags: [],
+        translatorComments: [],
+      },
       message: Hello World,
       obsolete: false,
       origin: [],
@@ -375,10 +391,12 @@ exports[`Catalog make should merge with existing catalogs 2`] = `
     Component A: {
       comments: [],
       context: null,
-      extractedComments: [],
-      flags: [
-        explicit-id,
-      ],
+      extra: {
+        flags: [
+          explicit-id,
+        ],
+        translatorComments: [],
+      },
       obsolete: false,
       origin: [
         [
@@ -391,10 +409,12 @@ exports[`Catalog make should merge with existing catalogs 2`] = `
     Component B: {
       comments: [],
       context: null,
-      extractedComments: [],
-      flags: [
-        explicit-id,
-      ],
+      extra: {
+        flags: [
+          explicit-id,
+        ],
+        translatorComments: [],
+      },
       obsolete: false,
       origin: [
         [
@@ -405,16 +425,18 @@ exports[`Catalog make should merge with existing catalogs 2`] = `
       translation: ,
     },
     Hello World: {
-      comments: [],
-      context: null,
-      extractedComments: [
+      comments: [
         Comment A,
         Comment A again,
         Hello comment,
       ],
-      flags: [
-        explicit-id,
-      ],
+      context: null,
+      extra: {
+        flags: [
+          explicit-id,
+        ],
+        translatorComments: [],
+      },
       obsolete: false,
       origin: [
         [
@@ -435,10 +457,12 @@ exports[`Catalog make should merge with existing catalogs 2`] = `
     custom.id: {
       comments: [],
       context: null,
-      extractedComments: [],
-      flags: [
-        explicit-id,
-      ],
+      extra: {
+        flags: [
+          explicit-id,
+        ],
+        translatorComments: [],
+      },
       obsolete: false,
       origin: [
         [
@@ -451,8 +475,10 @@ exports[`Catalog make should merge with existing catalogs 2`] = `
     mY42CM: {
       comments: [],
       context: null,
-      extractedComments: [],
-      flags: [],
+      extra: {
+        flags: [],
+        translatorComments: [],
+      },
       message: Hello World,
       obsolete: true,
       origin: [],
@@ -463,10 +489,12 @@ exports[`Catalog make should merge with existing catalogs 2`] = `
     Component A: {
       comments: [],
       context: null,
-      extractedComments: [],
-      flags: [
-        explicit-id,
-      ],
+      extra: {
+        flags: [
+          explicit-id,
+        ],
+        translatorComments: [],
+      },
       obsolete: false,
       origin: [
         [
@@ -479,10 +507,12 @@ exports[`Catalog make should merge with existing catalogs 2`] = `
     Component B: {
       comments: [],
       context: null,
-      extractedComments: [],
-      flags: [
-        explicit-id,
-      ],
+      extra: {
+        flags: [
+          explicit-id,
+        ],
+        translatorComments: [],
+      },
       obsolete: false,
       origin: [
         [
@@ -493,16 +523,18 @@ exports[`Catalog make should merge with existing catalogs 2`] = `
       translation: ,
     },
     Hello World: {
-      comments: [],
-      context: null,
-      extractedComments: [
+      comments: [
         Comment A,
         Comment A again,
         Hello comment,
       ],
-      flags: [
-        explicit-id,
-      ],
+      context: null,
+      extra: {
+        flags: [
+          explicit-id,
+        ],
+        translatorComments: [],
+      },
       obsolete: false,
       origin: [
         [
@@ -523,10 +555,12 @@ exports[`Catalog make should merge with existing catalogs 2`] = `
     custom.id: {
       comments: [],
       context: null,
-      extractedComments: [],
-      flags: [
-        explicit-id,
-      ],
+      extra: {
+        flags: [
+          explicit-id,
+        ],
+        translatorComments: [],
+      },
       obsolete: false,
       origin: [
         [
@@ -539,8 +573,10 @@ exports[`Catalog make should merge with existing catalogs 2`] = `
     mY42CM: {
       comments: [],
       context: null,
-      extractedComments: [],
-      flags: [],
+      extra: {
+        flags: [],
+        translatorComments: [],
+      },
       message: Hello World,
       obsolete: true,
       origin: [],
@@ -564,10 +600,12 @@ exports[`Catalog make should only update the specified locale 2`] = `
     Component A: {
       comments: [],
       context: null,
-      extractedComments: [],
-      flags: [
-        explicit-id,
-      ],
+      extra: {
+        flags: [
+          explicit-id,
+        ],
+        translatorComments: [],
+      },
       obsolete: false,
       origin: [
         [
@@ -578,16 +616,18 @@ exports[`Catalog make should only update the specified locale 2`] = `
       translation: ,
     },
     Hello World: {
-      comments: [],
-      context: null,
-      extractedComments: [
+      comments: [
         Comment A,
         Comment A again,
         Hello comment,
       ],
-      flags: [
-        explicit-id,
-      ],
+      context: null,
+      extra: {
+        flags: [
+          explicit-id,
+        ],
+        translatorComments: [],
+      },
       obsolete: false,
       origin: [
         [
@@ -608,10 +648,12 @@ exports[`Catalog make should only update the specified locale 2`] = `
     custom.id: {
       comments: [],
       context: null,
-      extractedComments: [],
-      flags: [
-        explicit-id,
-      ],
+      extra: {
+        flags: [
+          explicit-id,
+        ],
+        translatorComments: [],
+      },
       obsolete: false,
       origin: [
         [
@@ -632,10 +674,12 @@ exports[`Catalog makeTemplate should collect and write a template 2`] = `
   Component A: {
     comments: [],
     context: null,
-    extractedComments: [],
-    flags: [
-      explicit-id,
-    ],
+    extra: {
+      flags: [
+        explicit-id,
+      ],
+      translatorComments: [],
+    },
     obsolete: false,
     origin: [
       [
@@ -646,16 +690,18 @@ exports[`Catalog makeTemplate should collect and write a template 2`] = `
     translation: ,
   },
   Hello World: {
-    comments: [],
-    context: null,
-    extractedComments: [
+    comments: [
       Comment A,
       Comment A again,
       Hello comment,
     ],
-    flags: [
-      explicit-id,
-    ],
+    context: null,
+    extra: {
+      flags: [
+        explicit-id,
+      ],
+      translatorComments: [],
+    },
     obsolete: false,
     origin: [
       [
@@ -676,10 +722,12 @@ exports[`Catalog makeTemplate should collect and write a template 2`] = `
   custom.id: {
     comments: [],
     context: null,
-    extractedComments: [],
-    flags: [
-      explicit-id,
-    ],
+    extra: {
+      flags: [
+        explicit-id,
+      ],
+      translatorComments: [],
+    },
     obsolete: false,
     origin: [
       [
@@ -697,10 +745,12 @@ exports[`Catalog read should read file in given format 1`] = `
   obsolete: {
     comments: [],
     context: null,
-    extractedComments: [],
-    flags: [
-      explicit-id,
-    ],
+    extra: {
+      flags: [
+        explicit-id,
+      ],
+      translatorComments: [],
+    },
     obsolete: true,
     origin: [],
     translation: Is marked as obsolete,
@@ -708,10 +758,12 @@ exports[`Catalog read should read file in given format 1`] = `
   static: {
     comments: [],
     context: null,
-    extractedComments: [],
-    flags: [
-      explicit-id,
-    ],
+    extra: {
+      flags: [
+        explicit-id,
+      ],
+      translatorComments: [],
+    },
     obsolete: false,
     origin: [],
     translation: Static message,
@@ -719,37 +771,43 @@ exports[`Catalog read should read file in given format 1`] = `
   veryLongString: {
     comments: [],
     context: null,
-    extractedComments: [],
-    flags: [
-      explicit-id,
-    ],
+    extra: {
+      flags: [
+        explicit-id,
+      ],
+      translatorComments: [],
+    },
     obsolete: false,
     origin: [],
     translation: One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections. The bedding was hardly able to cover it and seemed ready to slide off any moment. His many legs, pitifully thin compared with the size of the rest of him, waved about helplessly as he looked. "What's happened to me?" he thought. It wasn't a dream. His room, a proper human,
   },
   withComments: {
-    comments: [
-      Translator comment,
-      This one might come from developer,
-    ],
+    comments: [],
     context: null,
-    extractedComments: [],
-    flags: [
-      explicit-id,
-    ],
+    extra: {
+      flags: [
+        explicit-id,
+      ],
+      translatorComments: [
+        Translator comment,
+        This one might come from developer,
+      ],
+    },
     obsolete: false,
     origin: [],
     translation: Support translator comments separately,
   },
   withDescription: {
-    comments: [],
-    context: null,
-    extractedComments: [
+    comments: [
       Description is comment from developers to translators,
     ],
-    flags: [
-      explicit-id,
-    ],
+    context: null,
+    extra: {
+      flags: [
+        explicit-id,
+      ],
+      translatorComments: [],
+    },
     obsolete: false,
     origin: [],
     translation: Message with description,
@@ -757,12 +815,14 @@ exports[`Catalog read should read file in given format 1`] = `
   withFlags: {
     comments: [],
     context: null,
-    extractedComments: [],
-    flags: [
-      fuzzy,
-      otherFlag,
-      explicit-id,
-    ],
+    extra: {
+      flags: [
+        fuzzy,
+        otherFlag,
+        explicit-id,
+      ],
+      translatorComments: [],
+    },
     obsolete: false,
     origin: [],
     translation: Keeps any flags that are defined,
@@ -770,10 +830,12 @@ exports[`Catalog read should read file in given format 1`] = `
   withMultipleOrigins: {
     comments: [],
     context: null,
-    extractedComments: [],
-    flags: [
-      explicit-id,
-    ],
+    extra: {
+      flags: [
+        explicit-id,
+      ],
+      translatorComments: [],
+    },
     obsolete: false,
     origin: [
       [
@@ -790,10 +852,12 @@ exports[`Catalog read should read file in given format 1`] = `
   withOrigin: {
     comments: [],
     context: null,
-    extractedComments: [],
-    flags: [
-      explicit-id,
-    ],
+    extra: {
+      flags: [
+        explicit-id,
+      ],
+      translatorComments: [],
+    },
     obsolete: false,
     origin: [
       [
@@ -804,12 +868,14 @@ exports[`Catalog read should read file in given format 1`] = `
     translation: Message with origin,
   },
   xC8QeX: {
-    comments: [],
-    context: null,
-    extractedComments: [
+    comments: [
       js-lingui-id: pXy+hm,
     ],
-    flags: [],
+    context: null,
+    extra: {
+      flags: [],
+      translatorComments: [],
+    },
     message: Message with default hash id,
     obsolete: false,
     origin: [],
@@ -826,8 +892,10 @@ exports[`Catalog readAll should read existing catalogs for all locales 1`] = `
     mY42CM: {
       comments: [],
       context: null,
-      extractedComments: [],
-      flags: [],
+      extra: {
+        flags: [],
+        translatorComments: [],
+      },
       message: Hello World,
       obsolete: false,
       origin: [],
@@ -838,8 +906,10 @@ exports[`Catalog readAll should read existing catalogs for all locales 1`] = `
     mY42CM: {
       comments: [],
       context: null,
-      extractedComments: [],
-      flags: [],
+      extra: {
+        flags: [],
+        translatorComments: [],
+      },
       message: Hello World,
       obsolete: false,
       origin: [],

--- a/packages/cli/src/api/catalog.test.ts
+++ b/packages/cli/src/api/catalog.test.ts
@@ -204,8 +204,8 @@ describe("Catalog", () => {
       expect(messages).toMatchInlineSnapshot(`
         {
           xDAtGP: {
+            comments: [],
             context: undefined,
-            extractedComments: [],
             message: Message,
             origin: [
               [

--- a/packages/cli/src/api/catalog/extractFromFiles.ts
+++ b/packages/cli/src/api/catalog/extractFromFiles.ts
@@ -24,7 +24,7 @@ export async function extractFromFiles(
           messages[next.id] = {
             message: next.message,
             context: next.context,
-            extractedComments: [],
+            comments: [],
             origin: [],
           }
         }
@@ -50,9 +50,9 @@ export async function extractFromFiles(
 
         messages[next.id] = {
           ...prev,
-          extractedComments: next.comment
-            ? [...prev.extractedComments, next.comment]
-            : prev.extractedComments,
+          comments: next.comment
+            ? [...prev.comments, next.comment]
+            : prev.comments,
           origin: [...prev.origin, [filename, next.origin[1]]],
         }
       },

--- a/packages/conf/src/types.ts
+++ b/packages/conf/src/types.ts
@@ -23,24 +23,28 @@ export type ExtractorCtx = {
   linguiConfig: LinguiConfigNormalized
 }
 
+type CatalogExtra = Record<string, unknown>
 export type MessageOrigin = [filename: string, line?: number]
-export type ExtractedMessageType = {
+export type ExtractedMessageType<Extra = CatalogExtra> = {
   message?: string
   origin?: MessageOrigin[]
   comments?: string[]
-  extractedComments?: string[]
   obsolete?: boolean
-  flags?: string[]
   context?: string
+  /**
+   * the generic field where
+   * formatters can store additional data
+   */
+  extra?: Extra
 }
-export type MessageType = ExtractedMessageType & {
+export type MessageType<Extra = CatalogExtra> = ExtractedMessageType<Extra> & {
   translation: string
 }
-export type ExtractedCatalogType = {
-  [msgId: string]: ExtractedMessageType
+export type ExtractedCatalogType<Extra = CatalogExtra> = {
+  [msgId: string]: ExtractedMessageType<Extra>
 }
-export type CatalogType = {
-  [msgId: string]: MessageType
+export type CatalogType<Extra = CatalogExtra> = {
+  [msgId: string]: MessageType<Extra>
 }
 
 export type ExtractorType = {

--- a/packages/format-json/src/__snapshots__/json.test.ts.snap
+++ b/packages/format-json/src/__snapshots__/json.test.ts.snap
@@ -36,15 +36,11 @@ exports[`json format style: lingui should write catalog in lingui format 1`] = `
   },
   "withDescription": {
     "translation": "Message with description",
-    "extractedComments": [
+    "comments": [
       "Description is comment from developers to translators"
     ]
   },
   "withComments": {
-    "comments": [
-      "Translator comment",
-      "This one might come from developer"
-    ],
     "translation": "Support translator comments separately"
   },
   "obsolete": {
@@ -52,10 +48,6 @@ exports[`json format style: lingui should write catalog in lingui format 1`] = `
     "obsolete": true
   },
   "withFlags": {
-    "flags": [
-      "fuzzy",
-      "otherFlag"
-    ],
     "translation": "Keeps any flags that are defined"
   },
   "veryLongString": {

--- a/packages/format-json/src/json.test.ts
+++ b/packages/format-json/src/json.test.ts
@@ -27,15 +27,9 @@ describe("json format", () => {
         },
         withDescription: {
           translation: "Message with description",
-          extractedComments: [
-            "Description is comment from developers to translators",
-          ],
+          comments: ["Description is comment from developers to translators"],
         },
         withComments: {
-          comments: [
-            "Translator comment",
-            "This one might come from developer",
-          ],
           translation: "Support translator comments separately",
         },
         obsolete: {
@@ -43,7 +37,6 @@ describe("json format", () => {
           obsolete: true,
         },
         withFlags: {
-          flags: ["fuzzy", "otherFlag"],
           translation: "Keeps any flags that are defined",
         },
         veryLongString: {
@@ -186,15 +179,9 @@ describe("json format", () => {
         },
         withDescription: {
           translation: "Message with description",
-          extractedComments: [
-            "Description is comment from developers to translators",
-          ],
+          comments: ["Description is comment from developers to translators"],
         },
         withComments: {
-          comments: [
-            "Translator comment",
-            "This one might come from developer",
-          ],
           translation: "Support translator comments separately",
         },
         obsolete: {
@@ -202,7 +189,6 @@ describe("json format", () => {
           obsolete: true,
         },
         withFlags: {
-          flags: ["fuzzy", "otherFlag"],
           translation: "Keeps any flags that are defined",
         },
       }

--- a/packages/format-po-gettext/src/__snapshots__/po-gettext.test.ts.snap
+++ b/packages/format-po-gettext/src/__snapshots__/po-gettext.test.ts.snap
@@ -5,8 +5,10 @@ exports[`po-gettext format convertPluralsToIco handle correctly locales with 4-l
   WGI12K: {
     comments: [],
     context: null,
-    extractedComments: [],
-    flags: [],
+    extra: {
+      flags: [],
+      translatorComments: [],
+    },
     message: {anotherCount, plural, one {Singular case} other {Case number {anotherCount}}},
     obsolete: false,
     origin: [],
@@ -15,8 +17,10 @@ exports[`po-gettext format convertPluralsToIco handle correctly locales with 4-l
   jO/SBZ: {
     comments: [],
     context: null,
-    extractedComments: [],
-    flags: [],
+    extra: {
+      flags: [],
+      translatorComments: [],
+    },
     message: {count, plural, one {Singular} other {Plural}},
     obsolete: false,
     origin: [],
@@ -25,23 +29,27 @@ exports[`po-gettext format convertPluralsToIco handle correctly locales with 4-l
   message_with_id: {
     comments: [],
     context: null,
-    extractedComments: [],
-    flags: [
-      explicit-id,
-    ],
+    extra: {
+      flags: [
+        explicit-id,
+      ],
+      translatorComments: [],
+    },
     obsolete: false,
     origin: [],
     translation: {someCount, plural, one {Singular case} other {Case number {someCount}}},
   },
   message_with_id_but_without_translation: {
-    comments: [],
-    context: null,
-    extractedComments: [
+    comments: [
       Comment made by the developers.,
     ],
-    flags: [
-      explicit-id,
-    ],
+    context: null,
+    extra: {
+      flags: [
+        explicit-id,
+      ],
+      translatorComments: [],
+    },
     obsolete: false,
     origin: [],
     translation: ,
@@ -106,8 +114,10 @@ exports[`po-gettext format should convert gettext plurals to ICU plural messages
   WGI12K: {
     comments: [],
     context: null,
-    extractedComments: [],
-    flags: [],
+    extra: {
+      flags: [],
+      translatorComments: [],
+    },
     message: {anotherCount, plural, one {Singular case} other {Case number {anotherCount}}},
     obsolete: false,
     origin: [],
@@ -116,8 +126,10 @@ exports[`po-gettext format should convert gettext plurals to ICU plural messages
   jO/SBZ: {
     comments: [],
     context: null,
-    extractedComments: [],
-    flags: [],
+    extra: {
+      flags: [],
+      translatorComments: [],
+    },
     message: {count, plural, one {Singular} other {Plural}},
     obsolete: false,
     origin: [],
@@ -126,23 +138,27 @@ exports[`po-gettext format should convert gettext plurals to ICU plural messages
   message_with_id: {
     comments: [],
     context: null,
-    extractedComments: [],
-    flags: [
-      explicit-id,
-    ],
+    extra: {
+      flags: [
+        explicit-id,
+      ],
+      translatorComments: [],
+    },
     obsolete: false,
     origin: [],
     translation: {someCount, plural, one {Singular case} other {Case number {someCount}}},
   },
   message_with_id_but_without_translation: {
-    comments: [],
-    context: null,
-    extractedComments: [
+    comments: [
       Comment made by the developers.,
     ],
-    flags: [
-      explicit-id,
-    ],
+    context: null,
+    extra: {
+      flags: [
+        explicit-id,
+      ],
+      translatorComments: [],
+    },
     obsolete: false,
     origin: [],
     translation: ,

--- a/packages/format-po-gettext/src/po-gettext.test.ts
+++ b/packages/format-po-gettext/src/po-gettext.test.ts
@@ -39,7 +39,7 @@ describe("po-gettext format", () => {
           and linebreak} other {Case number {someCount} with id}}",
         translation:
           "{someCount, plural, one {Singular case with id} other {Case number {someCount} with id}}",
-        extractedComments: [
+        comments: [
           "This is a comment by the developers about how the content must be localized.",
         ],
       },
@@ -131,19 +131,23 @@ msgstr[2] "# dní"
 
     const parsed = format.parse(po, defaultParseCtx)
 
-    expect(parsed).toEqual({
-      Y8Xw2Y: {
-        // Note that the last case must be `other` (the 4th CLDR case name) instead of `many` (the 3rd CLDR case name).
-        translation: "{#, plural, one {# den} few {# dny} other {# dní}}",
-        message: "{#, plural, one {day} other {days}}",
-        extractedComments: [],
-        context: null,
-        comments: [],
-        obsolete: false,
-        origin: [],
-        flags: [],
-      },
-    })
+    // Note that the last case must be `other` (the 4th CLDR case name) instead of `many` (the 3rd CLDR case name).
+    expect(parsed).toMatchInlineSnapshot(`
+      {
+        Y8Xw2Y: {
+          comments: [],
+          context: null,
+          extra: {
+            flags: [],
+            translatorComments: [],
+          },
+          message: {#, plural, one {day} other {days}},
+          obsolete: false,
+          origin: [],
+          translation: {#, plural, one {# den} few {# dny} other {# dní}},
+        },
+      }
+    `)
   })
 
   describe("when using 'select' format", () => {

--- a/packages/format-po/src/__snapshots__/po.test.ts.snap
+++ b/packages/format-po/src/__snapshots__/po.test.ts.snap
@@ -4,31 +4,35 @@ exports[`pofile format should correct badly used comments 1`] = `
 {
   withDescriptionAndComments: {
     comments: [
-      Translator comment,
-    ],
-    context: null,
-    extractedComments: [
       Single description only,
       Second description?,
     ],
-    flags: [
-      explicit-id,
-    ],
+    context: null,
+    extra: {
+      flags: [
+        explicit-id,
+      ],
+      translatorComments: [
+        Translator comment,
+      ],
+    },
     obsolete: false,
     origin: [],
     translation: Second description joins translator comments,
   },
   withMultipleDescriptions: {
-    comments: [],
-    context: null,
-    extractedComments: [
+    comments: [
       First description,
       Second comment,
       Third comment,
     ],
-    flags: [
-      explicit-id,
-    ],
+    context: null,
+    extra: {
+      flags: [
+        explicit-id,
+      ],
+      translatorComments: [],
+    },
     obsolete: false,
     origin: [],
     translation: Extra comments are separated from the first description line,
@@ -75,10 +79,12 @@ exports[`pofile format should read catalog in pofile format 1`] = `
   obsolete: {
     comments: [],
     context: null,
-    extractedComments: [],
-    flags: [
-      explicit-id,
-    ],
+    extra: {
+      flags: [
+        explicit-id,
+      ],
+      translatorComments: [],
+    },
     obsolete: true,
     origin: [],
     translation: Is marked as obsolete,
@@ -86,10 +92,12 @@ exports[`pofile format should read catalog in pofile format 1`] = `
   static: {
     comments: [],
     context: null,
-    extractedComments: [],
-    flags: [
-      explicit-id,
-    ],
+    extra: {
+      flags: [
+        explicit-id,
+      ],
+      translatorComments: [],
+    },
     obsolete: false,
     origin: [],
     translation: Static message,
@@ -97,37 +105,43 @@ exports[`pofile format should read catalog in pofile format 1`] = `
   veryLongString: {
     comments: [],
     context: null,
-    extractedComments: [],
-    flags: [
-      explicit-id,
-    ],
+    extra: {
+      flags: [
+        explicit-id,
+      ],
+      translatorComments: [],
+    },
     obsolete: false,
     origin: [],
     translation: One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections. The bedding was hardly able to cover it and seemed ready to slide off any moment. His many legs, pitifully thin compared with the size of the rest of him, waved about helplessly as he looked. "What's happened to me?" he thought. It wasn't a dream. His room, a proper human,
   },
   withComments: {
-    comments: [
-      Translator comment,
-      This one might come from developer,
-    ],
+    comments: [],
     context: null,
-    extractedComments: [],
-    flags: [
-      explicit-id,
-    ],
+    extra: {
+      flags: [
+        explicit-id,
+      ],
+      translatorComments: [
+        Translator comment,
+        This one might come from developer,
+      ],
+    },
     obsolete: false,
     origin: [],
     translation: Support translator comments separately,
   },
   withDescription: {
-    comments: [],
-    context: null,
-    extractedComments: [
+    comments: [
       Description is comment from developers to translators,
     ],
-    flags: [
-      explicit-id,
-    ],
+    context: null,
+    extra: {
+      flags: [
+        explicit-id,
+      ],
+      translatorComments: [],
+    },
     obsolete: false,
     origin: [],
     translation: Message with description,
@@ -135,12 +149,14 @@ exports[`pofile format should read catalog in pofile format 1`] = `
   withFlags: {
     comments: [],
     context: null,
-    extractedComments: [],
-    flags: [
-      fuzzy,
-      otherFlag,
-      explicit-id,
-    ],
+    extra: {
+      flags: [
+        fuzzy,
+        otherFlag,
+        explicit-id,
+      ],
+      translatorComments: [],
+    },
     obsolete: false,
     origin: [],
     translation: Keeps any flags that are defined,
@@ -148,10 +164,12 @@ exports[`pofile format should read catalog in pofile format 1`] = `
   withMultipleOrigins: {
     comments: [],
     context: null,
-    extractedComments: [],
-    flags: [
-      explicit-id,
-    ],
+    extra: {
+      flags: [
+        explicit-id,
+      ],
+      translatorComments: [],
+    },
     obsolete: false,
     origin: [
       [
@@ -168,10 +186,12 @@ exports[`pofile format should read catalog in pofile format 1`] = `
   withOrigin: {
     comments: [],
     context: null,
-    extractedComments: [],
-    flags: [
-      explicit-id,
-    ],
+    extra: {
+      flags: [
+        explicit-id,
+      ],
+      translatorComments: [],
+    },
     obsolete: false,
     origin: [
       [
@@ -182,12 +202,14 @@ exports[`pofile format should read catalog in pofile format 1`] = `
     translation: Message with origin,
   },
   xC8QeX: {
-    comments: [],
-    context: null,
-    extractedComments: [
+    comments: [
       js-lingui-id: pXy+hm,
     ],
-    flags: [],
+    context: null,
+    extra: {
+      flags: [],
+      translatorComments: [],
+    },
     message: Message with default hash id,
     obsolete: false,
     origin: [],

--- a/packages/format-po/src/po.test.ts
+++ b/packages/format-po/src/po.test.ts
@@ -1,7 +1,7 @@
 import fs from "fs"
 import path from "path"
 
-import { formatter as createFormatter } from "./po"
+import { formatter as createFormatter, POCatalogExtra } from "./po"
 import { CatalogFormatter, CatalogType } from "@lingui/conf"
 
 const defaultParseCtx: Parameters<CatalogFormatter["parse"]>[1] = {
@@ -23,7 +23,7 @@ describe("pofile format", () => {
   it("should write catalog in pofile format", () => {
     const format = createFormatter({ origins: true })
 
-    const catalog: CatalogType = {
+    const catalog: CatalogType<POCatalogExtra> = {
       static: {
         translation: "Static message",
       },
@@ -49,12 +49,15 @@ describe("pofile format", () => {
       },
       withDescription: {
         translation: "Message with description",
-        extractedComments: [
-          "Description is comment from developers to translators",
-        ],
+        comments: ["Description is comment from developers to translators"],
       },
       withComments: {
-        comments: ["Translator comment", "This one might come from developer"],
+        extra: {
+          translatorComments: [
+            "Translator comment",
+            "This one might come from developer",
+          ],
+        },
         translation: "Support translator comments separately",
       },
       obsolete: {
@@ -62,7 +65,9 @@ describe("pofile format", () => {
         obsolete: true,
       },
       withFlags: {
-        flags: ["fuzzy", "otherFlag"],
+        extra: {
+          flags: ["fuzzy", "otherFlag"],
+        },
         translation: "Keeps any flags that are defined",
       },
       veryLongString: {
@@ -137,7 +142,7 @@ describe("pofile format", () => {
         message: "with generated id",
         translation: "",
         context: "my context",
-        extractedComments: ["js-lingui-id: Dgzql1"],
+        comments: ["js-lingui-id: Dgzql1"],
       },
     }
 


### PR DESCRIPTION
# Description

While working on a new xliff formatter realized that current shape of CatalogType and ExtractedMessage are tightly coupled to shape of the message of Pofile. There some properties which is related to po formatter only and should not be in the core type. 

The same with other formatters. For example xliff may have additional attributes such as `state=final` which we also should store somewhere to not lost when extracting.  So there should be a way to add some `extra` fields which would be preserved by cli and returned back to formatter. 

In scheme it something like

formatter.parse -> extra: {special field} -> cli catalog processing -> formatter.serialize (get the same extra: {special field}) 

Notes: 

i renamed extractedComments -> comments.  this naming was because Pofile has it. When it's uncoupled, we don't 
 need it anymore and just `comments` looks much cleaner in the api.

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
