### PR TITLE
chore: import type testing APIs from `tsd-lite`

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "jest": "^29.4.3",
     "jest-environment-jsdom": "^29.4.3",
     "jest-environment-node-single-context": "^29.0.0",
-    "jest-runner-tsd": "^4.0.0",
+    "jest-runner-tsd": "^5.0.0",
     "lerna": "^6.5.1",
     "lint-staged": "^13.1.0",
     "memory-fs": "^0.5.0",

--- a/packages/conf/__typetests__/index.test-d.tsx
+++ b/packages/conf/__typetests__/index.test-d.tsx
@@ -4,7 +4,7 @@ import {
   FallbackLocales,
   LinguiConfig,
 } from "@lingui/conf"
-import { expectAssignable } from "tsd"
+import { expectAssignable } from "tsd-lite"
 
 // only required props
 expectAssignable<LinguiConfig>({
@@ -33,13 +33,13 @@ expectAssignable<LinguiConfig>({
     tsExperimentalDecorators: false,
   },
   fallbackLocales: {} as FallbackLocales,
-  format: "po",
+  format: "po" as const,
   formatOptions: { origins: true, lineNumbers: true },
   locales: [],
-  orderBy: "messageId",
+  orderBy: "messageId" as const,
   pseudoLocale: "",
   rootDir: ".",
-  runtimeConfigModule: ["@lingui/core", "i18n"],
+  runtimeConfigModule: ["@lingui/core", "i18n"] as [string, string],
   sourceLocale: "",
   service: { name: "", apiKey: "" },
 })
@@ -64,13 +64,13 @@ expectAssignable<LinguiConfig>({
 // runtimeConfigModule
 expectAssignable<LinguiConfig>({
   locales: ["en", "pl"],
-  runtimeConfigModule: ["./custom-i18n-config", "i18n"],
+  runtimeConfigModule: ["./custom-i18n-config", "i18n"] as [string, string],
 })
 
 expectAssignable<LinguiConfig>({
   locales: ["en", "pl"],
   runtimeConfigModule: {
-    i18n: ["./custom-config", "i18n"],
-    Trans: ["./custom-config", "Trans"],
+    i18n: ["./custom-config", "i18n"] as [string, string],
+    Trans: ["./custom-config", "Trans"] as [string, string],
   },
 })

--- a/packages/conf/package.json
+++ b/packages/conf/package.json
@@ -39,7 +39,7 @@
   ],
   "devDependencies": {
     "@lingui/jest-mocks": "*",
-    "tsd": "^0.26.1",
+    "tsd-lite": "^0.7.0",
     "unbuild": "^1.1.2"
   }
 }

--- a/packages/core/__typetests__/index.test-d.tsx
+++ b/packages/core/__typetests__/index.test-d.tsx
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { expectType } from "tsd"
+import { expectType } from "tsd-lite"
 import { i18n } from "@lingui/core"
 
 expectType<string>(i18n._("message.id"))

--- a/packages/format-csv/__typetests__/index.test-d.ts
+++ b/packages/format-csv/__typetests__/index.test-d.ts
@@ -1,5 +1,5 @@
 import { CatalogFormatter } from "@lingui/conf"
-import { expectAssignable } from "tsd"
+import { expectAssignable } from "tsd-lite"
 import { formatter } from "@lingui/format-csv"
 
 expectAssignable<CatalogFormatter>(formatter())

--- a/packages/format-csv/package.json
+++ b/packages/format-csv/package.json
@@ -42,7 +42,7 @@
     "papaparse": "^5.4.0"
   },
   "devDependencies": {
-    "tsd": "^0.28.0",
+    "tsd-lite": "^0.7.0",
     "unbuild": "^1.1.2"
   }
 }

--- a/packages/format-json/__typetests__/index.test-d.ts
+++ b/packages/format-json/__typetests__/index.test-d.ts
@@ -1,5 +1,5 @@
 import { CatalogFormatter } from "@lingui/conf"
-import { expectAssignable } from "tsd"
+import { expectAssignable } from "tsd-lite"
 import { formatter } from "@lingui/format-json"
 
 expectAssignable<CatalogFormatter>(formatter())

--- a/packages/format-json/package.json
+++ b/packages/format-json/package.json
@@ -42,7 +42,7 @@
     "ramda": "^0.28.0"
   },
   "devDependencies": {
-    "tsd": "^0.28.0",
+    "tsd-lite": "^0.7.0",
     "unbuild": "^1.1.2"
   }
 }

