### PR TITLE
refactor(macro): show codeframe when error happened in macro

### DIFF
--- a/packages/macro/src/index.ts
+++ b/packages/macro/src/index.ts
@@ -121,7 +121,7 @@ function macro({ references, state, babel, config }: MacroParams) {
 
 function reportUnsupportedSyntax(path: NodePath, e: Error) {
   throw path.buildCodeFrameError(
-    `Unsupported macro usage. Please check examples at https://lingui.dev/ref/macro#examples-of-js-macros. 
+    `Unsupported macro usage. Please check the examples at https://lingui.dev/ref/macro#examples-of-js-macros. 
  If you think this is a bug, fill in an issue at https://github.com/lingui/js-lingui/issues
  
  Error: ${e.message}`

--- a/packages/macro/src/index.ts
+++ b/packages/macro/src/index.ts
@@ -122,7 +122,7 @@ function macro({ references, state, babel, config }: MacroParams) {
 function reportUnsupportedSyntax(path: NodePath, e: Error) {
   throw path.buildCodeFrameError(
     `Unsupported macro usage. Please check examples at https://lingui.dev/ref/macro#examples-of-js-macros. 
- If you think this is bug, fill an issue at https://github.com/lingui/js-lingui/issues
+ If you think this is a bug, fill in an issue at https://github.com/lingui/js-lingui/issues
  
  Error: ${e.message}`
   )

--- a/packages/macro/src/index.ts
+++ b/packages/macro/src/index.ts
@@ -91,14 +91,23 @@ function macro({ references, state, babel, config }: MacroParams) {
       stripNonEssentialProps,
       nameMap,
     })
-    if (macro.replacePath(path)) needsI18nImport = true
+    try {
+      if (macro.replacePath(path)) needsI18nImport = true
+    } catch (e) {
+      reportUnsupportedSyntax(path, e as Error)
+    }
   })
 
   const jsxNodesArray = Array.from(jsxNodes)
 
   jsxNodesArray.filter(isRootPath(jsxNodesArray)).forEach((path) => {
     const macro = new MacroJSX(babel, { stripNonEssentialProps, nameMap })
-    macro.replacePath(path)
+
+    try {
+      macro.replacePath(path)
+    } catch (e) {
+      reportUnsupportedSyntax(path, e as Error)
+    }
   })
 
   if (needsI18nImport) {
@@ -108,6 +117,15 @@ function macro({ references, state, babel, config }: MacroParams) {
   if (jsxNodes.size) {
     addImport(babel, state, TransImportModule, TransImportName)
   }
+}
+
+function reportUnsupportedSyntax(path: NodePath, e: Error) {
+  throw path.buildCodeFrameError(
+    `Unsupported macro usage. Please check examples at https://lingui.dev/ref/macro#examples-of-js-macros. 
+ If you think this is bug, fill an issue at https://github.com/lingui/js-lingui/issues
+ 
+ Error: ${e.message}`
+  )
 }
 
 function addImport(


### PR DESCRIPTION
# Description

To simplify identifying  problematic code, show a code frame where the macro was unable to process code.  This makes issues like that https://github.com/lingui/js-lingui/issues/1616 much easier to solve. 

<img width="927" alt="image" src="https://user-images.githubusercontent.com/1586852/234876956-46d21d84-e39f-46f6-b975-9b388b692fc4.png">


[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
