### PR TITLE
fix(cli): allow import from ESM context, add tests

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,31 +18,21 @@
     "name": "Tomáš Ehrlich",
     "email": "tomas.ehrlich@gmail.com"
   },
-  "main": "./dist/lingui.js",
   "bin": {
     "lingui": "./dist/lingui.js"
   },
   "exports": {
-    ".": {
-      "require": "./dist/lingui.js"
-    },
     "./api": {
-      "require": {
-        "types": "./dist/api/index.d.ts",
-        "default": "./dist/api/index.js"
-      }
+      "types": "./dist/api/index.d.ts",
+      "default": "./dist/api/index.js"
     },
     "./api/extractors/babel": {
-      "require": {
-        "types": "./dist/api/extractors/babel.d.ts",
-        "default": "./dist/api/extractors/babel.js"
-      }
+      "types": "./dist/api/extractors/babel.d.ts",
+      "default": "./dist/api/extractors/babel.js"
     },
     "./api/extractors/typescript": {
-      "require": {
-        "types": "./dist/api/extractors/typescript.d.ts",
-        "default": "./dist/api/extractors/typescript.js"
-      }
+      "types": "./dist/api/extractors/typescript.d.ts",
+      "default": "./dist/api/extractors/typescript.js"
     }
   },
   "scripts": {

--- a/test/cli-version/index.js
+++ b/test/cli-version/index.js
@@ -1,0 +1,5 @@
+import { execa } from "execa"
+import assert from "node:assert"
+
+const { stdout } = await execa("lingui", ["--version"])
+assert.match(stdout, /^\d\.\d\.\d/)

--- a/test/cli-version/package.json
+++ b/test/cli-version/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "cli-version",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test:e2e": "node index.js"
+  },
+  "dependencies": {
+    "@lingui/cli": "workspace:*",
+    "@lingui/core": "workspace:*",
+    "execa": "^7.1.1"
+  }
+}

--- a/test/node-api-esm/index.js
+++ b/test/node-api-esm/index.js
@@ -1,0 +1,8 @@
+import assert from "node:assert"
+
+assert(await import("@lingui/cli/api"))
+
+assert(await import("@lingui/cli/api/extractors/typescript"))
+assert(await import("@lingui/cli/api/extractors/babel"))
+
+assert(await import("@lingui/core"))

--- a/test/node-api-esm/package.json
+++ b/test/node-api-esm/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "node-api-esm",
+  "version": "1.0.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "test:e2e": "node index.js"
+  },
+  "dependencies": {
+    "@lingui/cli": "workspace:*",
+    "@lingui/core": "workspace:*"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5574,6 +5574,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cli-version@workspace:test/cli-version":
+  version: 0.0.0-use.local
+  resolution: "cli-version@workspace:test/cli-version"
+  dependencies:
+    "@lingui/cli": "workspace:*"
+    "@lingui/core": "workspace:*"
+    execa: ^7.1.1
+  languageName: unknown
+  linkType: soft
+
 "cli-width@npm:^3.0.0":
   version: 3.0.0
   resolution: "cli-width@npm:3.0.0"
@@ -7381,6 +7391,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"execa@npm:^7.1.1":
+  version: 7.1.1
+  resolution: "execa@npm:7.1.1"
+  dependencies:
+    cross-spawn: ^7.0.3
+    get-stream: ^6.0.1
+    human-signals: ^4.3.0
+    is-stream: ^3.0.0
+    merge-stream: ^2.0.0
+    npm-run-path: ^5.1.0
+    onetime: ^6.0.0
+    signal-exit: ^3.0.7
+    strip-final-newline: ^3.0.0
+  checksum: 21fa46fc69314ace4068cf820142bdde5b643a5d89831c2c9349479c1555bff137a291b8e749e7efca36535e4e0a8c772c11008ca2e84d2cbd6ca141a3c8f937
+  languageName: node
+  linkType: hard
+
 "exit@npm:^0.1.2":
   version: 0.1.2
   resolution: "exit@npm:0.1.2"
@@ -8319,6 +8346,13 @@ __metadata:
   version: 3.0.1
   resolution: "human-signals@npm:3.0.1"
   checksum: f252a7769c8094a5c9dc6772816bdb417b188820b04c8b42d0fc468e03a0ba905b1dd07afabe9385cc83504af1ccc2b985cd1e4aeeeb8e0029896c5af2e6f354
+  languageName: node
+  linkType: hard
+
+"human-signals@npm:^4.3.0":
+  version: 4.3.1
+  resolution: "human-signals@npm:4.3.1"
+  checksum: 6f12958df3f21b6fdaf02d90896c271df00636a31e2bbea05bddf817a35c66b38a6fdac5863e2df85bd52f34958997f1f50350ff97249e1dff8452865d5235d1
   languageName: node
   linkType: hard
 
@@ -10833,6 +10867,15 @@ __metadata:
   checksum: 2369986bb0881ccd9ef6bacdf39550e07e089a9c8ede1cbc5fc7712d8e2faa4d50da0e487e333d4125f8c7a616c730131d1091676c9d499af1d74560756b4a18
   languageName: node
   linkType: hard
+
+"node-api-esm@workspace:test/node-api-esm":
+  version: 0.0.0-use.local
+  resolution: "node-api-esm@workspace:test/node-api-esm"
+  dependencies:
+    "@lingui/cli": "workspace:*"
+    "@lingui/core": "workspace:*"
+  languageName: unknown
+  linkType: soft
 
 "node-api@workspace:test/node-api":
   version: 0.0.0-use.local


### PR DESCRIPTION
# Description

- Remove stricter `require` export condition to be able to import `@lingui/cli` from ESM context.  See conversation https://discord.com/channels/974702239358783608/974704045346394172/1097863445459783750
- Add tests for this case, as well for the `lingui --version` command


[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
