### PR TITLE
fix: fallback to `other` only when undefined

### DIFF
--- a/packages/core/src/interpolate.test.ts
+++ b/packages/core/src/interpolate.test.ts
@@ -72,6 +72,12 @@ describe("interpolate", () => {
     expect(offset({ value: 3 })).toEqual("2 Books")
   })
 
+  it("should compile plurals with falsy value choice", () => {
+    const plural = prepare("{value, plural, one {} other {# Books}}")
+    expect(plural({ value: 1 })).toEqual("")
+    expect(plural({ value: 2 })).toEqual("2 Books")
+  })
+
   it("when a value is defined (even when empty) plural will return it. Conversely, if a value is not defined, plural defaults to 'other'", () => {
     const plural = prepare("{value, plural, =0 {} other {#% discount}}")
     expect(plural({ value: 0 })).toEqual("")
@@ -117,6 +123,15 @@ describe("interpolate", () => {
     const cache = prepare("{value, select, female {She} other {They}}")
     expect(cache({ value: "female" })).toEqual("She")
     expect(cache({ value: "n/a" })).toEqual("They")
+  })
+
+  it("should support select with empty string choice", () => {
+    const cache = prepare("{value, select, female {} other {They}}")
+    expect(cache({ value: "female" })).toEqual("")
+    expect(cache({ value: "n/a" })).toEqual("They")
+    const cache2 = prepare("{value, select, female {0} other {They}}")
+    expect(cache2({ value: "female" })).toEqual("0")
+    expect(cache2({ value: "n/a" })).toEqual("They")
   })
 
   describe("Custom format", () => {

--- a/packages/core/src/interpolate.ts
+++ b/packages/core/src/interpolate.ts
@@ -34,7 +34,7 @@ const getDefaultFormats = (
       return replaceOctothorpe(value - offset, message)
     },
 
-    select: (value: string, rules) => rules[value] || rules.other,
+    select: (value: string, rules) => rules[value] ?? rules.other,
 
     number: (
       value: number,


### PR DESCRIPTION
# Description

fix https://github.com/lingui/js-lingui/issues/1664

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Fixes https://github.com/lingui/js-lingui/issues/1664

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
