### PR TITLE
refactor(build): fix @lingui/message-utils package

### DIFF
--- a/packages/cli/src/api/compile.ts
+++ b/packages/cli/src/api/compile.ts
@@ -1,6 +1,9 @@
 import * as t from "@babel/types"
 import generate, { GeneratorOptions } from "@babel/generator"
-import { compileMessage, CompiledMessage } from "@lingui/message-utils"
+import {
+  compileMessage,
+  CompiledMessage,
+} from "@lingui/message-utils/compileMessage"
 import pseudoLocalize from "./pseudoLocalize"
 
 export type CompiledCatalogNamespace = "cjs" | "es" | "ts" | "json" | string

--- a/packages/core/src/i18n.ts
+++ b/packages/core/src/i18n.ts
@@ -2,8 +2,8 @@ import { interpolate, UNICODE_REGEX } from "./interpolate"
 import { isString, isFunction } from "./essentials"
 import { date, number } from "./formats"
 import { EventEmitter } from "./eventEmitter"
-import { compileMessage } from "@lingui/message-utils"
-import type { CompiledMessage } from "@lingui/message-utils"
+import { compileMessage } from "@lingui/message-utils/compileMessage"
+import type { CompiledMessage } from "@lingui/message-utils/compileMessage"
 
 export type MessageOptions = {
   message?: string

--- a/packages/core/src/interpolate.test.ts
+++ b/packages/core/src/interpolate.test.ts
@@ -1,4 +1,4 @@
-import { compileMessage as compile } from "@lingui/message-utils"
+import { compileMessage as compile } from "@lingui/message-utils/compileMessage"
 import { mockEnv, mockConsole } from "@lingui/jest-mocks"
 import { interpolate } from "./interpolate"
 import { Locale, Locales } from "./i18n"

--- a/packages/format-csv/package.json
+++ b/packages/format-csv/package.json
@@ -5,6 +5,7 @@
   "main": "./dist/csv.cjs",
   "module": "./dist/csv.mjs",
   "types": "./dist/csv.d.ts",
+  "sideEffects": false,
   "license": "MIT",
   "keywords": [
     "i18n",

--- a/packages/format-json/package.json
+++ b/packages/format-json/package.json
@@ -5,6 +5,7 @@
   "main": "./dist/json.cjs",
   "module": "./dist/json.mjs",
   "types": "./dist/json.d.ts",
+  "sideEffects": false,
   "license": "MIT",
   "keywords": [
     "i18n",

--- a/packages/format-po-gettext/package.json
+++ b/packages/format-po-gettext/package.json
@@ -5,6 +5,7 @@
   "main": "./dist/po-gettext.cjs",
   "module": "./dist/po-gettext.mjs",
   "types": "./dist/po-gettext.d.ts",
+  "sideEffects": false,
   "license": "MIT",
   "keywords": [
     "i18n",

--- a/packages/format-po-gettext/src/po-gettext.ts
+++ b/packages/format-po-gettext/src/po-gettext.ts
@@ -5,7 +5,7 @@ import PO from "pofile"
 import gettextPlurals from "node-gettext/lib/plurals"
 
 import type { CatalogFormatter, CatalogType, MessageType } from "@lingui/conf"
-import { generateMessageId } from "@lingui/message-utils"
+import { generateMessageId } from "@lingui/message-utils/generateMessageId"
 import { formatter as poFormatter } from "@lingui/format-po"
 import type { PoFormatterOptions } from "@lingui/format-po"
 

--- a/packages/format-po/package.json
+++ b/packages/format-po/package.json
@@ -5,6 +5,7 @@
   "main": "./dist/po.cjs",
   "module": "./dist/po.mjs",
   "types": "./dist/po.d.ts",
+  "sideEffects": false,
   "license": "MIT",
   "keywords": [
     "i18n",

--- a/packages/format-po/src/po.ts
+++ b/packages/format-po/src/po.ts
@@ -2,7 +2,7 @@ import { format as formatDate } from "date-fns"
 import PO from "pofile"
 
 import { CatalogFormatter, CatalogType, MessageType } from "@lingui/conf"
-import { generateMessageId } from "@lingui/message-utils"
+import { generateMessageId } from "@lingui/message-utils/generateMessageId"
 
 type POItem = InstanceType<typeof PO.Item>
 

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -5,6 +5,7 @@
   "types": "./dist/index.d.ts",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
+  "sideEffects": false,
   "author": {
     "name": "Tomáš Ehrlich",
     "email": "tomas.ehrlich@gmail.com"

--- a/packages/macro/package.json
+++ b/packages/macro/package.json
@@ -5,6 +5,7 @@
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./index.d.ts",
+  "sideEffects": false,
   "author": {
     "name": "Tomáš Ehrlich",
     "email": "tomas.ehrlich@gmail.com"

--- a/packages/macro/src/macroJs.ts
+++ b/packages/macro/src/macroJs.ts
@@ -22,7 +22,7 @@ import ICUMessageFormat, {
 } from "./icu"
 import { makeCounter } from "./utils"
 import { COMMENT, CONTEXT, EXTRACT_MARK, ID, MESSAGE } from "./constants"
-import { generateMessageId } from "@lingui/message-utils"
+import { generateMessageId } from "@lingui/message-utils/generateMessageId"
 
 const keepSpaceRe = /(?:\\(?:\r\n|\r|\n))+\s+/g
 const keepNewLineRe = /(?:\r\n|\r|\n)+\s+/g

--- a/packages/macro/src/macroJsx.ts
+++ b/packages/macro/src/macroJsx.ts
@@ -22,7 +22,7 @@ import ICUMessageFormat, {
 } from "./icu"
 import { makeCounter } from "./utils"
 import { COMMENT, CONTEXT, ID, MESSAGE } from "./constants"
-import { generateMessageId } from "@lingui/message-utils"
+import { generateMessageId } from "@lingui/message-utils/generateMessageId"
 
 const pluralRuleRe = /(_[\d\w]+|zero|one|two|few|many|other)/
 const jsx2icuExactChoice = (value: string) =>

--- a/packages/message-utils/package.json
+++ b/packages/message-utils/package.json
@@ -1,11 +1,21 @@
 {
   "name": "@lingui/message-utils",
   "version": "4.0.0-next.4",
-  "main": "./dist/index.cjs",
-  "module": "./dist/index.mjs",
-  "types": "./dist/index.d.ts",
   "license": "MIT",
   "keywords": [],
+  "sideEffects": false,
+  "exports": {
+    "./generateMessageId": {
+      "import": "./dist/generateMessageId.mjs",
+      "require": "./dist/generateMessageId.cjs",
+      "types": "./dist/generateMessageId.d.ts"
+    },
+    "./compileMessage": {
+      "import": "./dist/compileMessage.mjs",
+      "require": "./dist/compileMessage.cjs",
+      "types": "./dist/compileMessage.d.ts"
+    }
+  },
   "scripts": {
     "build": "rimraf ./dist && unbuild",
     "stub": "unbuild --stub"

--- a/packages/message-utils/src/index.ts
+++ b/packages/message-utils/src/index.ts
@@ -1,2 +1,0 @@
-export * from "./generateMessageId"
-export * from "./compileMessage"

--- a/packages/remote-loader/src/browserCompiler.ts
+++ b/packages/remote-loader/src/browserCompiler.ts
@@ -1,4 +1,4 @@
-import { compileMessage } from "@lingui/message-utils"
+import { compileMessage } from "@lingui/message-utils/compileMessage"
 
 export function createBrowserCompiledCatalog(messages: Record<string, any>) {
   return Object.keys(messages).reduce((obj, key: string) => {

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -5,6 +5,7 @@
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
+  "sideEffects": false,
   "license": "MIT",
   "keywords": [
     "vite-plugin",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "paths": {
       "@lingui/babel-plugin-extract-messages": ["./packages/babel-plugin-extract-messages/src"],
       "@lingui/core": ["./packages/core/src"],
-      "@lingui/message-utils": ["./packages/message-utils/src/index.ts"],
+      "@lingui/message-utils/*": ["./packages/message-utils/src/*"],
       "@lingui/cli/api": ["./packages/cli/src/api"],
       "@lingui/react": ["./packages/react/src"],
       "@lingui/conf": ["./packages/conf/src"],


### PR DESCRIPTION
# Description

@lingui/message-utils package used in both environments, in browser and node. But generateMessageId exported from this package is a pure nodejs function. This caused errors when bundling packages depending on @lingui/message-utils

I didn't want to make `generateMessageId` a universal (read as working in browser / node) because that would have a performance hit over native nodejs crypto implementation. And since this function now used only in nodejs context i just add two diffrent exports from the package to not bloat browser bundles with nodejs imports. 

Also i added "sideEffect: false" to packages to make them tree-shaking compatible. 

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
