### PR TITLE
fix(po-formatter): save explicit id flag in comments instead of flags

### DIFF
--- a/examples/js/src/locale/cs/messages.po
+++ b/examples/js/src/locale/cs/messages.po
@@ -15,7 +15,7 @@ msgstr ""
 
 #. Title of example
 #: src/ids.js:24
-#, explicit-id
+#. js-lingui-explicit-id
 msgid "static"
 msgstr "Ukázka @lingui/core"
 
@@ -25,7 +25,7 @@ msgid "@lingui/core example"
 msgstr "Ukázka @lingui/core"
 
 #: src/ids.js:57
-#, explicit-id
+#. js-lingui-explicit-id
 msgid "lazy"
 msgstr "Chcete pokračovat? {yes}/{no}"
 
@@ -34,7 +34,7 @@ msgid "Do you want to proceed? {yes}/{no}"
 msgstr "Chcete pokračovat? {yes}/{no}"
 
 #: src/ids.js:34
-#, explicit-id
+#. js-lingui-explicit-id
 msgid "variables"
 msgstr "Ahoj {name}"
 
@@ -44,7 +44,7 @@ msgstr "Ahoj {name}"
 
 #. Disagreement
 #: src/ids.js:15
-#, explicit-id
+#. js-lingui-explicit-id
 msgid "common.no"
 msgstr "Ne"
 
@@ -54,7 +54,7 @@ msgid "No"
 msgstr "Ne"
 
 #: src/ids.js:43
-#, explicit-id
+#. js-lingui-explicit-id
 msgid "plural"
 msgstr "{value, plural, one {# láhev} few {# láhve} other {# láhví}} visí na stěně"
 
@@ -64,7 +64,7 @@ msgstr "{value, plural, one {# láhev} few {# láhve} other {# láhví}} visí n
 
 #. Agreement
 #: src/ids.js:10
-#, explicit-id
+#. js-lingui-explicit-id
 msgid "common.yes"
 msgstr "Ano"
 

--- a/examples/js/src/locale/en/messages.po
+++ b/examples/js/src/locale/en/messages.po
@@ -15,7 +15,7 @@ msgstr ""
 
 #. Title of example
 #: src/ids.js:24
-#, explicit-id
+#. js-lingui-explicit-id
 msgid "static"
 msgstr "@lingui/core example"
 
@@ -25,7 +25,7 @@ msgid "@lingui/core example"
 msgstr ""
 
 #: src/ids.js:57
-#, explicit-id
+#. js-lingui-explicit-id
 msgid "lazy"
 msgstr "Do you want to proceed? {yes}/{no}"
 
@@ -34,7 +34,7 @@ msgid "Do you want to proceed? {yes}/{no}"
 msgstr ""
 
 #: src/ids.js:34
-#, explicit-id
+#. js-lingui-explicit-id
 msgid "variables"
 msgstr "Hello {name}"
 
@@ -44,7 +44,7 @@ msgstr ""
 
 #. Disagreement
 #: src/ids.js:15
-#, explicit-id
+#. js-lingui-explicit-id
 msgid "common.no"
 msgstr "No"
 
@@ -54,7 +54,7 @@ msgid "No"
 msgstr ""
 
 #: src/ids.js:43
-#, explicit-id
+#. js-lingui-explicit-id
 msgid "plural"
 msgstr "There are {value, plural, one {# bottle} other {# bottles}} hanging on the wall"
 
@@ -64,7 +64,7 @@ msgstr ""
 
 #. Agreement
 #: src/ids.js:10
-#, explicit-id
+#. js-lingui-explicit-id
 msgid "common.yes"
 msgstr "Yes"
 

--- a/packages/cli/src/api/__snapshots__/catalog.test.ts.snap
+++ b/packages/cli/src/api/__snapshots__/catalog.test.ts.snap
@@ -215,12 +215,12 @@ exports[`Catalog make should collect and write catalogs 2`] = `
 {
   cs: {
     Component A: {
-      comments: [],
+      comments: [
+        js-lingui-explicit-id,
+      ],
       context: null,
       extra: {
-        flags: [
-          explicit-id,
-        ],
+        flags: [],
         translatorComments: [],
       },
       obsolete: false,
@@ -237,12 +237,11 @@ exports[`Catalog make should collect and write catalogs 2`] = `
         Comment A,
         Comment A again,
         Hello comment,
+        js-lingui-explicit-id,
       ],
       context: null,
       extra: {
-        flags: [
-          explicit-id,
-        ],
+        flags: [],
         translatorComments: [],
       },
       obsolete: false,
