### PR TITLE
fix(vue-extractor): support components with no <template>

### DIFF
--- a/packages/extractor-vue/src/__snapshots__/extractor.test.ts.snap
+++ b/packages/extractor-vue/src/__snapshots__/extractor.test.ts.snap
@@ -1,5 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`vue extractor should extract message from functional component 1`] = `
+[
+  {
+    comment: undefined,
+    context: undefined,
+    id: Render function message,
+    message: undefined,
+    origin: [
+      functional.vue,
+      10,
+      33,
+    ],
+  },
+]
+`;
+
 exports[`vue extractor should extract message from vue file 1`] = `
 [
   {

--- a/packages/extractor-vue/src/extractor.test.ts
+++ b/packages/extractor-vue/src/extractor.test.ts
@@ -61,4 +61,26 @@ describe("vue extractor", () => {
 
     expect(messages).toMatchSnapshot()
   })
+
+  it("should extract message from functional component", async () => {
+    const filePath = path.resolve(__dirname, "fixtures/functional.vue")
+    const code = fs.readFileSync(filePath, "utf-8")
+
+    let messages: ExtractedMessage[] = []
+
+    await vueExtractor.extract(
+      "functional.vue",
+      code,
+      (res) => {
+        messages.push(res)
+      },
+      {
+        linguiConfig,
+      }
+    )
+
+    messages = normalizePath(messages)
+
+    expect(messages).toMatchSnapshot()
+  })
 })

--- a/packages/extractor-vue/src/fixtures/functional.vue
+++ b/packages/extractor-vue/src/fixtures/functional.vue
@@ -1,0 +1,12 @@
+<script lang="ts">
+import { defineComponent } from "vue"
+import { i18n } from "@lingui/core"
+
+// @ts-ignore only used to check if extractor doesn't crash with Typescript
+const foo: number = 5
+
+export default defineComponent({
+  render(createElement) {
+    return createElement('div', [i18n._("Render function message")])
+  }})
+</script>

--- a/packages/extractor-vue/src/vue-extractor.ts
+++ b/packages/extractor-vue/src/vue-extractor.ts
@@ -18,12 +18,14 @@ export const vueExtractor: ExtractorType = {
       ignoreEmpty: true,
     })
 
-    const compiledTemplate = compileTemplate({
-      source: descriptor.template.content,
-      filename,
-      inMap: descriptor.template.map,
-      id: filename,
-    })
+    const compiledTemplate =
+      descriptor.template &&
+      compileTemplate({
+        source: descriptor.template.content,
+        filename,
+        inMap: descriptor.template.map,
+        id: filename,
+      })
 
     const isTsBlock = (block: SFCBlock) => block?.lang === "ts"
 


### PR DESCRIPTION
# Description

An improvement to the recently merged Vue single-file component extractor : A SFC may have no `<template>` (functional components), in which case the extract should just move on with the script.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate) (N/A)
