### PR TITLE
feat(webpack + vite): Ensure that bundlers respect catalog dependencies

### DIFF
--- a/packages/cli/src/api/catalog.ts
+++ b/packages/cli/src/api/catalog.ts
@@ -76,6 +76,13 @@ export class Catalog {
       getTemplatePath(this.format.getTemplateExtension(), this.path)
   }
 
+  getFilename(locale: string): string {
+    return (
+      replacePlaceholders(this.path, { locale }) +
+      this.format.getCatalogExtension()
+    )
+  }
+
   async make(options: MakeOptions): Promise<AllCatalogsType | false> {
     const nextCatalog = await this.collect({ files: options.files })
     if (!nextCatalog) return false
@@ -176,9 +183,7 @@ export class Catalog {
     locale: string,
     messages: CatalogType
   ): Promise<[created: boolean, filename: string]> {
-    const filename =
-      replacePlaceholders(this.path, { locale }) +
-      this.format.getCatalogExtension()
+    const filename = this.getFilename(locale)
 
     const created = !fs.existsSync(filename)
 
@@ -211,11 +216,7 @@ export class Catalog {
   }
 
   async read(locale: string): Promise<CatalogType> {
-    const filename =
-      replacePlaceholders(this.path, { locale }) +
-      this.format.getCatalogExtension()
-
-    return await this.format.read(filename, locale)
+    return await this.format.read(this.getFilename(locale), locale)
   }
 
   async readAll(): Promise<AllCatalogsType> {

--- a/packages/cli/src/api/catalog/getCatalogDependentFiles.test.ts
+++ b/packages/cli/src/api/catalog/getCatalogDependentFiles.test.ts
@@ -1,0 +1,76 @@
+import { getCatalogDependentFiles, getFormat } from "@lingui/cli/api"
+import { makeConfig } from "@lingui/conf"
+import { Catalog } from "../catalog"
+import { FormatterWrapper } from "../formats"
+
+describe("getCatalogDependentFiles", () => {
+  let format: FormatterWrapper
+
+  beforeAll(async () => {
+    format = await getFormat("po", {}, "en")
+  })
+
+  it("Should return list template + fallbacks + sourceLocale", () => {
+    const config = makeConfig(
+      {
+        locales: ["en", "pl", "es", "pt-PT", "pt-BR"],
+        sourceLocale: "en",
+        fallbackLocales: {
+          "pt-PT": "pt-BR",
+          default: "en",
+        },
+      },
+      { skipValidation: true }
+    )
+
+    const catalog = new Catalog(
+      {
+        name: null,
+        path: "src/locales/{locale}",
+        include: ["src/"],
+        exclude: [],
+        format,
+      },
+      config
+    )
+
+    expect(getCatalogDependentFiles(catalog, "pt-PT")).toMatchInlineSnapshot(`
+      [
+        src/locales/messages.pot,
+        src/locales/pt-BR.po,
+        src/locales/en.po,
+      ]
+    `)
+  })
+
+  it("Should not return itself", () => {
+    const config = makeConfig(
+      {
+        locales: ["en", "pl", "es", "pt-PT", "pt-BR"],
+        sourceLocale: "en",
+        fallbackLocales: {
+          "pt-PT": "pt-BR",
+          default: "en",
+        },
+      },
+      { skipValidation: true }
+    )
+
+    const catalog = new Catalog(
+      {
+        name: null,
+        path: "src/locales/{locale}",
+        include: ["src/"],
+        exclude: [],
+        format,
+      },
+      config
+    )
+
+    expect(getCatalogDependentFiles(catalog, "en")).toMatchInlineSnapshot(`
+      [
+        src/locales/messages.pot,
+      ]
+    `)
+  })
+})

--- a/packages/cli/src/api/catalog/getCatalogDependentFiles.ts
+++ b/packages/cli/src/api/catalog/getCatalogDependentFiles.ts
@@ -1,0 +1,23 @@
+import { Catalog } from "../catalog"
+import { getFallbackListForLocale } from "./getFallbackListForLocale"
+
+/**
+ * Return all files catalog implicitly depends on.
+ */
+export function getCatalogDependentFiles(
+  catalog: Catalog,
+  locale: string
+): string[] {
+  const files = new Set([catalog.templateFile])
+  getFallbackListForLocale(catalog.config.fallbackLocales, locale).forEach(
+    (locale) => {
+      files.add(catalog.getFilename(locale))
+    }
+  )
+
+  if (catalog.config.sourceLocale && locale !== catalog.config.sourceLocale) {
+    files.add(catalog.getFilename(catalog.config.sourceLocale))
+  }
+
+  return Array.from(files.values())
+}

--- a/packages/cli/src/api/catalog/getFallbackListForLocale.test.ts
+++ b/packages/cli/src/api/catalog/getFallbackListForLocale.test.ts
@@ -1,0 +1,64 @@
+import { getFallbackListForLocale } from "./getFallbackListForLocale"
+
+describe("getFallbackListForLocale", () => {
+  it("Should return normalized fallback locales for passed locale", () => {
+    const actual = getFallbackListForLocale(
+      {
+        "pt-PT": "pt-BR",
+        default: "en",
+      },
+      "pt-PT"
+    )
+
+    expect(actual).toMatchInlineSnapshot(`
+      [
+        pt-BR,
+        en,
+      ]
+    `)
+  })
+
+  it("Should work with list of fallbacks", () => {
+    const actual = getFallbackListForLocale(
+      {
+        "pt-PT": ["pt-BR", "pt"],
+        default: "en",
+      },
+      "pt-PT"
+    )
+
+    expect(actual).toMatchInlineSnapshot(`
+      [
+        pt-BR,
+        pt,
+        en,
+      ]
+    `)
+  })
+
+  it("Should work when no fallback set", () => {
+    const actual = getFallbackListForLocale(
+      {
+        default: "en",
+      },
+      "pt-PT"
+    )
+
+    expect(actual).toMatchInlineSnapshot(`
+      [
+        en,
+      ]
+    `)
+  })
+
+  it("Should not return itself", () => {
+    const actual = getFallbackListForLocale(
+      {
+        default: "en",
+      },
+      "en"
+    )
+
+    expect(actual).toMatchInlineSnapshot(`[]`)
+  })
+})

--- a/packages/cli/src/api/catalog/getFallbackListForLocale.ts
+++ b/packages/cli/src/api/catalog/getFallbackListForLocale.ts
@@ -1,0 +1,19 @@
+import { FallbackLocales } from "@lingui/conf"
+
+export function getFallbackListForLocale(
+  fallbackLocales: FallbackLocales,
+  locale: string
+): string[] {
+  const fL: string[] = []
+
+  if (fallbackLocales?.[locale]) {
+    const mapping = fallbackLocales?.[locale]
+    Array.isArray(mapping) ? fL.push(...mapping) : fL.push(mapping)
+  }
+
+  if (fallbackLocales?.default && locale !== fallbackLocales?.default) {
+    fL.push(fallbackLocales?.default)
+  }
+
+  return fL
+}

--- a/packages/cli/src/api/index.ts
+++ b/packages/cli/src/api/index.ts
@@ -4,5 +4,5 @@ export { getCatalogForFile, getCatalogs } from "./catalog/getCatalogs"
 export { createCompiledCatalog } from "./compile"
 
 export { default as extractor } from "./extractors/babel"
-
+export { getCatalogDependentFiles } from "./catalog/getCatalogDependentFiles"
 export * from "./types"

--- a/packages/loader/src/webpackLoader.ts
+++ b/packages/loader/src/webpackLoader.ts
@@ -4,6 +4,7 @@ import {
   createCompiledCatalog,
   getCatalogs,
   getCatalogForFile,
+  getCatalogDependentFiles,
 } from "@lingui/cli/api"
 import { LoaderDefinitionFunction } from "webpack"
 
@@ -27,6 +28,10 @@ const loader: LoaderDefinitionFunction<LinguiLoaderOptions> = async function (
     catalogRelativePath,
     await getCatalogs(config)
   )
+
+  getCatalogDependentFiles(catalog, locale).forEach((locale) => {
+    this.addDependency(catalog.getFilename(locale))
+  })
 
   const messages = await catalog.getTranslations(locale, {
     fallbackLocales: config.fallbackLocales,

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -3,6 +3,7 @@ import {
   createCompiledCatalog,
   getCatalogs,
   getCatalogForFile,
+  getCatalogDependentFiles,
 } from "@lingui/cli/api"
 import path from "path"
 import type { Plugin } from "vite"
@@ -51,6 +52,10 @@ Please check that catalogs.path is filled properly.\n`
         }
 
         const { locale, catalog } = fileCatalog
+
+        getCatalogDependentFiles(catalog, locale).forEach((locale) => {
+          this.addWatchFile(catalog.getFilename(locale))
+        })
 
         const messages = await catalog.getTranslations(locale, {
           fallbackLocales: config.fallbackLocales,


### PR DESCRIPTION
# Description

Catalog compiler operates on a bunch of files when compiling one catalog (template + fallbacks + source language). Loaders in bundlers expecting deterministic results, meaning for the same source it should always produce the same result. 

Currently, implementation of webpack loader / vite plugin does not respect catalog dependencies. That breaks caching in Webpack and watch mode (catalog will not be rebuilt if one of the dependencies changed)

This PR brings tracking of all catalog dependencies and should resolve mentioned issues. 

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