@@ -263,12 +262,12 @@ exports[`Catalog make should collect and write catalogs 2`] = `
       translation: ,
     },
     custom.id: {
-      comments: [],
+      comments: [
+        js-lingui-explicit-id,
+      ],
       context: null,
       extra: {
-        flags: [
-          explicit-id,
-        ],
+        flags: [],
         translatorComments: [],
       },
       obsolete: false,
@@ -283,12 +282,12 @@ exports[`Catalog make should collect and write catalogs 2`] = `
   },
   en: {
     Component A: {
-      comments: [],
+      comments: [
+        js-lingui-explicit-id,
+      ],
       context: null,
       extra: {
-        flags: [
-          explicit-id,
-        ],
+        flags: [],
         translatorComments: [],
       },
       obsolete: false,
@@ -305,12 +304,11 @@ exports[`Catalog make should collect and write catalogs 2`] = `
         Comment A,
         Comment A again,
         Hello comment,
+        js-lingui-explicit-id,
       ],
       context: null,
       extra: {
-        flags: [
-          explicit-id,
-        ],
+        flags: [],
         translatorComments: [],
       },
       obsolete: false,
@@ -331,12 +329,12 @@ exports[`Catalog make should collect and write catalogs 2`] = `
       translation: ,
     },
     custom.id: {
-      comments: [],
+      comments: [
+        js-lingui-explicit-id,
+      ],
       context: null,
       extra: {
-        flags: [
-          explicit-id,
-        ],
+        flags: [],
         translatorComments: [],
       },
       obsolete: false,
@@ -389,12 +387,12 @@ exports[`Catalog make should merge with existing catalogs 2`] = `
 {
   cs: {
     Component A: {
-      comments: [],
+      comments: [
+        js-lingui-explicit-id,
+      ],
       context: null,
       extra: {
-        flags: [
-          explicit-id,
-        ],
+        flags: [],
         translatorComments: [],
       },
       obsolete: false,
@@ -407,12 +405,12 @@ exports[`Catalog make should merge with existing catalogs 2`] = `
       translation: ,
     },
     Component B: {
-      comments: [],
+      comments: [
+        js-lingui-explicit-id,
+      ],
       context: null,
       extra: {
-        flags: [
-          explicit-id,
-        ],
+        flags: [],
         translatorComments: [],
       },
       obsolete: false,
@@ -429,12 +427,11 @@ exports[`Catalog make should merge with existing catalogs 2`] = `
         Comment A,
         Comment A again,
         Hello comment,
+        js-lingui-explicit-id,
       ],
       context: null,
       extra: {
-        flags: [
-          explicit-id,
-        ],
+        flags: [],
         translatorComments: [],
       },
       obsolete: false,
@@ -455,12 +452,12 @@ exports[`Catalog make should merge with existing catalogs 2`] = `
       translation: ,
     },
     custom.id: {
-      comments: [],
+      comments: [
+        js-lingui-explicit-id,
+      ],
       context: null,
       extra: {
-        flags: [
-          explicit-id,
-        ],
+        flags: [],
         translatorComments: [],
       },
       obsolete: false,
@@ -487,12 +484,12 @@ exports[`Catalog make should merge with existing catalogs 2`] = `
   },
   en: {
     Component A: {
-      comments: [],
+      comments: [
+        js-lingui-explicit-id,
+      ],
       context: null,
       extra: {
-        flags: [
-          explicit-id,
-        ],
+        flags: [],
         translatorComments: [],
       },
       obsolete: false,
@@ -505,12 +502,12 @@ exports[`Catalog make should merge with existing catalogs 2`] = `
       translation: ,
     },
     Component B: {
-      comments: [],
+      comments: [
+        js-lingui-explicit-id,
+      ],
       context: null,
       extra: {
-        flags: [
-          explicit-id,
-        ],
+        flags: [],
         translatorComments: [],
       },
       obsolete: false,
@@ -527,12 +524,11 @@ exports[`Catalog make should merge with existing catalogs 2`] = `
         Comment A,
         Comment A again,
         Hello comment,
+        js-lingui-explicit-id,
       ],
       context: null,
       extra: {
-        flags: [
-          explicit-id,
-        ],
+        flags: [],
         translatorComments: [],
       },
       obsolete: false,
@@ -553,12 +549,12 @@ exports[`Catalog make should merge with existing catalogs 2`] = `
       translation: ,
     },
     custom.id: {
-      comments: [],
+      comments: [
+        js-lingui-explicit-id,
+      ],
       context: null,
       extra: {
-        flags: [
-          explicit-id,
-        ],
+        flags: [],
         translatorComments: [],
       },
       obsolete: false,
@@ -598,12 +594,12 @@ exports[`Catalog make should only update the specified locale 2`] = `
   cs: null,
   en: {
     Component A: {
-      comments: [],
+      comments: [
+        js-lingui-explicit-id,
+      ],
       context: null,
       extra: {
-        flags: [
-          explicit-id,
-        ],
+        flags: [],
         translatorComments: [],
       },
       obsolete: false,
@@ -620,12 +616,11 @@ exports[`Catalog make should only update the specified locale 2`] = `
         Comment A,
         Comment A again,
         Hello comment,
+        js-lingui-explicit-id,
       ],
       context: null,
       extra: {
-        flags: [
-          explicit-id,
-        ],
+        flags: [],
         translatorComments: [],
       },
       obsolete: false,
@@ -646,12 +641,12 @@ exports[`Catalog make should only update the specified locale 2`] = `
       translation: ,
     },
     custom.id: {
-      comments: [],
+      comments: [
+        js-lingui-explicit-id,
+      ],
       context: null,
       extra: {
-        flags: [
-          explicit-id,
-        ],
+        flags: [],
         translatorComments: [],
       },
       obsolete: false,
@@ -672,12 +667,12 @@ exports[`Catalog makeTemplate should collect and write a template 1`] = `null`;
 exports[`Catalog makeTemplate should collect and write a template 2`] = `
 {
   Component A: {
-    comments: [],
+    comments: [
+      js-lingui-explicit-id,
+    ],
     context: null,
     extra: {
-      flags: [
-        explicit-id,
-      ],
+      flags: [],
       translatorComments: [],
     },
     obsolete: false,
@@ -694,12 +689,11 @@ exports[`Catalog makeTemplate should collect and write a template 2`] = `
       Comment A,
       Comment A again,
       Hello comment,
+      js-lingui-explicit-id,
     ],
     context: null,
     extra: {
-      flags: [
-        explicit-id,
-      ],
+      flags: [],
       translatorComments: [],
     },
     obsolete: false,
@@ -720,12 +714,12 @@ exports[`Catalog makeTemplate should collect and write a template 2`] = `
     translation: ,
   },
   custom.id: {
-    comments: [],
+    comments: [
+      js-lingui-explicit-id,
+    ],
     context: null,
     extra: {
-      flags: [
-        explicit-id,
-      ],
+      flags: [],
       translatorComments: [],
     },
     obsolete: false,
@@ -743,12 +737,12 @@ exports[`Catalog makeTemplate should collect and write a template 2`] = `
 exports[`Catalog read should read file in given format 1`] = `
 {
   obsolete: {
-    comments: [],
+    comments: [
+      js-lingui-explicit-id,
+    ],
     context: null,
     extra: {
-      flags: [
-        explicit-id,
-      ],
+      flags: [],
       translatorComments: [],
     },
     obsolete: true,
@@ -756,12 +750,12 @@ exports[`Catalog read should read file in given format 1`] = `
     translation: Is marked as obsolete,
   },
   static: {
-    comments: [],
+    comments: [
+      js-lingui-explicit-id,
+    ],
     context: null,
     extra: {
-      flags: [
-        explicit-id,
-      ],
+      flags: [],
       translatorComments: [],
     },
     obsolete: false,
@@ -769,12 +763,12 @@ exports[`Catalog read should read file in given format 1`] = `
     translation: Static message,
   },
   veryLongString: {
-    comments: [],
+    comments: [
+      js-lingui-explicit-id,
+    ],
     context: null,
     extra: {
-      flags: [
-        explicit-id,
-      ],
+      flags: [],
       translatorComments: [],
     },
     obsolete: false,
@@ -782,12 +776,12 @@ exports[`Catalog read should read file in given format 1`] = `
     translation: One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections. The bedding was hardly able to cover it and seemed ready to slide off any moment. His many legs, pitifully thin compared with the size of the rest of him, waved about helplessly as he looked. "What's happened to me?" he thought. It wasn't a dream. His room, a proper human,
   },
   withComments: {
-    comments: [],
+    comments: [
+      js-lingui-explicit-id,
+    ],
     context: null,
     extra: {
-      flags: [
-        explicit-id,
-      ],
+      flags: [],
       translatorComments: [
         Translator comment,
         This one might come from developer,
@@ -800,40 +794,24 @@ exports[`Catalog read should read file in given format 1`] = `
   withDescription: {
     comments: [
       Description is comment from developers to translators,
+      js-lingui-explicit-id,
     ],
     context: null,
     extra: {
-      flags: [
-        explicit-id,
-      ],
+      flags: [],
       translatorComments: [],
     },
     obsolete: false,
     origin: [],
     translation: Message with description,
   },
-  withFlags: {
-    comments: [],
-    context: null,
-    extra: {
-      flags: [
-        fuzzy,
-        otherFlag,
-        explicit-id,
-      ],
-      translatorComments: [],
-    },
-    obsolete: false,
-    origin: [],
-    translation: Keeps any flags that are defined,
-  },
   withMultipleOrigins: {
-    comments: [],
+    comments: [
+      js-lingui-explicit-id,
+    ],
     context: null,
     extra: {
-      flags: [
-        explicit-id,
-      ],
+      flags: [],
       translatorComments: [],
     },
     obsolete: false,
@@ -850,12 +828,12 @@ exports[`Catalog read should read file in given format 1`] = `
     translation: Message with multiple origin,
   },
   withOrigin: {
-    comments: [],
+    comments: [
+      js-lingui-explicit-id,
+    ],
     context: null,
     extra: {
-      flags: [
-        explicit-id,
-      ],
+      flags: [],
       translatorComments: [],
     },
     obsolete: false,
@@ -880,6 +858,22 @@ exports[`Catalog read should read file in given format 1`] = `
     obsolete: false,
     origin: [],
     translation: Translation for: Message with default-hash id,
+  },
+  xLTujh: {
+    comments: [],
+    context: null,
+    extra: {
+      flags: [
+        fuzzy,
+        otherFlag,
+        explicit-id,
+      ],
+      translatorComments: [],
+    },
+    message: withFlags,
+    obsolete: false,
+    origin: [],
+    translation: Keeps any flags that are defined,
   },
 }
 `;

--- a/packages/cli/src/api/fixtures/messages.po
+++ b/packages/cli/src/api/fixtures/messages.po
@@ -13,37 +13,37 @@ msgstr ""
 "X-Generator: @lingui/cli\n"
 "Plural-Forms: nplurals=0\n"
 
-#, explicit-id
+#. js-lingui-explicit-id
 msgid "static"
 msgstr "Static message"
 
 #: src/App.js:4
-#, explicit-id
+#. js-lingui-explicit-id
 msgid "withOrigin"
 msgstr "Message with origin"
 
 #: src/App.js:4
 #: src/Component.js:2
-#, explicit-id
+#. js-lingui-explicit-id
 msgid "withMultipleOrigins"
 msgstr "Message with multiple origin"
 
 #. Description is comment from developers to translators
-#, explicit-id
+#. js-lingui-explicit-id
 msgid "withDescription"
 msgstr "Message with description"
 
 # Translator comment
 # This one might come from developer
-#, explicit-id
+#. js-lingui-explicit-id
 msgid "withComments"
 msgstr "Support translator comments separately"
 
-#, explicit-id
+#. js-lingui-explicit-id
 msgid "veryLongString"
 msgstr "One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections. The bedding was hardly able to cover it and seemed ready to slide off any moment. His many legs, pitifully thin compared with the size of the rest of him, waved about helplessly as he looked. \"What's happened to me?\" he thought. It wasn't a dream. His room, a proper human"
 
-#, explicit-id
+#. js-lingui-explicit-id
 #~ msgid "obsolete"
 #~ msgstr "Is marked as obsolete"
 

--- a/packages/cli/test/extract-po-format/expected/en.po
+++ b/packages/cli/test/extract-po-format/expected/en.po
@@ -30,12 +30,12 @@ msgstr "Hello world"
 msgid "Message in descriptor"
 msgstr "Message in descriptor"
 
+#. js-lingui-explicit-id
 #: fixtures/file-b.tsx:15
-#, explicit-id
 msgid "jsx.custom.id"
 msgstr "This JSX element has custom id"
 
+#. js-lingui-explicit-id
 #: fixtures/file-a.ts:11
-#, explicit-id
 msgid "custom.id"
 msgstr "This message has custom id"

--- a/packages/cli/test/extract-po-format/expected/pl.po
+++ b/packages/cli/test/extract-po-format/expected/pl.po
@@ -30,12 +30,12 @@ msgstr ""
 msgid "Message in descriptor"
 msgstr ""
 
+#. js-lingui-explicit-id
 #: fixtures/file-b.tsx:15
-#, explicit-id
 msgid "jsx.custom.id"
 msgstr ""
 
+#. js-lingui-explicit-id
 #: fixtures/file-a.ts:11
-#, explicit-id
 msgid "custom.id"
 msgstr ""

--- a/packages/cli/test/extract-template-po-format/expected/messages.pot
+++ b/packages/cli/test/extract-template-po-format/expected/messages.pot
@@ -29,12 +29,12 @@ msgstr ""
 msgid "Message in descriptor"
 msgstr ""
 
+#. js-lingui-explicit-id
 #: fixtures/file-b.tsx:15
-#, explicit-id
 msgid "jsx.custom.id"
 msgstr ""
 
+#. js-lingui-explicit-id
 #: fixtures/file-a.ts:11
-#, explicit-id
 msgid "custom.id"
 msgstr ""

--- a/packages/format-po-gettext/src/__snapshots__/po-gettext.test.ts.snap
+++ b/packages/format-po-gettext/src/__snapshots__/po-gettext.test.ts.snap
@@ -27,12 +27,12 @@ exports[`po-gettext format convertPluralsToIco handle correctly locales with 4-l
     translation: ,
   },
   message_with_id: {
-    comments: [],
+    comments: [
+      js-lingui-explicit-id,
+    ],
     context: null,
     extra: {
-      flags: [
-        explicit-id,
-      ],
+      flags: [],
       translatorComments: [],
     },
     obsolete: false,
@@ -42,12 +42,11 @@ exports[`po-gettext format convertPluralsToIco handle correctly locales with 4-l
   message_with_id_but_without_translation: {
     comments: [
       Comment made by the developers.,
+      js-lingui-explicit-id,
     ],
     context: null,
     extra: {
-      flags: [
-        explicit-id,
-      ],
+      flags: [],
       translatorComments: [],
     },
     obsolete: false,
@@ -73,16 +72,16 @@ msgstr ""
 "Language-Team: \\n"
 "Plural-Forms: \\n"
 
+#. js-lingui-explicit-id
 #. js-lingui:pluralize_on=count
-#, explicit-id
 msgid "message_with_id_and_octothorpe"
 msgid_plural "message_with_id_and_octothorpe_plural"
 msgstr[0] "Singular"
 msgstr[1] "Number is #"
 
 #. This is a comment by the developers about how the content must be localized.
+#. js-lingui-explicit-id
 #. js-lingui:pluralize_on=someCount
-#, explicit-id
 msgid "message_with_id"
 msgid_plural "message_with_id_plural"
 msgstr[0] "Singular case with id"
@@ -94,8 +93,8 @@ msgid_plural "Case number {anotherCount}"
 msgstr[0] "Singular case"
 msgstr[1] "Case number {anotherCount}"
 
+#. js-lingui-explicit-id
 #. js-lingui:pluralize_on=count
-#, explicit-id
 msgid "message_with_id_but_without_translation"
 msgid_plural "message_with_id_but_without_translation_plural"
 msgstr[0] ""
@@ -136,12 +135,12 @@ exports[`po-gettext format should convert gettext plurals to ICU plural messages
     translation: ,
   },
   message_with_id: {
-    comments: [],
+    comments: [
+      js-lingui-explicit-id,
+    ],
     context: null,
     extra: {
-      flags: [
-        explicit-id,
-      ],
+      flags: [],
       translatorComments: [],
     },
     obsolete: false,
@@ -151,12 +150,11 @@ exports[`po-gettext format should convert gettext plurals to ICU plural messages
   message_with_id_but_without_translation: {
     comments: [
       Comment made by the developers.,
+      js-lingui-explicit-id,
     ],
     context: null,
     extra: {
-      flags: [
-        explicit-id,
-      ],
+      flags: [],
       translatorComments: [],
     },
     obsolete: false,

--- a/packages/format-po-gettext/src/fixtures/messages_plural-4-letter.po
+++ b/packages/format-po-gettext/src/fixtures/messages_plural-4-letter.po
@@ -8,7 +8,7 @@ msgstr ""
 "Language: en_CA\n"
 
 #. js-lingui:pluralize_on=someCount
-#, explicit-id
+#. js-lingui-explicit-id
 msgid "message_with_id"
 msgid_plural "message_with_id_plural"
 msgstr[0] "Singular case"
@@ -22,7 +22,7 @@ msgstr[1] "Case number {anotherCount}"
 
 #. Comment made by the developers.
 #. js-lingui:pluralize_on=count
-#, explicit-id
+#. js-lingui-explicit-id
 msgid "message_with_id_but_without_translation"
 msgid_plural "message_with_id_but_without_translation_plural"
 msgstr[0] ""

--- a/packages/format-po-gettext/src/fixtures/messages_plural.po
+++ b/packages/format-po-gettext/src/fixtures/messages_plural.po
@@ -8,7 +8,7 @@ msgstr ""
 "Language: en\n"
 
 #. js-lingui:pluralize_on=someCount
-#, explicit-id
+#. js-lingui-explicit-id
 msgid "message_with_id"
 msgid_plural "message_with_id_plural"
 msgstr[0] "Singular case"
@@ -22,7 +22,7 @@ msgstr[1] "Case number {anotherCount}"
 
 #. Comment made by the developers.
 #. js-lingui:pluralize_on=count
-#, explicit-id
+#. js-lingui-explicit-id
 msgid "message_with_id_but_without_translation"
 msgid_plural "message_with_id_but_without_translation_plural"
 msgstr[0] ""

--- a/packages/format-po-gettext/src/po-gettext.test.ts
+++ b/packages/format-po-gettext/src/po-gettext.test.ts
@@ -35,6 +35,7 @@ describe("po-gettext format", () => {
       message_with_id_and_octothorpe: {
         message: "{count, plural, one {Singular} other {Number is #}}",
         translation: "{count, plural, one {Singular} other {Number is #}}",
+        comments: ["js-lingui-explicit-id"],
       },
       message_with_id: {
         message:
@@ -44,6 +45,7 @@ describe("po-gettext format", () => {
           "{someCount, plural, one {Singular case with id} other {Case number {someCount} with id}}",
         comments: [
           "This is a comment by the developers about how the content must be localized.",
+          "js-lingui-explicit-id",
         ],
       },
       WGI12K: {
@@ -57,6 +59,7 @@ describe("po-gettext format", () => {
         message:
           "{count, plural, one {Singular with id but no translation} other {Plural {count} with empty id but no translation}}",
         translation: "",
+        comments: ["js-lingui-explicit-id"],
       },
       // Entry with automatic ID that generates empty msgstr[] lines
       xZCXAV: {

--- a/packages/format-po-gettext/src/po-gettext.ts
+++ b/packages/format-po-gettext/src/po-gettext.ts
@@ -272,7 +272,9 @@ export function formatter(
       const po = PO.parse(formatter.serialize(catalog, ctx) as string)
 
       po.items = po.items.map((item) => {
-        const isGeneratedId = !item.flags["explicit-id"]
+        const isGeneratedId = !item.extractedComments.includes(
+          "js-lingui-explicit-id"
+        )
         const id = isGeneratedId
           ? generateMessageId(item.msgid, item.msgctxt)
           : item.msgid

--- a/packages/format-po/src/__snapshots__/po.test.ts.snap
+++ b/packages/format-po/src/__snapshots__/po.test.ts.snap
@@ -6,12 +6,11 @@ exports[`pofile format should correct badly used comments 1`] = `
     comments: [
       Single description only,
       Second description?,
+      js-lingui-explicit-id,
     ],
     context: null,
     extra: {
-      flags: [
-        explicit-id,
-      ],
+      flags: [],
       translatorComments: [
         Translator comment,
       ],
@@ -25,12 +24,11 @@ exports[`pofile format should correct badly used comments 1`] = `
       First description,
       Second comment,
       Third comment,
+      js-lingui-explicit-id,
     ],
     context: null,
     extra: {
-      flags: [
-        explicit-id,
-      ],
+      flags: [],
       translatorComments: [],
     },
     obsolete: false,
@@ -77,12 +75,12 @@ msgstr ""
 exports[`pofile format should read catalog in pofile format 1`] = `
 {
   obsolete: {
-    comments: [],
+    comments: [
+      js-lingui-explicit-id,
+    ],
     context: null,
     extra: {
-      flags: [
-        explicit-id,
-      ],
+      flags: [],
       translatorComments: [],
     },
     obsolete: true,
@@ -90,12 +88,12 @@ exports[`pofile format should read catalog in pofile format 1`] = `
     translation: Is marked as obsolete,
   },
   static: {
-    comments: [],
+    comments: [
+      js-lingui-explicit-id,
+    ],
     context: null,
     extra: {
-      flags: [
-        explicit-id,
-      ],
+      flags: [],
       translatorComments: [],
     },
     obsolete: false,
@@ -103,12 +101,12 @@ exports[`pofile format should read catalog in pofile format 1`] = `
     translation: Static message,
   },
   veryLongString: {
-    comments: [],
+    comments: [
+      js-lingui-explicit-id,
+    ],
     context: null,
     extra: {
-      flags: [
-        explicit-id,
-      ],
+      flags: [],
       translatorComments: [],
     },
     obsolete: false,
@@ -116,12 +114,12 @@ exports[`pofile format should read catalog in pofile format 1`] = `
     translation: One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections. The bedding was hardly able to cover it and seemed ready to slide off any moment. His many legs, pitifully thin compared with the size of the rest of him, waved about helplessly as he looked. "What's happened to me?" he thought. It wasn't a dream. His room, a proper human,
   },
   withComments: {
-    comments: [],
+    comments: [
+      js-lingui-explicit-id,
+    ],
     context: null,
     extra: {
-      flags: [
-        explicit-id,
-      ],
+      flags: [],
       translatorComments: [
         Translator comment,
         This one might come from developer,
@@ -134,40 +132,24 @@ exports[`pofile format should read catalog in pofile format 1`] = `
   withDescription: {
     comments: [
       Description is comment from developers to translators,
+      js-lingui-explicit-id,
     ],
     context: null,
     extra: {
-      flags: [
-        explicit-id,
-      ],
+      flags: [],
       translatorComments: [],
     },
     obsolete: false,
     origin: [],
     translation: Message with description,
   },
-  withFlags: {
-    comments: [],
-    context: null,
-    extra: {
-      flags: [
-        fuzzy,
-        otherFlag,
-        explicit-id,
-      ],
-      translatorComments: [],
-    },
-    obsolete: false,
-    origin: [],
-    translation: Keeps any flags that are defined,
-  },
   withMultipleOrigins: {
-    comments: [],
+    comments: [
+      js-lingui-explicit-id,
+    ],
     context: null,
     extra: {
-      flags: [
-        explicit-id,
-      ],
+      flags: [],
       translatorComments: [],
     },
     obsolete: false,
@@ -184,12 +166,12 @@ exports[`pofile format should read catalog in pofile format 1`] = `
     translation: Message with multiple origin,
   },
   withOrigin: {
-    comments: [],
+    comments: [
+      js-lingui-explicit-id,
+    ],
     context: null,
     extra: {
-      flags: [
-        explicit-id,
-      ],
+      flags: [],
       translatorComments: [],
     },
     obsolete: false,
@@ -215,6 +197,22 @@ exports[`pofile format should read catalog in pofile format 1`] = `
     origin: [],
     translation: Translation for: Message with default-hash id,
   },
+  xLTujh: {
+    comments: [],
+    context: null,
+    extra: {
+      flags: [
+        fuzzy,
+        otherFlag,
+        explicit-id,
+      ],
+      translatorComments: [],
+    },
+    message: withFlags,
+    obsolete: false,
+    origin: [],
+    translation: Keeps any flags that are defined,
+  },
 }
 `;
 
@@ -228,16 +226,16 @@ msgstr ""
 "X-Generator: @lingui/cli\\n"
 "Language: en\\n"
 
-#, explicit-id
+#. js-lingui-explicit-id
 msgid "static"
 msgstr "Static message"
 
+#. js-lingui-explicit-id
 #: src/App.js:4
-#, explicit-id
 msgid "withOrigin"
 msgstr "Message with origin"
 
-#, explicit-id
+#. js-lingui-explicit-id
 msgctxt "my context"
 msgid "withContext"
 msgstr "Message with context"
@@ -246,32 +244,33 @@ msgctxt "my context"
 msgid "with generated id"
 msgstr ""
 
+#. js-lingui-explicit-id
 #: src/App.js:4
 #: src/Component.js:2
-#, explicit-id
 msgid "withMultipleOrigins"
 msgstr "Message with multiple origin"
 
 #. Description is comment from developers to translators
-#, explicit-id
+#. js-lingui-explicit-id
 msgid "withDescription"
 msgstr "Message with description"
 
 # Translator comment
 # This one might come from developer
-#, explicit-id
+#. js-lingui-explicit-id
 msgid "withComments"
 msgstr "Support translator comments separately"
 
-#, explicit-id
+#. js-lingui-explicit-id
 #~ msgid "obsolete"
 #~ msgstr "Obsolete message"
 
-#, fuzzy,otherFlag,explicit-id
+#. js-lingui-explicit-id
+#, fuzzy,otherFlag
 msgid "withFlags"
 msgstr "Keeps any flags that are defined"
 
-#, explicit-id
+#. js-lingui-explicit-id
 msgid "veryLongString"
 msgstr "One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections. The bedding was hardly able to cover it and seemed ready to slide off any moment. His many legs, pitifully thin compared with the size of the rest of him, waved about helplessly as he looked. \\"What's happened to me?\\" he thought. It wasn't a dream. His room, a proper human"
 

--- a/packages/format-po/src/fixtures/messages.po
+++ b/packages/format-po/src/fixtures/messages.po
@@ -13,37 +13,37 @@ msgstr ""
 "X-Generator: @lingui/cli\n"
 "Plural-Forms: nplurals=0\n"
 
-#, explicit-id
+#. js-lingui-explicit-id
 msgid "static"
 msgstr "Static message"
 
 #: src/App.js:4
-#, explicit-id
+#. js-lingui-explicit-id
 msgid "withOrigin"
 msgstr "Message with origin"
 
 #: src/App.js:4
 #: src/Component.js:2
-#, explicit-id
+#. js-lingui-explicit-id
 msgid "withMultipleOrigins"
 msgstr "Message with multiple origin"
 
 #. Description is comment from developers to translators
-#, explicit-id
+#. js-lingui-explicit-id
 msgid "withDescription"
 msgstr "Message with description"
 
 # Translator comment
 # This one might come from developer
-#, explicit-id
+#. js-lingui-explicit-id
 msgid "withComments"
 msgstr "Support translator comments separately"
 
-#, explicit-id
+#. js-lingui-explicit-id
 msgid "veryLongString"
 msgstr "One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections. The bedding was hardly able to cover it and seemed ready to slide off any moment. His many legs, pitifully thin compared with the size of the rest of him, waved about helplessly as he looked. \"What's happened to me?\" he thought. It wasn't a dream. His room, a proper human"
 
-#, explicit-id
+#. js-lingui-explicit-id
 #~ msgid "obsolete"
 #~ msgstr "Is marked as obsolete"
 

--- a/packages/format-po/src/po.test.ts
+++ b/packages/format-po/src/po.test.ts
@@ -164,14 +164,14 @@ describe("pofile format", () => {
       #. First description
       #. Second comment
       #. Third comment
-      #, explicit-id
+      #. js-lingui-explicit-id
       msgid "withMultipleDescriptions"
       msgstr "Extra comments are separated from the first description line"
 
       # Translator comment
       #. Single description only
       #. Second description?
-      #, explicit-id
+      #. js-lingui-explicit-id
       msgid "withDescriptionAndComments"
       msgstr "Second description joins translator comments"
     `
@@ -236,18 +236,18 @@ describe("pofile format", () => {
       "X-Generator: @lingui/cli\\n"
       "Language: en\\n"
 
-      #, explicit-id
+      #. js-lingui-explicit-id
       msgid "static"
       msgstr "Static message"
 
+      #. js-lingui-explicit-id
       #: src/App.js
-      #, explicit-id
       msgid "withOrigin"
       msgstr "Message with origin"
 
+      #. js-lingui-explicit-id
       #: src/App.js
       #: src/Component.js
-      #, explicit-id
       msgid "withMultipleOrigins"
       msgstr "Message with multiple origin"
 
@@ -283,18 +283,18 @@ describe("pofile format", () => {
       "X-Generator: @lingui/cli\\n"
       "Language: en\\n"
 
-      #, explicit-id
+      #. js-lingui-explicit-id
       msgid "static"
       msgstr "Static message"
 
+      #. js-lingui-explicit-id
       #: src/App.js
-      #, explicit-id
       msgid "withOrigin"
       msgstr "Message with origin"
 
+      #. js-lingui-explicit-id
       #: src/App.js
       #: src/Component.js
-      #, explicit-id
       msgid "withMultipleOrigins"
       msgstr "Message with multiple origin"
 

--- a/packages/format-po/src/po.ts
+++ b/packages/format-po/src/po.ts
@@ -60,7 +60,7 @@ function getCreateHeaders(language: string): PO["headers"] {
   }
 }
 
-const EXPLICIT_ID_FLAG = "explicit-id"
+const EXPLICIT_ID_FLAG = "js-lingui-explicit-id"
 
 const serialize = (catalog: CatalogType, options: PoFormatterOptions) => {
   return Object.keys(catalog).map((id) => {
@@ -90,7 +90,9 @@ const serialize = (catalog: CatalogType, options: PoFormatterOptions) => {
         }
       }
     } else {
-      item.flags[EXPLICIT_ID_FLAG] = true
+      if (!item.extractedComments.includes(EXPLICIT_ID_FLAG)) {
+        item.extractedComments.push(EXPLICIT_ID_FLAG)
+      }
       item.msgid = id
     }
 
@@ -131,7 +133,7 @@ function deserialize(items: POItem[]): CatalogType {
     let id = item.msgid
 
     // if generated id, recreate it
-    if (!item.flags[EXPLICIT_ID_FLAG]) {
+    if (!item.extractedComments.includes(EXPLICIT_ID_FLAG)) {
       id = generateMessageId(item.msgid, item.msgctxt)
       message.message = item.msgid
     }


### PR DESCRIPTION
# Description

fixes https://github.com/lingui/js-lingui/issues/1573