### PR TITLE
feat(po-format): add `explicitIdAsDefault` for po-format for easier migration

### DIFF
--- a/packages/format-po/README.md
+++ b/packages/format-po/README.md
@@ -61,6 +61,21 @@ export type PoFormatterOptions = {
    * @default false
    */
   printLinguiId?: boolean
+  
+  /**
+   * By default, the po-formatter treats the pair `msgid` + `msgctx` as the source
+   * for generating an ID by hashing its value.
+   *
+   * For messages with explicit IDs, the formatter adds a special comment `js-lingui-explicit-id` as a flag.
+   * When this flag is present, the formatter will use the `msgid` as-is without any additional processing.
+   *
+   * Set this option to true if you exclusively use explicit-ids in your project.
+   *
+   * https://lingui.dev/tutorials/react-patterns#using-custom-id
+   *
+   * @default false
+   */
+  explicitIdAsDefault?: boolean
 }
 ```
 

--- a/packages/format-po/src/po.test.ts
+++ b/packages/format-po/src/po.test.ts
@@ -122,6 +122,148 @@ describe("pofile format", () => {
     expect(actual).toMatchObject(catalog)
   })
 
+  describe("explicitIdAsDefault", () => {
+    const catalog: CatalogType = {
+      // with generated id
+      Dgzql1: {
+        message: "with generated id",
+        translation: "",
+        context: "my context",
+      },
+
+      "custom.id": {
+        message: "with explicit id",
+        translation: "",
+      },
+    }
+
+    it("should set `js-lingui-generated-id` for messages with generated id when [explicitIdAsDefault: true]", () => {
+      const format = createFormatter({
+        origins: true,
+        explicitIdAsDefault: true,
+      })
+
+      const serialized = format.serialize(
+        catalog,
+        defaultSerializeCtx
+      ) as string
+
+      expect(serialized).toMatchInlineSnapshot(`
+        msgid ""
+        msgstr ""
+        "POT-Creation-Date: 2018-08-27 10:00+0000\\n"
+        "MIME-Version: 1.0\\n"
+        "Content-Type: text/plain; charset=utf-8\\n"
+        "Content-Transfer-Encoding: 8bit\\n"
+        "X-Generator: @lingui/cli\\n"
+        "Language: en\\n"
+
+        #. js-lingui-generated-id
+        msgctxt "my context"
+        msgid "with generated id"
+        msgstr ""
+
+        msgid "custom.id"
+        msgstr ""
+
+      `)
+
+      const actual = format.parse(serialized, defaultParseCtx)
+      expect(actual).toMatchInlineSnapshot(`
+        {
+          Dgzql1: {
+            comments: [
+              js-lingui-generated-id,
+            ],
+            context: my context,
+            extra: {
+              flags: [],
+              translatorComments: [],
+            },
+            message: with generated id,
+            obsolete: false,
+            origin: [],
+            translation: ,
+          },
+          custom.id: {
+            comments: [],
+            context: null,
+            extra: {
+              flags: [],
+              translatorComments: [],
+            },
+            obsolete: false,
+            origin: [],
+            translation: ,
+          },
+        }
+      `)
+    })
+
+    it("should set `js-explicit-id` for messages with explicit id when [explicitIdAsDefault: false]", () => {
+      const format = createFormatter({
+        origins: true,
+        explicitIdAsDefault: false,
+      })
+
+      const serialized = format.serialize(
+        catalog,
+        defaultSerializeCtx
+      ) as string
+
+      expect(serialized).toMatchInlineSnapshot(`
+        msgid ""
+        msgstr ""
+        "POT-Creation-Date: 2018-08-27 10:00+0000\\n"
+        "MIME-Version: 1.0\\n"
+        "Content-Type: text/plain; charset=utf-8\\n"
+        "Content-Transfer-Encoding: 8bit\\n"
+        "X-Generator: @lingui/cli\\n"
+        "Language: en\\n"
+
+        msgctxt "my context"
+        msgid "with generated id"
+        msgstr ""
+
+        #. js-lingui-explicit-id
+        msgid "custom.id"
+        msgstr ""
+
+      `)
+
+      const actual = format.parse(serialized, defaultParseCtx)
+      expect(actual).toMatchInlineSnapshot(`
+        {
+          Dgzql1: {
+            comments: [],
+            context: my context,
+            extra: {
+              flags: [],
+              translatorComments: [],
+            },
+            message: with generated id,
+            obsolete: false,
+            origin: [],
+            translation: ,
+          },
+          custom.id: {
+            comments: [
+              js-lingui-explicit-id,
+            ],
+            context: null,
+            extra: {
+              flags: [],
+              translatorComments: [],
+            },
+            obsolete: false,
+            origin: [],
+            translation: ,
+          },
+        }
+      `)
+    })
+  })
+
   it("should print lingui id if printLinguiId = true", () => {
     const format = createFormatter({ origins: true, printLinguiId: true })
 

--- a/website/docs/releases/migration-4.md
+++ b/website/docs/releases/migration-4.md
@@ -89,6 +89,37 @@ The context feature affects the message ID generation and adds the `msgctxt` par
 
 This also affects the `orderBy` with `messageId` as now the generated id is used when custom id is absent. To avoid confusion, we switched the default `orderBy` to use the source message (`message`) instead.
 
+### Translation outside React components migration
+
+If you have been using the following pattern in your code:
+
+```tsx
+import { t } from "@lingui/macro"
+
+const myMsg = t`Hello world!`
+
+export function Greeting(props: {}) {
+  return <h1>{t(myMsg)}</h1>
+}
+```
+You will need to make some changes as this is a misuse of the library that actually worked in v3.
+
+Due to the changes caused by hash-based message ID feature described earlier, this approach will no longer work.
+
+Instead, please use [recommended](/docs/tutorials/react-patterns.md#lazy-translations) pattern for such translations:
+```tsx
+import { t } from "@lingui/macro"
+import { useLingui } from "@lingui/react"
+
+const myMsg = msg`Hello world!`
+
+export function Greeting(props: {}) {
+  const { i18n } = useLingui()
+
+  return <h1>{i18n._(myMsg)}</h1>
+}
+```
+
 ### Change in generated ICU messages for nested JSX Macros
 
 We have made a small change in how Lingui generates ICU messages for nested JSX Macros. We have removed leading spaces from the texts in all cases.

--- a/website/docs/tutorials/react.md
+++ b/website/docs/tutorials/react.md
@@ -110,7 +110,7 @@ Let's start with the basics - static messages. These messages don't have any var
 All we need to make this heading translatable is wrap it in [`Trans`](/docs/ref/macro.md#trans) macro:
 
 ```jsx
