### PR TITLE
docs: fix import in migration v4

### DIFF
--- a/website/docs/releases/migration-4.md
+++ b/website/docs/releases/migration-4.md
@@ -108,7 +108,7 @@ Due to the changes caused by hash-based message ID feature described earlier, th
 
 Instead, please use [recommended](/docs/tutorials/react-patterns.md#lazy-translations) pattern for such translations:
 ```tsx
-import { t } from "@lingui/macro"
+import { msg } from "@lingui/macro"
 import { useLingui } from "@lingui/react"
 
 const myMsg = msg`Hello world!`


### PR DESCRIPTION
# Description

Hi, the v4 migration page specifies a recommended pattern with "msg" but the associated import is still the old "t".

## Types of changes



- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

Fixes # (issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
