### PR TITLE
Use MESSAGE as default for ID when extracting messages from non-transpiled code

### DIFF
--- a/packages/babel-plugin-extract-messages/src/index.ts
+++ b/packages/babel-plugin-extract-messages/src/index.ts
@@ -295,14 +295,16 @@ export default function ({ types: t }: { types: BabelTypes }): PluginObj {
           "context",
         ])
 
-        if (!props.id) {
+        if (!props.id && !props.message) {
           console.warn(
-            path.buildCodeFrameError("Missing message ID, skipping.").message
+            path.buildCodeFrameError("Missing message ID and MESSAGE, skipping.").message
           )
           return
         }
 
-        collectMessage(path, props, ctx)
+        const propsUseDefault = props.id ? props : { ...props, id: props.message }
+
+        collectMessage(path, propsUseDefault, ctx)
       },
     },
   }

--- a/packages/babel-plugin-extract-messages/test/index.ts
+++ b/packages/babel-plugin-extract-messages/test/index.ts
@@ -268,8 +268,8 @@ import { Trans } from "@lingui/react";
       })
     })
 
-    it("Should log error when no ID provided", () => {
-      const code = "const msg = /*i18n*/ {message: `Hello ${name}`}"
+    it("Should log error when no ID or MESSAGE provided", () => {
+      const code = "const msg = /*i18n*/ {noIdNorMessage: `foobar`}"
 
       return mockConsole((console) => {
         const messages = transformCode(code)
@@ -278,8 +278,19 @@ import { Trans } from "@lingui/react";
         expect(console.error).not.toBeCalled()
 
         expect(console.warn).toBeCalledWith(
-          expect.stringContaining(`Missing message ID`)
+          expect.stringContaining(`Missing message ID and MESSAGE`)
         )
+      })
+    })
+
+    it("Should use MESSAGE as default for ID", () => {
+      const code = "const msg = /*i18n*/ {message: `Hello {name}`}"
+
+      return mockConsole((console) => {
+        const messages = transformCode(code)
+        expect(messages[0]).toMatchObject({
+          id: "Hello {name}",
+        })
       })
     })
 


### PR DESCRIPTION
# Description

Use MESSAGE as default for ID when extracting messages from non-transpiled code.

See issue https://github.com/lingui/js-lingui/issues/1559.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Fixes # (issue)
https://github.com/lingui/js-lingui/issues/1559

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
