### PR TITLE
feat(react): export react server sub-entry

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -51,6 +51,16 @@
         "default": "./dist/index.mjs"
       }
     },
+    "./server": {
+      "require": {
+        "types": "./dist/server.d.ts",
+        "default": "./dist/server.cjs"
+      },
+      "import": {
+        "types": "./dist/server.d.ts",
+        "default": "./dist/server.mjs"
+      }
+    },
     "./package.json": "./package.json"
   },
   "files": [

--- a/test/node-api-esm/index.js
+++ b/test/node-api-esm/index.js
@@ -6,3 +6,4 @@ assert(await import("@lingui/cli/api/extractors/typescript"))
 assert(await import("@lingui/cli/api/extractors/babel"))
 
 assert(await import("@lingui/core"))
+assert(await import("@lingui/react/server"))


### PR DESCRIPTION
# Description

Exposing `@lingui/react/server` as sub-entry in package.json. 

It seems i messed up somewhere because I clearly remember that I already did it (and local history in webstorm confirming it), but that somehow didn't go to the PR and was never merged to the master.  Fixing this.

Related to: https://github.com/lingui/js-lingui/issues/1698

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
