### PR TITLE
fix(extractor): support jsx in js files

### DIFF
--- a/packages/cli/src/api/catalog.test.ts
+++ b/packages/cli/src/api/catalog.test.ts
@@ -180,6 +180,7 @@ describe("Catalog", () => {
     it("should support JSX and Typescript", async () => {
       const messages = await extractFromFiles(
         [
+          fixture("collect-typescript-jsx/jsx-in-js.js"),
           fixture("collect-typescript-jsx/jsx-syntax.jsx"),
           fixture("collect-typescript-jsx/tsx-syntax.tsx"),
           fixture("collect-typescript-jsx/macro.tsx"),

--- a/packages/cli/src/api/extractors/babel.ts
+++ b/packages/cli/src/api/extractors/babel.ts
@@ -49,7 +49,7 @@ const extractor: ExtractorType = {
       }
     }
 
-    if ([/\.jsx$/, /\.tsx$/].some((r) => filename.match(r))) {
+    if ([/\.js$/, /\.jsx$/, /\.tsx$/].some((r) => filename.match(r))) {
       parserPlugins.push("jsx")
     }
 

--- a/packages/cli/src/api/fixtures/collect-typescript-jsx/jsx-in-js.js
+++ b/packages/cli/src/api/fixtures/collect-typescript-jsx/jsx-in-js.js
@@ -1,0 +1,2 @@
+// jsx syntax in files without explicit jsx extension
+const jsx = <div>Hello!</div>


### PR DESCRIPTION
# Description

It seems it's quite common to have JSX in *.js files (not *.jsx)
https://github.com/lingui/js-lingui/issues/1638#issuecomment-1567093390