--- a/packages/format-po-gettext/__typetests__/index.test-d.ts
+++ b/packages/format-po-gettext/__typetests__/index.test-d.ts
@@ -1,5 +1,5 @@
 import { CatalogFormatter } from "@lingui/conf"
-import { expectAssignable } from "tsd"
+import { expectAssignable } from "tsd-lite"
 import { formatter } from "@lingui/format-po-gettext"
 
 expectAssignable<CatalogFormatter>(formatter())

--- a/packages/format-po-gettext/package.json
+++ b/packages/format-po-gettext/package.json
@@ -51,7 +51,7 @@
   "devDependencies": {
     "@lingui/jest-mocks": "workspace:^",
     "mockdate": "^3.0.5",
-    "tsd": "^0.28.0",
+    "tsd-lite": "^0.7.0",
     "unbuild": "^1.1.2"
   }
 }

--- a/packages/format-po/__typetests__/index.test-d.ts
+++ b/packages/format-po/__typetests__/index.test-d.ts
@@ -1,5 +1,5 @@
 import { CatalogFormatter } from "@lingui/conf"
-import { expectAssignable } from "tsd"
+import { expectAssignable } from "tsd-lite"
 import { formatter } from "@lingui/format-po"
 
 expectAssignable<CatalogFormatter>(formatter())

--- a/packages/format-po/package.json
+++ b/packages/format-po/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@lingui/jest-mocks": "workspace:^",
     "mockdate": "^3.0.5",
-    "tsd": "^0.28.0",
+    "tsd-lite": "^0.7.0",
     "unbuild": "^1.1.2"
   }
 }

