### PR TITLE
chore: bump unraw from 2.0.1 to 3.0.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,7 +55,7 @@
   "dependencies": {
     "@babel/runtime": "^7.20.13",
     "@lingui/message-utils": "4.4.2",
-    "unraw": "^2.0.1"
+    "unraw": "^3.0.0"
   },
   "devDependencies": {
     "@lingui/jest-mocks": "*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2962,7 +2962,7 @@ __metadata:
     "@lingui/jest-mocks": "*"
     "@lingui/message-utils": 4.4.2
     unbuild: ^1.1.2
-    unraw: ^2.0.1
+    unraw: ^3.0.0
   languageName: unknown
   linkType: soft
 
@@ -14765,10 +14765,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"unraw@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "unraw@npm:2.0.1"
-  checksum: af9a9d2f6e420cb4f52fe2f1f5982e6b0be95da640d6ae8d6d9ff631d864771793cb9fe7e2a16ef1ce631b94065f4438e7bd7f1701076fc69296edc4e704d42f
+"unraw@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "unraw@npm:3.0.0"
+  checksum: 19eee0bc500ce197d262b79723a2c8c81c1d716baaa2a62c48a4d0d6b9e1fd9d350c5df86262e51343d591ab9c8a47ed150317d0b867b2b65795cdc17ef69873
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

This bumps unraw to version 3.0.0. It fixes source map warnings found in https://github.com/iansan5653/unraw/issues/33.

After upgrading to newer version of `@lingui/core`, I started getting warnings like these due to unraw 2.0.1:

```bash
WARNING in ./.yarn/cache/unraw-npm-2.0.1-5ecb408b75-af9a9d2f6e.zip/node_modules/unraw/dist/index.js
Module Warning (from ./.yarn/__virtual__/source-map-loader-virtual-27a3af5d08/0/cache/source-map-loader-npm-3.0.1-4faa2e7eac-6ff27ba933.zip/node_modules/source-map-loader/dist/cjs.js):
Failed to parse source map from '.yarn\cache\unraw-npm-2.0.1-5ecb408b75-af9a9d2f6e.zip\node_modules\unraw\src\index.ts' file: Error: ENOENT: no such file or directory, open '/node_modules/unraw/src/index.ts'
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Fixes https://github.com/iansan5653/unraw/issues/33.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
