### PR TITLE
Revert "refactor: use useSyncExternalStore to subscribe for context u…

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -63,14 +63,12 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.20.13",
-    "@lingui/core": "4.4.1",
-    "use-sync-external-store": "^1.2.0"
+    "@lingui/core": "4.4.1"
   },
   "devDependencies": {
     "@lingui/jest-mocks": "*",
     "@testing-library/react": "^14.0.0",
     "@types/react": "^18.2.13",
-    "@types/use-sync-external-store": "^0.0.3",
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "react": "^18.2.0",

--- a/packages/react/src/I18nProvider.test.tsx
+++ b/packages/react/src/I18nProvider.test.tsx
@@ -132,6 +132,53 @@ describe("I18nProvider", () => {
     expect(container.textContent).toEqual("1_cs2_cs")
   })
 
+  it(
+    "given 'en' locale, if activate('cs') call happens before i18n.on-change subscription in useEffect(), " +
+      "I18nProvider detects that it's stale and re-renders with the 'cs' locale value",
+    () => {
+      const i18n = setupI18n({
+        locale: "en",
+        messages: { en: {} },
+      })
+      let renderCount = 0
+
+      const CurrentLocaleContextConsumer = () => {
+        const { i18n } = useLingui()
+        renderCount++
+        return <span data-testid="child">{i18n.locale}</span>
+      }
+
+      /**
+       * Note that we're doing exactly what the description says:
+       * but to simulate the equivalent situation, we pass our own mock subscriber
+       * to i18n.on("change", ...) and in it we call i18n.activate("cs") ourselves
+       * so that the condition in useEffect() is met and the component re-renders
+       * */
+      const mockSubscriber = jest.fn(() => {
+        i18n.load("cs", {})
+        i18n.activate("cs")
+        return () => {
+          // unsubscriber - noop to make TS happy
+        }
+      })
+      jest.spyOn(i18n, "on").mockImplementation(mockSubscriber)
+
+      const { getByTestId } = render(
+        <I18nProvider i18n={i18n}>
+          <CurrentLocaleContextConsumer />
+        </I18nProvider>
+      )
+
+      expect(mockSubscriber).toHaveBeenCalledWith(
+        "change",
+        expect.any(Function)
+      )
+
+      expect(getByTestId("child").textContent).toBe("cs")
+      expect(renderCount).toBe(2)
+    }
+  )
+
   it("should render children", () => {
     const i18n = setupI18n({
       locale: "en",
@@ -178,37 +225,5 @@ describe("I18nProvider", () => {
     })
 
     expect(getByText("Ahoj světe")).toBeTruthy()
-  })
-
-  it("when re-rendered with new i18n instance, it will forward it to children", () => {
-    const i18nCs = setupI18n({
-      locale: "cs",
-      messages: { cs: {} },
-    })
-
-    const i18nEn = setupI18n({
-      locale: "en",
-      messages: { en: {} },
-    })
-
-    const CurrentLocaleContextConsumer = () => {
-      const { i18n } = useLingui()
-      return <span data-testid="dynamic">{i18n.locale}</span>
-    }
-
-    const { container, rerender } = render(
-      <I18nProvider i18n={i18nCs}>
-        <CurrentLocaleContextConsumer />
-      </I18nProvider>
-    )
-
-    expect(container.textContent).toEqual("cs")
-
-    rerender(
-      <I18nProvider i18n={i18nEn}>
-        <CurrentLocaleContextConsumer />
-      </I18nProvider>
-    )
-    expect(container.textContent).toEqual("en")
   })
 })

--- a/packages/react/src/I18nProvider.tsx
+++ b/packages/react/src/I18nProvider.tsx
@@ -1,11 +1,4 @@
-import React, {
-  ComponentType,
-  FunctionComponent,
-  useCallback,
-  useRef,
-} from "react"
-import { useSyncExternalStore } from "use-sync-external-store/shim"
-
+import React, { ComponentType, FunctionComponent } from "react"
 import type { I18n } from "@lingui/core"
 import type { TransRenderProps } from "./TransNoContext"
 
@@ -38,6 +31,7 @@ export const I18nProvider: FunctionComponent<I18nProviderProps> = ({
   defaultComponent,
   children,
 }) => {
+  const latestKnownLocale = React.useRef<string | undefined>(i18n.locale)
   /**
    * We can't pass `i18n` object directly through context, because even when locale
    * or messages are changed, i18n object is still the same. Context provider compares
@@ -49,7 +43,7 @@ export const I18nProvider: FunctionComponent<I18nProviderProps> = ({
    *
    * We can't use useMemo hook either, because we want to recalculate value manually.
    */
-  const makeContext = useCallback(
+  const makeContext = React.useCallback(
     () => ({
       i18n,
       defaultComponent,
@@ -57,43 +51,34 @@ export const I18nProvider: FunctionComponent<I18nProviderProps> = ({
     }),
     [i18n, defaultComponent]
   )
-  const context = useRef<I18nContext>(makeContext())
 
-  const subscribe = useCallback(
-    (onStoreChange: () => void) => {
-      const renderWithFreshContext = () => {
-        context.current = makeContext()
-        onStoreChange()
-      }
-      const propsChanged =
-        context.current.i18n !== i18n ||
-        context.current.defaultComponent !== defaultComponent
-      if (propsChanged) {
-        renderWithFreshContext()
-      }
-      return i18n.on("change", renderWithFreshContext)
-    },
-    [makeContext, i18n, defaultComponent]
-  )
-
-  const getSnapshot = useCallback(() => {
-    return context.current
-  }, [])
+  const [context, setContext] = React.useState<I18nContext>(makeContext())
 
   /**
    * Subscribe for locale/message changes
    *
-   * the I18n object passed via props is the single source of truth for all i18n related
+   * I18n object from `@lingui/core` is the single source of truth for all i18n related
    * data (active locale, catalogs). When new messages are loaded or locale is changed
-   * we need to trigger re-rendering of LinguiContext consumers.
+   * we need to trigger re-rendering of LinguiContext.Consumers.
    */
-  const contextObject = useSyncExternalStore(
-    subscribe,
-    getSnapshot,
-    getSnapshot
-  )
+  React.useEffect(() => {
+    const updateContext = () => {
+      latestKnownLocale.current = i18n.locale
+      setContext(makeContext())
+    }
+    const unsubscribe = i18n.on("change", updateContext)
 
-  if (!contextObject.i18n.locale) {
+    /**
+     * unlikely, but if the locale changes before the onChange listener
+     * was added, we need to trigger a rerender
+     * */
+    if (latestKnownLocale.current !== i18n.locale) {
+      updateContext()
+    }
+    return unsubscribe
+  }, [i18n, makeContext])
+
+  if (!latestKnownLocale.current) {
     process.env.NODE_ENV === "development" &&
       console.log(
         "I18nProvider rendered `null`. A call to `i18n.activate` needs to happen in order for translations to be activated and for the I18nProvider to render." +
@@ -103,8 +88,6 @@ export const I18nProvider: FunctionComponent<I18nProviderProps> = ({
   }
 
   return (
-    <LinguiContext.Provider value={contextObject}>
-      {children}
-    </LinguiContext.Provider>
+    <LinguiContext.Provider value={context}>{children}</LinguiContext.Provider>
   )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3123,13 +3123,11 @@ __metadata:
     "@lingui/jest-mocks": "*"
     "@testing-library/react": ^14.0.0
     "@types/react": ^18.2.13
-    "@types/use-sync-external-store": ^0.0.3
     eslint-plugin-react: ^7.32.2
     eslint-plugin-react-hooks: ^4.6.0
     react: ^18.2.0
     react-dom: ^18.2.0
     unbuild: ^1.1.2
-    use-sync-external-store: ^1.2.0
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
   languageName: unknown
@@ -4394,13 +4392,6 @@ __metadata:
   version: 4.0.2
   resolution: "@types/tough-cookie@npm:4.0.2"
   checksum: e055556ffdaa39ad85ede0af192c93f93f986f4bd9e9426efdc2948e3e2632db3a4a584d4937dbf6d7620527419bc99e6182d3daf2b08685e710f2eda5291905
-  languageName: node
-  linkType: hard
-
-"@types/use-sync-external-store@npm:^0.0.3":
-  version: 0.0.3
-  resolution: "@types/use-sync-external-store@npm:0.0.3"
-  checksum: 161ddb8eec5dbe7279ac971531217e9af6b99f7783213566d2b502e2e2378ea19cf5e5ea4595039d730aa79d3d35c6567d48599f69773a02ffcff1776ec2a44e
   languageName: node
   linkType: hard
 
@@ -14830,15 +14821,6 @@ __metadata:
     querystringify: ^2.1.1
     requires-port: ^1.0.0
   checksum: fbdba6b1d83336aca2216bbdc38ba658d9cfb8fc7f665eb8b17852de638ff7d1a162c198a8e4ed66001ddbf6c9888d41e4798912c62b4fd777a31657989f7bdf
-  languageName: node
-  linkType: hard
-
-"use-sync-external-store@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "use-sync-external-store@npm:1.2.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: 5c639e0f8da3521d605f59ce5be9e094ca772bd44a4ce7322b055a6f58eeed8dda3c94cabd90c7a41fb6fa852210092008afe48f7038792fd47501f33299116a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
…pdates (#1746)"

This reverts commit 47d4fdb89889647f2dd823666fb75b1a0f1e9f39.

this closes #1754.

For now, this seems to be the best way to go about this, probably until https://github.com/facebook/react/pull/26230 is released.

# Description

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