-import { Trans } from '@lingui/macro'
+import { Trans } from '@lingui/macro';
 
 <h1><Trans>Message Inbox</Trans></h1>
 ```
@@ -124,7 +124,7 @@ In general, macros are executed at compile time and they transform source code i
 Under the hood, all JSX macros are transformed into [`Trans`](/docs/ref/react.md#trans) component. Take a look at this short example. This is what we write:
 
 ```jsx
-import { Trans } from '@lingui/macro'
+import { Trans } from '@lingui/macro';
 
 <Trans>Hello {name}</Trans>
 ```
@@ -132,13 +132,22 @@ import { Trans } from '@lingui/macro'
 And this is how the code is transformed:
 
 ```jsx
-import { Trans } from '@lingui/react'
+import { Trans } from '@lingui/react';
 
-<Trans id="Hello {name}" values={{ name }} />
+<Trans id="OVaF9k" message="Hello {name}" values={{ name }} />
 ```
 
-See the difference? [`Trans`](/docs/ref/react.md#trans) component receives `id` prop with a message in ICU MessageFormat syntax.
+See the difference? [`Trans`](/docs/ref/react.md#trans) component receives `id` and `message` props with a message in ICU MessageFormat syntax.
 We could write it manually, but it's just easier and shorter to write JSX as we're used to and let macros to generate message for ourselves.
+
+Another advantage of using macros is that all non-essential properties are dropped in the production build. This results in a significant reduction in the size footprint for internationalization.
+
+```jsx
+// NODE_ENV=production
+import { Trans } from '@lingui/react';
+
+<Trans id="OVaF9k" values={{ name }} />
+```
 
 ### Extracting messages
 


### PR DESCRIPTION
# Description

As was raised few time on github issues and discord, people experiencing troubles while migrating catalogs with explicit IDs. This PR adds documentation as well as a new option for `po-format` which is aimed to make migration smoother. 

Related: https://github.com/lingui/js-lingui/issues/1667

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
