### PR TITLE
chore: use ^version notation for peerDependencies

### DIFF
--- a/packages/macro/package.json
+++ b/packages/macro/package.json
@@ -63,7 +63,7 @@
     "@lingui/message-utils": "4.0.0"
   },
   "peerDependencies": {
-    "@lingui/react": "4.0.0",
+    "@lingui/react": "^4.0.0",
     "babel-plugin-macros": "2 || 3"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2845,7 +2845,7 @@ __metadata:
     tsd: ^0.26.1
     unbuild: ^1.1.2
   peerDependencies:
-    "@lingui/react": 4.0.0
+    "@lingui/react": ^4.0.0
     babel-plugin-macros: 2 || 3
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
# Description

Lerna can't automatically bump package versions for `peerDependencies`. https://github.com/lerna/lerna/issues/2402

So I decided to use the `^` for the version specifying. This will allow continuing using the Lerna version bumping without the need to bump the `peerDependencies` versions.

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
