### PR TITLE
fix(core): improve MessageDescriptor typings. id is always present

### DIFF
--- a/packages/core/src/i18n.ts
+++ b/packages/core/src/i18n.ts
@@ -40,7 +40,7 @@ export type Messages = Record<string, CompiledMessage>
 export type AllMessages = Record<Locale, Messages>
 
 export type MessageDescriptor = {
-  id?: string
+  id: string
   comment?: string
   message?: string
   values?: Record<string, unknown>

--- a/packages/macro/global.d.ts
+++ b/packages/macro/global.d.ts
@@ -4,6 +4,20 @@
 declare module "@lingui/macro" {
   import type { MessageDescriptor, I18n } from "@lingui/core"
 
+  type MacroMessageDescriptor = (
+    | {
+        id: string
+        message?: string
+      }
+    | {
+        id?: string
+        message: string
+      }
+  ) & {
+    comment?: string
+    context?: string
+  }
+
   export type BasicType = {
     id?: string
     comment?: string
@@ -33,7 +47,7 @@ declare module "@lingui/macro" {
    *
    * @param descriptor The message descriptor to translate
    */
-  export function t(descriptor: MessageDescriptor): string
+  export function t(descriptor: MacroMessageDescriptor): string
 
   /**
    * Translates a template string using the global I18n instance
@@ -76,7 +90,7 @@ declare module "@lingui/macro" {
    */
   export function t(i18n: I18n): {
     (literals: TemplateStringsArray, ...placeholders: any[]): string
-    (descriptor: MessageDescriptor): string
+    (descriptor: MacroMessageDescriptor): string
   }
 
   export type UnderscoreDigit<T = string> = { [digit: string]: T }
@@ -177,7 +191,7 @@ declare module "@lingui/macro" {
    * @param descriptor The message descriptor
    */
   export function defineMessage(
-    descriptor: MessageDescriptor
+    descriptor: MacroMessageDescriptor
   ): MessageDescriptor
 
   export type ChoiceProps = {


### PR DESCRIPTION
# Description

https://github.com/lingui/js-lingui/discussions/1479#discussioncomment-5443272

Historically, MessageDescriptor was used in macro and in the underlying runtime functions. Because for macro it wasn't required to specify all properties for MessageDescriptor they all was marked as optional. 

Since we have now more clarified typings for macro which have it's own MessageDescriptor type we can make core's MessageDescriptor is more strict and reflecting real runtime structure. 

MessageDescriptor is returned from defineMessage macro or used in i18n._ methods. They both always returns and requires id to be set. 

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
