### PR TITLE
fix: require should use cjs instead of mjs

### DIFF
--- a/packages/detect-locale/package.json
+++ b/packages/detect-locale/package.json
@@ -35,7 +35,7 @@
   },
   "exports": {
     ".": {
-      "require": "./dist/index.mjs",
+      "require": "./dist/index.cjs",
       "import": "./dist/index.mjs"
     },
     "./package.json": "./package.json"


### PR DESCRIPTION
# Description

this is breaking our jest as the default jest resolver ([`resolve.exports`](https://github.com/lukeed/resolve.exports/) with default conditions (`['require', 'default' ...]`)) will try to pull in asset listed in the package, and the mapping on `require` for detect-locale was pointing to `mjs` instead of `cjs`.

I have double checked and this seems to be the only one across all lingui packages ;)

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Fixes https://github.com/lingui/js-lingui/issues/1575

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
