### PR TITLE
fix(message-utils): workaround package.json exports field for older runtimes

### DIFF
--- a/packages/message-utils/compileMessage.js
+++ b/packages/message-utils/compileMessage.js
@@ -3,4 +3,4 @@
  * such as React Native or Jest 27 which is not
  * support package.json exports field
  **/
-exports = require("./dist/compileMessage.cjs")
+module.exports = require("./dist/compileMessage.cjs")

--- a/packages/message-utils/generateMessageId.js
+++ b/packages/message-utils/generateMessageId.js
@@ -3,4 +3,4 @@
  * such as React Native or Jest 27 which is not
  * support package.json exports field
  **/
-exports = require("./dist/generateMessageId.cjs")
+module.exports = require("./dist/generateMessageId.cjs")


### PR DESCRIPTION
Previously, I wrote something non-workable. This time it should work.
 
Fixes: https://github.com/lingui/js-lingui/issues/1633