### PR TITLE
test(verdacio-integration): use yarn berry command to update lingui deps

### DIFF
--- a/.github/verdaccio/config.yaml
+++ b/.github/verdaccio/config.yaml
@@ -7,8 +7,9 @@ auth:
 store:
   memory:
     limit: 1000
-## we don't need any remote request
 uplinks:
+  npmjs:
+    url: https://registry.npmjs.org/
 packages:
   '@*/*':
     access: $all

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -34,7 +34,6 @@ jobs:
           git switch -c "pull-request"
           npm i -g {verdaccio,verdaccio-auth-memory,verdaccio-memory}
           mkdir -p $HOME/.config/verdaccio
-          cp --verbose ./github/verdaccio/config.yaml $HOME/.config/verdaccio/config.yaml
-          nohup verdaccio --config ./github/verdaccio/config.yaml
+          nohup verdaccio --config .github/verdaccio/config.yaml
           yarn verdaccio:release
           yarn verdaccio:integration

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -34,7 +34,7 @@ jobs:
           git switch -c "pull-request"
           npm i -g {verdaccio,verdaccio-auth-memory,verdaccio-memory}
           mkdir -p $HOME/.config/verdaccio
-          cp --verbose .github/verdaccio/config.yaml $HOME/.config/verdaccio/config.yaml
-          nohup verdaccio --config $HOME/.config/verdaccio/config.yaml &>mktemp &
+          cp --verbose ./github/verdaccio/config.yaml $HOME/.config/verdaccio/config.yaml
+          nohup verdaccio --config ./github/verdaccio/config.yaml
           yarn verdaccio:release
           yarn verdaccio:integration

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -33,7 +33,6 @@ jobs:
         run: |
           git switch -c "pull-request"
           npm i -g {verdaccio,verdaccio-auth-memory,verdaccio-memory}
-          mkdir -p $HOME/.config/verdaccio
-          nohup verdaccio --config .github/verdaccio/config.yaml
+          nohup verdaccio --config .github/verdaccio/config.yaml &>mktemp &
           yarn verdaccio:release
           yarn verdaccio:integration

--- a/scripts/verdaccio-integration.ts
+++ b/scripts/verdaccio-integration.ts
@@ -12,11 +12,9 @@ async function main() {
   await exec("yarn", OPTS)
   spinner.start("Linking create-react-app")
   await exec(
-    "npm i -g update-by-scope --registry https://registry.npmjs.org",
+    'YARN_NPM_REGISTRY_SERVER=http://0.0.0.0:4873/ yarn up "@lingui/*" ',
     OPTS
   )
-  await exec("npm config set registry http://0.0.0.0:4873/", OPTS)
-  await exec("update-by-scope @lingui", OPTS)
   spinner.succeed("Updated @lingui packages")
 
   spinner.start("Running tests")


### PR DESCRIPTION
# Description

it seems that Verdaccio integration script doesn't work properly. It tests against latest published version to NPM instead of locally published to Verdaccio. Yarn Berry does not respect `npm config set registry` instead specific to yarn commands should be used. 