### PR TITLE
feat: allow comment prop on react Trans component

### DIFF
--- a/packages/react/src/Trans.tsx
+++ b/packages/react/src/Trans.tsx
@@ -27,6 +27,7 @@ export type TransProps = {
   values?: Record<string, unknown>
   components?: { [key: string]: React.ElementType | any }
   formats?: Record<string, unknown>
+  comment?: string
   children?: React.ReactNode
 } & TransRenderCallbackOrComponent
 

--- a/website/docs/ref/react.md
+++ b/website/docs/ref/react.md
@@ -18,8 +18,9 @@ Default rendering component can be set using `defaultComponent` prop in [`I18nPr
 | Prop name   | Type                                      | Description                                    |
 |-------------| ----------------------------------------- |------------------------------------------------|
 | `className` | string                                    | Class name to be added to `<span>` element     |
-| `render`    | Function(props) -> Element \| `null`   | Custom render callback to render translation        |
-| `component` | Component \| `null`                         | Custom component to render translation |
+| `render`    | Function(props) -> Element \| `null`      | Custom render callback to render translation   |
+| `component` | Component \| `null`                       | Custom component to render translation         |
+| `comment`   | string                                    | Comment picked up by extractor to provide translation context |
 
 `className` is used only for built-in components (when *render* is string).
 
@@ -153,7 +154,7 @@ import { Trans } from "@lingui/macro"
 ```
 :::
 
-It's also possible to use `Trans` component directly without macros. In that case, `id` identifies the message being translated. `values` and `components` are arguments and components used for formatting translation:
+It's also possible to use `Trans` component directly without macros. In that case, `id` identifies the message being translated. `values` and `components` are arguments and components used for formatting translation. `comment` helps add context for translators:
 
 ```jsx
 <Trans id="my.message" message="Hello World"/>
@@ -162,6 +163,12 @@ It's also possible to use `Trans` component directly without macros. In that cas
   id="greeting"
   message="Hello {name}"
   values={{ name: 'Arthur' }}
+/>
+
+<Trans
+  id="hello.world"
+  message="Hello world"
+  comment="a message that says hi to the world"
 />
 
 // number of tag corresponds to index in `components` prop


### PR DESCRIPTION
Tested by publishing to Verdaccio and installing in a project of mine. Worked like a charm. The React Trans tests even use comment in `jsx-without-macros.js`.

# Description

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Fixes # (issue)

https://github.com/lingui/js-lingui/issues/1713

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
