### PR TITLE
chore: deprecate isTranslated prop

### DIFF
--- a/packages/react/src/TransNoContext.tsx
+++ b/packages/react/src/TransNoContext.tsx
@@ -9,6 +9,9 @@ export type TransRenderProps = {
   translation: React.ReactNode
   children: React.ReactNode
   message?: string | null
+  /**
+   * @deprecated isTranslated prop is undocumented and buggy. It'll be removed in v5 release.
+   * */
   isTranslated: boolean
 }
 
@@ -107,6 +110,7 @@ export function TransNoContext(
     id,
     message,
     translation,
+    // TODO vonovak - remove isTranslated prop in v5 release
     isTranslated: id !== translation && message !== translation,
     children: translation, // for type-compatibility with `component` prop
   }

--- a/website/docs/ref/react.md
+++ b/website/docs/ref/react.md
@@ -94,9 +94,7 @@ i18n.load({
 });
 i18n.activate("en");
 
-const DefaultI18n = ({ isTranslated, children }) => (
-  <span style={{ color: isTranslated ? undefined : "red" }}>{children}</span>
-);
+const DefaultI18n = ({ children }) => <span>{children}</span>;
 
 const App = () => {
   return (


### PR DESCRIPTION
# Description

Small maintenance PR: this prop is not really documented and it's buggy, as seen in https://github.com/lingui/js-lingui/pull/1643#discussion_r1186893179

I tried to print a console warning when user accesses the prop so they get a message. However, React itself reads the props when calling createElement and so even if users don't use the prop, the warning would be logged. We'd need to do some heuristic on the stack trace to determine when to not print the warning and it wouldn't be pretty.

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
