### PR TITLE
fix: just use require to import services

### DIFF
--- a/packages/cli/src/lingui-extract.ts
+++ b/packages/cli/src/lingui-extract.ts
@@ -80,11 +80,16 @@ export default async function command(
     const moduleName =
       config.service.name.charAt(0).toLowerCase() + config.service.name.slice(1)
 
-    await import(`./services/${moduleName}`)
-      .then((module) => module.default(config, options))
-      .catch((err) =>
-        console.error(`Can't load service module ${moduleName}`, err)
-      )
+    try {
+      const module = require(`./services/${moduleName}`)
+
+      await module
+        .default(config, options)
+        .then(console.log)
+        .catch(console.error)
+    } catch (err) {
+      console.error(`Can't load service module ${moduleName}`, err)
+    }
   }
 
   return commandSuccess

--- a/packages/cli/src/services/translationIO.ts
+++ b/packages/cli/src/services/translationIO.ts
@@ -41,7 +41,7 @@ const getTargetLocales = (config: LinguiConfigNormalized) => {
 }
 
 // Main sync method, call "Init" or "Sync" depending on the project context
-export default function syncProcess(
+export default async function syncProcess(
   config: LinguiConfigNormalized,
   options: CliExtractOptions
 ) {
@@ -52,29 +52,31 @@ export default function syncProcess(
     process.exit(1)
   }
 
-  const successCallback = (project: TranslationIoProject) => {
-    console.log(
-      `\n----------\nProject successfully synchronized. Please use this URL to translate: ${project.url}\n----------`
-    )
-  }
-
-  const failCallback = (errors: string[]) => {
-    console.error(
-      `\n----------\nSynchronization with Translation.io failed: ${errors.join(
-        ", "
-      )}\n----------`
-    )
-  }
-
-  init(config, options, successCallback, (errors) => {
-    if (
-      errors.length &&
-      errors[0] === "This project has already been initialized."
-    ) {
-      sync(config, options, successCallback, failCallback)
-    } else {
-      failCallback(errors)
+  return await new Promise<string>((resolve, reject) => {
+    const successCallback = (project: TranslationIoProject) => {
+      resolve(
+        `\n----------\nProject successfully synchronized. Please use this URL to translate: ${project.url}\n----------`
+      )
     }
+
+    const failCallback = (errors: string[]) => {
+      reject(
+        `\n----------\nSynchronization with Translation.io failed: ${errors.join(
+          ", "
+        )}\n----------`
+      )
+    }
+
+    init(config, options, successCallback, (errors) => {
+      if (
+        errors.length &&
+        errors[0] === "This project has already been initialized."
+      ) {
+        sync(config, options, successCallback, failCallback)
+      } else {
+        failCallback(errors)
+      }
+    })
   })
 }
 


### PR DESCRIPTION
- update services to be async and can be awaited

# Description

from #1631, there is error importing TranslationIO service with `import`. It result in `Cannot find module`. The problem is that it need the js extension.

One solution is to add js extension `import('xxx' + .js)` , but the result would still need to be
```
import('xxx'.js).then(module => module.default.default(xxx))
```
Not sure why the double default there, but using require would solve at least the double default.

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Fixes # (issue)
#1631 

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
