### PR TITLE
docs: add hook usage description to update `t` content on language change

### DIFF
--- a/website/docs/tutorials/react-patterns.md
+++ b/website/docs/tutorials/react-patterns.md
@@ -113,6 +113,20 @@ export default function ImageWithCaption() {
 }
 ```
 
+:::tip
+In order for the translation to update on language change where the `t` macro is used, call `useLingui()` in your component:
+
+```jsx
+import { useLingui } from "@lingui/react"
+import { t } from "@lingui/macro"
+
+export default function ImageWithCaption() {
+   useLingui()
+   return <img src="..." alt={t`Image caption`} />
+}
+```
+:::
+
 ## Translations outside React components
 
 Another common pattern is when you need to access translations outside React components, for example inside `redux-saga`. You can use [`t`](/docs/ref/macro.md#t) macro outside React context as usual:


### PR DESCRIPTION
# Description

Add a tip in the documentation to warn users that they need to call `useLingui()` in order for the `t` macro to update on language change.

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
