### PR TITLE
fix(webpack + vite): fix dependency watching in loader

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -71,6 +71,7 @@
     "micromatch": "4.0.2",
     "normalize-path": "^3.0.0",
     "ora": "^5.1.0",
+    "pathe": "^1.1.0",
     "pkg-up": "^3.1.0",
     "pofile": "^1.1.4",
     "pseudolocale": "^2.0.0",

--- a/packages/cli/src/api/catalog/getCatalogDependentFiles.ts
+++ b/packages/cli/src/api/catalog/getCatalogDependentFiles.ts
@@ -1,6 +1,6 @@
 import { Catalog } from "../catalog"
 import { getFallbackListForLocale } from "./getFallbackListForLocale"
-import path from "node:path"
+import path from "pathe"
 import fs from "node:fs/promises"
 
 const fileExists = async (path: string) =>

--- a/packages/cli/src/api/catalog/getCatalogDependentFiles.ts
+++ b/packages/cli/src/api/catalog/getCatalogDependentFiles.ts
@@ -1,13 +1,18 @@
 import { Catalog } from "../catalog"
 import { getFallbackListForLocale } from "./getFallbackListForLocale"
+import path from "node:path"
+import fs from "node:fs/promises"
+
+const fileExists = async (path: string) =>
+  !!(await fs.stat(path).catch(() => false))
 
 /**
  * Return all files catalog implicitly depends on.
  */
-export function getCatalogDependentFiles(
+export async function getCatalogDependentFiles(
   catalog: Catalog,
   locale: string
-): string[] {
+): Promise<string[]> {
   const files = new Set([catalog.templateFile])
   getFallbackListForLocale(catalog.config.fallbackLocales, locale).forEach(
     (locale) => {
@@ -19,5 +24,14 @@ export function getCatalogDependentFiles(
     files.add(catalog.getFilename(catalog.config.sourceLocale))
   }
 
-  return Array.from(files.values())
+  const out: string[] = []
+
+  for (const file of files) {
+    const filePath = path.join(catalog.config.rootDir, file)
+    if (await fileExists(filePath)) {
+      out.push(filePath)
+    }
+  }
+
+  return out
 }

--- a/packages/loader/src/webpackLoader.ts
+++ b/packages/loader/src/webpackLoader.ts
@@ -29,9 +29,8 @@ const loader: LoaderDefinitionFunction<LinguiLoaderOptions> = async function (
     await getCatalogs(config)
   )
 
-  getCatalogDependentFiles(catalog, locale).forEach((locale) => {
-    this.addDependency(catalog.getFilename(locale))
-  })
+  const dependency = await getCatalogDependentFiles(catalog, locale)
+  dependency.forEach((file) => this.addDependency(file))
 
   const messages = await catalog.getTranslations(locale, {
     fallbackLocales: config.fallbackLocales,

--- a/packages/loader/test/json-format/lingui.config.ts
+++ b/packages/loader/test/json-format/lingui.config.ts
@@ -7,5 +7,8 @@ export default {
       path: "<rootDir>/locale/{locale}",
     },
   ],
+  fallbackLocales: {
+    default: "en",
+  },
   format: formatter({ style: "minimal" }),
 }

--- a/packages/loader/test/po-format/.linguirc
+++ b/packages/loader/test/po-format/.linguirc
@@ -3,5 +3,8 @@
   "catalogs": [{
     "path": "<rootDir>/locale/{locale}"
   }],
+  "fallbackLocales": {
+    "default": "en"
+  },
   "format": "po"
 }

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -53,9 +53,8 @@ Please check that catalogs.path is filled properly.\n`
 
         const { locale, catalog } = fileCatalog
 
-        getCatalogDependentFiles(catalog, locale).forEach((locale) => {
-          this.addWatchFile(catalog.getFilename(locale))
-        })
+        const dependency = await getCatalogDependentFiles(catalog, locale)
+        dependency.forEach((file) => this.addWatchFile(file))
 
         const messages = await catalog.getTranslations(locale, {
           fallbackLocales: config.fallbackLocales,

--- a/packages/vite-plugin/test/json-format/lingui.config.ts
+++ b/packages/vite-plugin/test/json-format/lingui.config.ts
@@ -7,5 +7,8 @@ export default {
       path: "<rootDir>/locale/{locale}",
     },
   ],
+  fallbackLocales: {
+    default: "en",
+  },
   format: formatter({ style: "minimal" }),
 }

--- a/packages/vite-plugin/test/po-format/.linguirc
+++ b/packages/vite-plugin/test/po-format/.linguirc
@@ -3,5 +3,8 @@
   "catalogs": [{
     "path": "<rootDir>/locale/{locale}"
   }],
+  "fallbackLocales": {
+    "default": "en"
+  },
   "format": "po"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2694,6 +2694,7 @@ __metadata:
     mockdate: ^3.0.5
     normalize-path: ^3.0.0
     ora: ^5.1.0
+    pathe: ^1.1.0
     pkg-up: ^3.1.0
     pofile: ^1.1.4
     pseudolocale: ^2.0.0


### PR DESCRIPTION
# Description

Fixing a bug introduced in https://github.com/lingui/js-lingui/pull/1654 
Closes: https://github.com/lingui/js-lingui/issues/1661

Vite's `addWatchFile` does not have a file existance check as webpack has, so i have to add check it manually before. 

Also, we need an e2e tests for /example projects. Because this kind of things really hard to test from build side. 