### PR TITLE
fix(format-po-gettext): bad return during mapping with `serializePlurals`

### DIFF
--- a/packages/format-po-gettext/src/__snapshots__/po-gettext.test.ts.snap
+++ b/packages/format-po-gettext/src/__snapshots__/po-gettext.test.ts.snap
@@ -73,6 +73,10 @@ msgstr ""
 "Plural-Forms: \\n"
 
 #. js-lingui-explicit-id
+msgid "static"
+msgstr "Static message"
+
+#. js-lingui-explicit-id
 #. js-lingui:pluralize_on=count
 msgid "message_with_id_and_octothorpe"
 msgid_plural "message_with_id_and_octothorpe_plural"
@@ -160,6 +164,19 @@ exports[`po-gettext format should convert gettext plurals to ICU plural messages
     obsolete: false,
     origin: [],
     translation: ,
+  },
+  static: {
+    comments: [
+      js-lingui-explicit-id,
+    ],
+    context: null,
+    extra: {
+      flags: [],
+      translatorComments: [],
+    },
+    obsolete: false,
+    origin: [],
+    translation: Static message,
   },
 }
 `;

--- a/packages/format-po-gettext/src/fixtures/messages_plural.po
+++ b/packages/format-po-gettext/src/fixtures/messages_plural.po
@@ -7,6 +7,10 @@ msgstr ""
 "X-Generator: @lingui/cli\n"
 "Language: en\n"
 
+#. js-lingui-explicit-id
+msgid "static"
+msgstr "Static message"
+
 #. js-lingui:pluralize_on=someCount
 #. js-lingui-explicit-id
 msgid "message_with_id"

--- a/packages/format-po-gettext/src/po-gettext.test.ts
+++ b/packages/format-po-gettext/src/po-gettext.test.ts
@@ -32,6 +32,9 @@ describe("po-gettext format", () => {
 
   it("should convert ICU plural messages to gettext plurals", () => {
     const catalog: CatalogType = {
+      static: {
+        translation: "Static message",
+      },
       message_with_id_and_octothorpe: {
         message: "{count, plural, one {Singular} other {Number is #}}",
         translation: "{count, plural, one {Singular} other {Number is #}}",

--- a/packages/format-po-gettext/src/po-gettext.ts
+++ b/packages/format-po-gettext/src/po-gettext.ts
@@ -54,7 +54,7 @@ function serializePlurals(
   const icuMessage = message.message
 
   if (!icuMessage) {
-    return
+    return item
   }
 
   const _simplifiedMessage = icuMessage.replace(LINE_ENDINGS, " ")


### PR DESCRIPTION
# Description

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

In v4 this formatter can return `undefined` when passing a non-plural message to the `serializePlurals` function, which will throw later when serializing the PO file. The original item should be returned instead.

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
