### PR TITLE
Make generateMessageId work in browser

### DIFF
--- a/packages/core/src/interpolate.test.ts
+++ b/packages/core/src/interpolate.test.ts
@@ -1,5 +1,4 @@
 import { compileMessage as compile } from "@lingui/message-utils/compileMessage"
-import { mockEnv, mockConsole } from "@lingui/jest-mocks"
 import { interpolate } from "./interpolate"
 import { Locale, Locales } from "./i18n"
 
@@ -8,15 +7,6 @@ describe("interpolate", () => {
     const tokens = compile(translation)
     return interpolate(tokens, locale || "en", locales)
   }
-
-  it("should handle an error if message has syntax errors", () => {
-    mockConsole((console) => {
-      expect(compile("Invalid {message")).toEqual("Invalid {message")
-      expect(console.error).toBeCalledWith(
-        expect.stringMatching("Unexpected message end at line")
-      )
-    })
-  })
 
   it("should process string chunks with provided map fn", () => {
     const tokens = compile(
@@ -36,17 +26,7 @@ describe("interpolate", () => {
     ])
   })
 
-  it("should compile static message", () => {
-    const cache = compile("Static message")
-    expect(cache).toEqual("Static message")
-
-    mockEnv("production", () => {
-      const cache = compile("Static message")
-      expect(cache).toEqual("Static message")
-    })
-  })
-
-  it("should compile message with variable", () => {
+  it("should interpolate message with variable", () => {
     const cache = compile("Hey {name}!")
     expect(interpolate(cache, "en", [])({ name: "Joe" })).toEqual("Hey Joe!")
   })
@@ -54,10 +34,10 @@ describe("interpolate", () => {
   it("should not interpolate escaped placeholder", () => {
     const msg = prepare("Hey '{name}'!")
 
-    expect(msg({})).toEqual("Hey {name}!")
+    expect(msg({ name: "Joe" })).toEqual("Hey {name}!")
   })
 
-  it("should compile plurals", () => {
+  it("should interpolate plurals", () => {
     const plural = prepare(
       "{value, plural, one {{value} Book} other {# Books}}"
     )
@@ -72,7 +52,7 @@ describe("interpolate", () => {
     expect(offset({ value: 3 })).toEqual("2 Books")
   })
 
-  it("should compile plurals with falsy value choice", () => {
+  it("should interpolate plurals with falsy value choice", () => {
     const plural = prepare("{value, plural, one {} other {# Books}}")
     expect(plural({ value: 1 })).toEqual("")
     expect(plural({ value: 2 })).toEqual("2 Books")
@@ -85,7 +65,7 @@ describe("interpolate", () => {
     expect(plural({ value: 30 })).toEqual("30% discount")
   })
 
-  it("should compile selectordinal", () => {
+  it("should interpolate selectordinal", () => {
     const cache = prepare(
       "{value, selectordinal, one {#st Book} two {#nd Book}}"
     )
@@ -119,7 +99,7 @@ describe("interpolate", () => {
     )
   })
 
-  it("should compile select", () => {
+  it("should interpolate select", () => {
     const cache = prepare("{value, select, female {She} other {They}}")
     expect(cache({ value: "female" })).toEqual("She")
     expect(cache({ value: "n/a" })).toEqual("They")
@@ -161,7 +141,7 @@ describe("interpolate", () => {
         expectedCurrency2,
       ] = tc
 
-      it(`should compile custom format for locale=${locale} and locales=${locales}`, () => {
+      it(`should interpolate custom format for locale=${locale} and locales=${locales}`, () => {
         const number = prepare("{value, number}", locale, locales)
         expect(number({ value: 0.1 })).toEqual(expectedNumber)
 

--- a/packages/message-utils/package.json
+++ b/packages/message-utils/package.json
@@ -47,7 +47,8 @@
     "generateMessageId.js"
   ],
   "dependencies": {
-    "@messageformat/parser": "^5.0.0"
+    "@messageformat/parser": "^5.0.0",
+    "js-sha256": "^0.10.1"
   },
   "devDependencies": {
     "@lingui/jest-mocks": "workspace:^",

--- a/packages/message-utils/src/compileMessage.test.ts
+++ b/packages/message-utils/src/compileMessage.test.ts
@@ -1,0 +1,211 @@
+import { mockConsole } from "@lingui/jest-mocks"
+import { compileMessage } from "./compileMessage"
+
+describe("compileMessage", () => {
+  it("should handle an error if message has syntax errors", () => {
+    mockConsole((console) => {
+      expect(compileMessage("Invalid {message")).toEqual("Invalid {message")
+      expect(console.error).toBeCalledWith(
+        expect.stringMatching("Unexpected message end at line")
+      )
+    })
+  })
+
+  it("should process string chunks with provided map fn", () => {
+    const tokens = compileMessage(
+      "Message {value, plural, one {{value} Book} other {# Books}}",
+      (text) => `<${text}>`
+    )
+    expect(tokens).toEqual([
+      "<Message >",
+      [
+        "value",
+        "plural",
+        {
+          one: [["value"], "< Book>"],
+          other: ["#", "< Books>"],
+        },
+      ],
+    ])
+  })
+
+  it("should compileMessage static message", () => {
+    const tokens = compileMessage("Static message")
+    expect(tokens).toEqual("Static message")
+  })
+
+  it("should compileMessage message with variable", () => {
+    const tokens = compileMessage("Hey {name}!")
+    expect(tokens).toMatchInlineSnapshot(`
+      [
+        Hey ,
+        [
+          name,
+        ],
+        !,
+      ]
+    `)
+  })
+
+  it("should not interpolate escaped placeholder", () => {
+    const tokens = compileMessage("Hey '{name}'!")
+    expect(tokens).toMatchInlineSnapshot(`Hey {name}!`)
+  })
+
+  it("should compile plurals", () => {
+    const tokens = compileMessage(
+      "{value, plural, offset:1 =0 {No Books} one {# Book} other {# Books}}"
+    )
+    expect(tokens).toMatchInlineSnapshot(`
+      [
+        [
+          value,
+          plural,
+          {
+            0: No Books,
+            offset: 1,
+            one: [
+              #,
+               Book,
+            ],
+            other: [
+              #,
+               Books,
+            ],
+          },
+        ],
+      ]
+    `)
+  })
+
+  it("should compile selectordinal", () => {
+    const tokens = compileMessage(
+      "{value, selectordinal, one {#st Book} two {#nd Book}}"
+    )
+    expect(tokens).toMatchInlineSnapshot(`
+      [
+        [
+          value,
+          selectordinal,
+          {
+            offset: undefined,
+            one: [
+              #,
+              st Book,
+            ],
+            two: [
+              #,
+              nd Book,
+            ],
+          },
+        ],
+      ]
+    `)
+  })
+
+  it("should compile nested choice components", () => {
+    const tokens = compileMessage(
+      `{
+      gender, select,
+      male {{numOfGuests, plural, one {He invites one guest} other {He invites # guests}}}
+      female {{numOfGuests, plural, one {She invites one guest} other {She invites # guests}}}
+      other {They is {gender}}}`
+    )
+    expect(tokens).toMatchInlineSnapshot(`
+      [
+        [
+          gender,
+          select,
+          {
+            female: [
+              [
+                numOfGuests,
+                plural,
+                {
+                  offset: undefined,
+                  one: She invites one guest,
+                  other: [
+                    She invites ,
+                    #,
+                     guests,
+                  ],
+                },
+              ],
+            ],
+            male: [
+              [
+                numOfGuests,
+                plural,
+                {
+                  offset: undefined,
+                  one: He invites one guest,
+                  other: [
+                    He invites ,
+                    #,
+                     guests,
+                  ],
+                },
+              ],
+            ],
+            offset: undefined,
+            other: [
+              They is ,
+              [
+                gender,
+              ],
+            ],
+          },
+        ],
+      ]
+    `)
+  })
+
+  it("should compile select", () => {
+    const tokens = compileMessage("{value, select, female {She} other {They}}")
+    expect(tokens).toMatchInlineSnapshot(`
+      [
+        [
+          value,
+          select,
+          {
+            female: She,
+            offset: undefined,
+            other: They,
+          },
+        ],
+      ]
+    `)
+  })
+
+  it("should compile date", () => {
+    const tokens = compileMessage("{value, date}")
+    expect(tokens).toMatchInlineSnapshot(`
+      [
+        [
+          value,
+          date,
+        ],
+      ]
+    `)
+  })
+
+  it("should compile number", () => {
+    expect(compileMessage("{value, number, percent}")).toMatchInlineSnapshot(`
+      [
+        [
+          value,
+          number,
+          percent,
+        ],
+      ]
+    `)
+    expect(compileMessage("{value, number}")).toMatchInlineSnapshot(`
+      [
+        [
+          value,
+          number,
+        ],
+      ]
+    `)
+  })
+})

--- a/packages/message-utils/src/generateMessageId.ts
+++ b/packages/message-utils/src/generateMessageId.ts
@@ -1,11 +1,17 @@
-import crypto from "crypto"
+import { sha256 } from "js-sha256"
 
 const UNIT_SEPARATOR = "\u001F"
 
 export function generateMessageId(msg: string, context = "") {
-  return crypto
-    .createHash("sha256")
-    .update(msg + UNIT_SEPARATOR + (context || ""))
-    .digest("base64")
-    .slice(0, 6)
+  return hexToBase64(sha256(msg + UNIT_SEPARATOR + (context || ""))).slice(0, 6)
+}
+
+function hexToBase64(hexStr: string) {
+  let base64 = ""
+  for (let i = 0; i < hexStr.length; i++) {
+    base64 += !((i - 1) & 1)
+      ? String.fromCharCode(parseInt(hexStr.substring(i - 1, i + 1), 16))
+      : ""
+  }
+  return btoa(base64)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3411,6 +3411,7 @@ __metadata:
   dependencies:
     "@lingui/jest-mocks": "workspace:^"
     "@messageformat/parser": ^5.0.0
+    js-sha256: ^0.10.1
     unbuild: 2.0.0
   languageName: unknown
   linkType: soft
@@ -10652,6 +10653,13 @@ __metadata:
     typescript: ^4.9.5
   languageName: unknown
   linkType: soft
+
+"js-sha256@npm:^0.10.1":
+  version: 0.10.1
+  resolution: "js-sha256@npm:0.10.1"
+  checksum: 6eb5c9f95aa902cec1930f036deb3bc664024b75fede456c0ac74b855797776c18620f47efec36787077a56ba2f3b8d6aacc7733ff8a2b5bb9ce6b655a35c5e6
+  languageName: node
+  linkType: hard
 
 "js-tokens@npm:^3.0.0 || ^4.0.0, js-tokens@npm:^4.0.0":
   version: 4.0.0


### PR DESCRIPTION
# Description

There is some demand to compile catalogs and messages on the fly. The `generateMessageId` function used nodejs api before, and it makes it not possible to use in the browser. There is a native WebCrypro api which supported in both browser and nodejs, but unfortunately it's async only and could not be used in babel macros transformation which is synchronous.  

I've used a custom [js sha256](https://github.com/emn178/js-sha256) implementation, which is according to theirs benchmark fast as a native implementation.

Also i did not like that tests for `compileMessage` Function is stored somewhere else, so i extracted them from `api` package.

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
