### PR TITLE
fix: export ts types from detect-locale

### DIFF
--- a/packages/detect-locale/package.json
+++ b/packages/detect-locale/package.json
@@ -36,8 +36,14 @@
   },
   "exports": {
     ".": {
-      "require": "./dist/index.cjs",
-      "import": "./dist/index.mjs"
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.cjs"
+      },
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.mjs"
+      }
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
# Description
Fixes a bug where typescript types for the detect-locale package aren't being exported.  Currently using detect-locale in a TS project throws the following error:

```
Could not find a declaration file for module '@lingui/detect-locale'. '.../@lingui+detect-locale@4.3.0/node_modules/@lingui/detect-locale/dist/index.mjs' implicitly has an 'any' type.
  There are types at '.../node_modules/@lingui/detect-locale/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@lingui/detect-locale' library may need to update its package.json or typings.ts(7016)
```

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