--- a/packages/macro/__typetests__/index.test-d.tsx
+++ b/packages/macro/__typetests__/index.test-d.tsx
@@ -1,4 +1,4 @@
-import { expectType } from "tsd"
+import { expectType } from "tsd-lite"
 import type { MessageDescriptor, I18n } from "@lingui/core"
 
 import {

--- a/packages/macro/package.json
+++ b/packages/macro/package.json
@@ -72,7 +72,7 @@
     "@babel/traverse": "7.20.12",
     "@types/babel-plugin-macros": "^2.8.5",
     "prettier": "2.8.3",
-    "tsd": "^0.26.1",
+    "tsd-lite": "^0.7.0",
     "unbuild": "^1.1.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2715,7 +2715,7 @@ __metadata:
     jest-validate: ^29.4.3
     jiti: ^1.17.1
     lodash.get: ^4.4.2
-    tsd: ^0.26.1
+    tsd-lite: ^0.7.0
     unbuild: ^1.1.2
   languageName: unknown
   linkType: soft
@@ -2758,7 +2758,7 @@ __metadata:
   dependencies:
     "@lingui/conf": 4.0.0
     papaparse: ^5.4.0
-    tsd: ^0.28.0
+    tsd-lite: ^0.7.0
     unbuild: ^1.1.2
   languageName: unknown
   linkType: soft
@@ -2769,7 +2769,7 @@ __metadata:
   dependencies:
     "@lingui/conf": 4.0.0
     ramda: ^0.28.0
-    tsd: ^0.28.0
+    tsd-lite: ^0.7.0
     unbuild: ^1.1.2
   languageName: unknown
   linkType: soft
@@ -2787,7 +2787,7 @@ __metadata:
     node-gettext: ^3.0.0
     plurals-cldr: ^2.0.1
     pofile: ^1.1.4
-    tsd: ^0.28.0
+    tsd-lite: ^0.7.0
     unbuild: ^1.1.2
   languageName: unknown
   linkType: soft
@@ -2802,7 +2802,7 @@ __metadata:
     date-fns: ^2.29.3
     mockdate: ^3.0.5
     pofile: ^1.1.4
-    tsd: ^0.28.0
+    tsd-lite: ^0.7.0
     unbuild: ^1.1.2
   languageName: unknown
   linkType: soft
@@ -2842,7 +2842,7 @@ __metadata:
     "@lingui/message-utils": 4.0.0
     "@types/babel-plugin-macros": ^2.8.5
     prettier: 2.8.3
-    tsd: ^0.26.1
+    tsd-lite: ^0.7.0
     unbuild: ^1.1.2
   peerDependencies:
     "@lingui/react": 4.0.0
@@ -3765,17 +3765,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tsd/typescript@npm:^4.9.5, @tsd/typescript@npm:~4.9.5":
+"@tsd/typescript@npm:^4.9.5":
   version: 4.9.5
   resolution: "@tsd/typescript@npm:4.9.5"
   checksum: f9f01ecf2094e0ac83e56cc57430bdf81da82aa20424280002b44ea29cdc171388a9777262257f550800bf76567774521728e1ef6e191633ae6f723ee64d396a
-  languageName: node
-  linkType: hard
-
-"@tsd/typescript@npm:~5.0.2":
-  version: 5.0.2
-  resolution: "@tsd/typescript@npm:5.0.2"
-  checksum: ab9274c5208ec882840d3cbddd897fb14699afe2a71a6039027f60a4d1f5b37746f41a0dbc385ebef363717c5490e45f15308c0cfb023393194afaca24d66850
   languageName: node
   linkType: hard
 
@@ -3867,16 +3860,6 @@ __metadata:
     "@types/estree": "*"
     "@types/json-schema": "*"
   checksum: a48864c837137ee5b3f4f934a5468dc00456c998a2479f8f7ba1c2c34e1fc08414d9f49157f90814a9e843b1dd2cd824b4660cba9425e23d109250ec7ae0a259
-  languageName: node
-  linkType: hard
-
-"@types/eslint@npm:^7.2.13":
-  version: 7.29.0
-  resolution: "@types/eslint@npm:7.29.0"
-  dependencies:
-    "@types/estree": "*"
-    "@types/json-schema": "*"
-  checksum: df13991c554954353ce8f3bb03e19da6cc71916889443d68d178d4f858b561ba4cc4a4f291c6eb9eebb7f864b12b9b9313051b3a8dfea3e513dadf3188a77bdf
   languageName: node
   linkType: hard
 
@@ -6284,7 +6267,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"decamelize@npm:^1.1.0, decamelize@npm:^1.2.0":
+"decamelize@npm:^1.1.0":
   version: 1.2.0
   resolution: "decamelize@npm:1.2.0"
   checksum: ad8c51a7e7e0720c70ec2eeb1163b66da03e7616d7b98c9ef43cce2416395e84c1e9548dd94f5f6ffecfee9f8b94251fc57121a8b021f2ff2469b2bae247b8aa
@@ -7079,22 +7062,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-formatter-pretty@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "eslint-formatter-pretty@npm:4.1.0"
-  dependencies:
-    "@types/eslint": ^7.2.13
-    ansi-escapes: ^4.2.1
-    chalk: ^4.1.0
-    eslint-rule-docs: ^1.1.5
-    log-symbols: ^4.0.0
-    plur: ^4.0.0
-    string-width: ^4.2.0
-    supports-hyperlinks: ^2.0.0
-  checksum: e8e0cd3843513fff32a70b036dd349fdab81d73b5e522f23685181c907a1faf2b2ebcae1688dc71d0fc026184011792f7e39b833d349df18fe2baea00d017901
-  languageName: node
-  linkType: hard
-
 "eslint-import-resolver-node@npm:^0.3.7":
   version: 0.3.7
   resolution: "eslint-import-resolver-node@npm:0.3.7"
@@ -7242,13 +7209,6 @@ __metadata:
   peerDependencies:
     eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
   checksum: 2232b3b8945aa50b7773919c15cd96892acf35d2f82503667a79e2f55def90f728ed4f0e496f0f157acbe1bd4397c5615b676ae7428fe84488a544ca53feb944
-  languageName: node
-  linkType: hard
-
-"eslint-rule-docs@npm:^1.1.5":
-  version: 1.1.235
-  resolution: "eslint-rule-docs@npm:1.1.235"
-  checksum: b163596f9a05568e287b2c78f51a280092122a2e43c45fa2c200f0bd3f61877af186c641dab97620978bec96d9e2cfb621e51728044d9efe42ddc24f5a594b26
   languageName: node
   linkType: hard
 
@@ -8154,7 +8114,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globby@npm:11.1.0, globby@npm:^11.0.1, globby@npm:^11.0.3, globby@npm:^11.1.0":
+"globby@npm:11.1.0, globby@npm:^11.0.3, globby@npm:^11.1.0":
   version: 11.1.0
   resolution: "globby@npm:11.1.0"
   dependencies:
@@ -8666,13 +8626,6 @@ __metadata:
   version: 2.0.0
   resolution: "ip@npm:2.0.0"
   checksum: cfcfac6b873b701996d71ec82a7dd27ba92450afdb421e356f44044ed688df04567344c36cbacea7d01b1c39a4c732dc012570ebe9bebfb06f27314bca625349
-  languageName: node
-  linkType: hard
-
-"irregular-plurals@npm:^3.2.0":
-  version: 3.4.1
-  resolution: "irregular-plurals@npm:3.4.1"
-  checksum: 1a22c5645957a4c09d7d0d206ee35bfc22a62750416cbcfb9049ae41c004fd9606388f04c569cb9ac153ff19d7649f3133e153ec4aad4fa3b278f06e73bd383b
   languageName: node
   linkType: hard
 
@@ -9229,18 +9182,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-diff@npm:^29.0.3":
-  version: 29.5.0
-  resolution: "jest-diff@npm:29.5.0"
-  dependencies:
-    chalk: ^4.0.0
-    diff-sequences: ^29.4.3
-    jest-get-type: ^29.4.3
-    pretty-format: ^29.5.0
-  checksum: dfd0f4a299b5d127779c76b40106c37854c89c3e0785098c717d52822d6620d227f6234c3a9291df204d619e799e3654159213bf93220f79c8e92a55475a3d39
-  languageName: node
-  linkType: hard
-
 "jest-diff@npm:^29.4.3":
   version: 29.4.3
   resolution: "jest-diff@npm:29.4.3"
@@ -9487,17 +9428,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-runner-tsd@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "jest-runner-tsd@npm:4.0.0"
+"jest-runner-tsd@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "jest-runner-tsd@npm:5.0.0"
   dependencies:
     "@babel/code-frame": ^7.15.8
     chalk: ^4.1.2
     create-jest-runner: ^0.12.0
-    tsd-lite: ^0.6.0
+    tsd-lite: ^0.7.0
   peerDependencies:
-    "@tsd/typescript": ^3.8.3 || ^4.0.7
-  checksum: 61fcbb842ee2de12f807f42ce78770dc0abcba46d4f7cf2078ff0305f1c200a323f686b96da79ed3bdbfb00f593760af0b9be61410d2a787e5fd2090b099d850
+    "@tsd/typescript": 4.x || 5.x
+  checksum: 697db424f8588218eeac9f82ae4c34f79dbbdc2453e19a866a00062f1ea571e24225203cad7e09bdc0c343084997947af3be638a0dc7ce38d866569f5234cf0a
   languageName: node
   linkType: hard
 
@@ -9752,7 +9693,7 @@ __metadata:
     jest: ^29.4.3
     jest-environment-jsdom: ^29.4.3
     jest-environment-node-single-context: ^29.0.0
-    jest-runner-tsd: ^4.0.0
+    jest-runner-tsd: ^5.0.0
     lerna: ^6.5.1
     lint-staged: ^13.1.0
     memory-fs: ^0.5.0
@@ -10377,7 +10318,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"log-symbols@npm:^4.0.0, log-symbols@npm:^4.1.0":
+"log-symbols@npm:^4.1.0":
   version: 4.1.0
   resolution: "log-symbols@npm:4.1.0"
   dependencies:
@@ -10570,26 +10511,6 @@ __metadata:
     type-fest: ^0.18.0
     yargs-parser: ^20.2.3
   checksum: bc23bf1b4423ef6a821dff9734406bce4b91ea257e7f10a8b7f896f45b59649f07adc0926e2917eacd8cf1df9e4cd89c77623cf63dfd0f8bf54de07a32ee5a85
-  languageName: node
-  linkType: hard
-
-"meow@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "meow@npm:9.0.0"
-  dependencies:
-    "@types/minimist": ^1.2.0
-    camelcase-keys: ^6.2.2
-    decamelize: ^1.2.0
-    decamelize-keys: ^1.1.0
-    hard-rejection: ^2.1.0
-    minimist-options: 4.1.0
-    normalize-package-data: ^3.0.0
-    read-pkg-up: ^7.0.1
-    redent: ^3.0.0
-    trim-newlines: ^3.0.0
-    type-fest: ^0.18.0
-    yargs-parser: ^20.2.3
-  checksum: 99799c47247f4daeee178e3124f6ef6f84bde2ba3f37652865d5d8f8b8adcf9eedfc551dd043e2455cd8206545fd848e269c0c5ab6b594680a0ad4d3617c9639
   languageName: node
   linkType: hard
 
@@ -12095,15 +12016,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"plur@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "plur@npm:4.0.0"
-  dependencies:
-    irregular-plurals: ^3.2.0
-  checksum: fea2e903efca67cc5c7a8952fca3db46ae8d9e9353373b406714977e601a5d3b628bcb043c3ad2126c6ff0e73d8020bf43af30a72dd087eff1ec240eb13b90e1
-  languageName: node
-  linkType: hard
-
 "plurals-cldr@npm:^2.0.1":
   version: 2.0.1
   resolution: "plurals-cldr@npm:2.0.1"
@@ -12488,7 +12400,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"read-pkg-up@npm:^7.0.0, read-pkg-up@npm:^7.0.1":
+"read-pkg-up@npm:^7.0.1":
   version: 7.0.1
   resolution: "read-pkg-up@npm:7.0.1"
   dependencies:
@@ -13603,7 +13515,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supports-color@npm:^7.0.0, supports-color@npm:^7.1.0":
+"supports-color@npm:^7.1.0":
   version: 7.2.0
   resolution: "supports-color@npm:7.2.0"
   dependencies:
@@ -13618,16 +13530,6 @@ __metadata:
   dependencies:
     has-flag: ^4.0.0
   checksum: c052193a7e43c6cdc741eb7f378df605636e01ad434badf7324f17fb60c69a880d8d8fcdcb562cf94c2350e57b937d7425ab5b8326c67c2adc48f7c87c1db406
-  languageName: node
-  linkType: hard
-
-"supports-hyperlinks@npm:^2.0.0":
-  version: 2.3.0
-  resolution: "supports-hyperlinks@npm:2.3.0"
-  dependencies:
-    has-flag: ^4.0.0
-    supports-color: ^7.0.0
-  checksum: 9ee0de3c8ce919d453511b2b1588a8205bd429d98af94a01df87411391010fe22ca463f268c84b2ce2abad019dfff8452aa02806eeb5c905a8d7ad5c4f4c52b8
   languageName: node
   linkType: hard
 
@@ -14005,45 +13907,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tsd-lite@npm:^0.6.0":
-  version: 0.6.0
-  resolution: "tsd-lite@npm:0.6.0"
+"tsd-lite@npm:^0.7.0":
+  version: 0.7.0
+  resolution: "tsd-lite@npm:0.7.0"
   peerDependencies:
-    "@tsd/typescript": ^3.8.3 || ^4.0.7
-  checksum: 7b603092411b9bf940b350475a741ffa6c5f3aa15e723a55d30069a47d25cecbedd4172740d8b894e08688500ec826f7d82a6252ea49e9fbd483c85199e662f0
-  languageName: node
-  linkType: hard
-
-"tsd@npm:^0.26.1":
-  version: 0.26.1
-  resolution: "tsd@npm:0.26.1"
-  dependencies:
-    "@tsd/typescript": ~4.9.5
-    eslint-formatter-pretty: ^4.1.0
-    globby: ^11.0.1
-    meow: ^9.0.0
-    path-exists: ^4.0.0
-    read-pkg-up: ^7.0.0
-  bin:
-    tsd: dist/cli.js
-  checksum: 43e6a43881c7124bb928da6e7ba445b4494fd6fb9fcb7e9d11844a37943879a4c3e42c1b6cdf793c0225a0a3c9612f9c82a7c146b139d2c749e283982a31d2ca
-  languageName: node
-  linkType: hard
-
-"tsd@npm:^0.28.0":
-  version: 0.28.0
-  resolution: "tsd@npm:0.28.0"
-  dependencies:
-    "@tsd/typescript": ~5.0.2
-    eslint-formatter-pretty: ^4.1.0
-    globby: ^11.0.1
-    jest-diff: ^29.0.3
-    meow: ^9.0.0
-    path-exists: ^4.0.0
-    read-pkg-up: ^7.0.0
-  bin:
-    tsd: dist/cli.js
-  checksum: 9dd5d58a1e568127b7e2ad6e91b2b791e81c807dfe063fa7547a756a0c3d5ca1366b19097cc6aa6d048d6b20d704469e511da5caf5db6d2b4283019187ad3130
+    "@tsd/typescript": 4.x || 5.x
+  checksum: 97e304de0bdc906377b213c662b48543fea7e8393f884bc1136d1b9cd731b304bdfefd513d5874b4b9c961fb6462ee40320297c38ec16b7921d0504616dd4c7f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

Glad to see you found it helpful to use `jest-runner-tsd`. As you may have noticed, instead of `tsd` this runner is using `tsd-lite` (I am maintaining this package). Just wanted to draw your attention, that it would be better to import type testing APIs from `tsd-lite`, because both implementations differ. For example, `tsd-lite` does not include few API which are not related with type testing.

Also the setup becomes somewhat more optimal. Take a look at changes in `yarn.lock`. `tsd-lite` makes your repo lighter (;

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Dependency update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
