### PR TITLE
docs: add explicit vs generated id doc. Move to non-global string-only translations

### DIFF
--- a/website/docs/ref/macro.md
+++ b/website/docs/ref/macro.md
@@ -778,11 +778,11 @@ const message = /*i18n*/ {
 
 ### `Trans`
 
-| Prop name | Type   | Description                                                                                     |
-| --------- | ------ | ----------------------------------------------------------------------------------------------- |
-| `id`      | string | Custom message ID                                                                               |
-| `comment` | string | Comment for translators                                                                         |
-| `context` | string | Allows to extract the same messages with different IDs. See [Context](#context) for more detail |
+| Prop name | Type   | Description                                                                                                                         |
+| --------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `id`      | string | Custom message ID                                                                                                                   |
+| `comment` | string | Comment for translators                                                                                                             |
+| `context` | string | Allows to extract the same messages with different IDs. See [Context](/tutorials/explicit-vs-generated-ids#context) for more detail |
 
 [`Trans`](/docs/ref/react.md#trans) is the basic macro for static messages, messages with variables, but also for messages with inline markup:
 
@@ -816,7 +816,7 @@ It's removed from the production code.
 
 Contextual information for translators. Similar to [`comment`](#comment) but also allows to extract the same messages with different IDs. It will be visible in the [TMS](/tools/introduction) if supported by it, and the [catalog format](/ref/catalog-formats).
 
-It's removed from the production code. See [Context](#context) for more details.
+It's removed from the production code. See [Context](/tutorials/explicit-vs-generated-ids#context) for more details.
 
 ```jsx
 import { Trans } from "@lingui/macro";
@@ -1010,14 +1010,3 @@ Use `<Select>` inside `<Trans>` macro if you want to provide `id`, `context` or 
   <Select value={gender} _male="His book" _female="Her book" other="Their book" />
 </Trans>
 ```
-
-## Context
-
-By default, when using generated IDs, the same text elements are extracted with the same ID, and then translated once. This, however, may not always be desired because the same text can have different meaning and translation: For example, consider the word "right" and its two possible meanings:
-
-- correct as in "you are right"
-- direction as in "turn right"
-
-To distinguish these two cases, you can add `context` to messages. The same text elements with different contexts are extracted with different IDs. Then, they can be translated differently and merged back into the application as different translation entries.
-
-Regardless of whether you use generated IDs or not, adding context makes the translation process less challenging and helps translators interpret the source accurately. You, in return, get translations of better quality faster and decrease the number of context-related issues you would need to solve.

--- a/website/docs/ref/macro.md
+++ b/website/docs/ref/macro.md
@@ -782,7 +782,7 @@ const message = /*i18n*/ {
 | --------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------- |
 | `id`      | string | Custom message ID                                                                                                                   |
 | `comment` | string | Comment for translators                                                                                                             |
-| `context` | string | Allows to extract the same messages with different IDs. See [Context](/tutorials/explicit-vs-generated-ids#context) for more detail |
+| `context` | string | Allows to extract the same messages with different IDs. See [Context](/docs/tutorials/explicit-vs-generated-ids.md#context) for more detail |
 
 [`Trans`](/docs/ref/react.md#trans) is the basic macro for static messages, messages with variables, but also for messages with inline markup:
 
@@ -816,7 +816,7 @@ It's removed from the production code.
 
 Contextual information for translators. Similar to [`comment`](#comment) but also allows to extract the same messages with different IDs. It will be visible in the [TMS](/tools/introduction) if supported by it, and the [catalog format](/ref/catalog-formats).
 
-It's removed from the production code. See [Context](/tutorials/explicit-vs-generated-ids#context) for more details.
+It's removed from the production code. See [Context](/docs/tutorials/explicit-vs-generated-ids.md#context) for more details.
 
 ```jsx
 import { Trans } from "@lingui/macro";

--- a/website/docs/ref/macro.md
+++ b/website/docs/ref/macro.md
@@ -778,10 +778,10 @@ const message = /*i18n*/ {
 
 ### `Trans`
 
-| Prop name | Type   | Description                                                                                                                         |
-| --------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `id`      | string | Custom message ID                                                                                                                   |
-| `comment` | string | Comment for translators                                                                                                             |
+| Prop name | Type   | Description                                                                                                                                 |
+| --------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`      | string | Custom message ID                                                                                                                           |
+| `comment` | string | Comment for translators                                                                                                                     |
 | `context` | string | Allows to extract the same messages with different IDs. See [Context](/docs/tutorials/explicit-vs-generated-ids.md#context) for more detail |
 
 [`Trans`](/docs/ref/react.md#trans) is the basic macro for static messages, messages with variables, but also for messages with inline markup:

--- a/website/docs/tutorials/explicit-vs-generated-ids.md
+++ b/website/docs/tutorials/explicit-vs-generated-ids.md
@@ -1,0 +1,216 @@
+# Choosing between generated and explicit ID
+
+In this guide, we will explore the fundamental concepts of explicit and generated IDs, and then delve into a comprehensive comparison, highlighting the benefits and drawbacks of each approach.
+
+## What is Explicit ID and What is Generated IDs?
+
+### Explicit ID
+
+An explicit ID, often referred to as a user-defined or custom ID, is a manually assigned identifier associated with a specific message. These IDs are typically chosen by developers and are explicitly specified within your code. The typical explicit id may look like `index.header.title` or `modal.buttons.cancel`.
+
+Lingui example:
+
+```jsx
+<Trans id="index.header.title">LinguiJS example</Trans>
+
+// extracted as
+{
+  id: "index.header.title",
+  message: "LinguiJS example",
+}
+```
+
+### Generated IDs
+
+On the other hand, generated IDs are automatically created by the internalization library. In Lingui, such IDs are created based on a source message and [context](#context).
+
+Lingui example:
+
+```jsx
+<Trans>LinguiJS example</Trans>
+
+// extracted as
+{
+  id: "uxV9Xq",
+  message: "LinguiJS example",
+}
+```
+
+### Benefits of Generated IDs
+
+1. **Avoiding "Naming Things" problem:** You don't need to come up with a name for each single phrase in the app. The natural language is used to create an ID.
+2. **Better Developer Experience:** a more streamlined development process with less code to write.
+3. **Preventing ID collisions:** As your application scales, explicit IDs can potentially lead to conflicts. Lingui's generated IDs ensure you steer clear of such collisions.
+4. **Avoiding Duplicates:** Duplicate messages are merged together automatically. Your translators will not have to translate the same phrases again and again. This could lead to cost savings, especially if translators charge by word count.
+5. **Smaller bundle:** The Lingui generates short ID such as `uxV9Xq` which are typically shorter than manually crafted IDs like `index.header.title`. This results in a smaller bundle size, optimizing your application's performance.
+
+### Benefits of Explicit IDs
+
+1. **Control:** Developers have full control over the naming and assignment of explicit IDs. This control allows for precise targeting and easy maintenance of internationalization keys.
+2. **Readability:** Explicit IDs often have meaningful names, making it easier for developers, translators, and content creators to understand their purpose within the codebase.
+3. **Predictability:** Since explicit IDs are manually assigned, they remain stable across different versions of your application, reducing the likelihood of breaking changes during updates.
+
+In conclusion, the choice between these two strategies depends on your project requirements and priorities. However, it's important to note that Lingui provides the full range of benefits, especially with generated IDs.
+
+:::note
+You don't need to worry about the readability of ID's because you would barely see them. When extracted into a PO file, translators would see source string and its corresponding translation, while the IDs remain behind the scenes.
+
+```gettext
+#: src/App.tsx:1
+msgid "LinguiJS example"
+msgstr "LinguiJS przyklad"
+```
+
+:::
+
+## Using ID generated from a message
+
+### With [`Trans`](/docs/ref/macro.md#trans) macro
+
+```jsx
+import { Trans } from "@lingui/macro";
+
+function render() {
+  return (
+    <>
+      <h1>
+        <Trans>LinguiJS example</Trans>
+      </h1>
+      <p>
+        <Trans>
+          Hello <a href="/profile">{name}</a>.
+        </Trans>
+      </p>
+    </>
+  );
+}
+```
+
+In the example code above, the content of [`Trans`](/docs/ref/macro.md#trans) is transformed into a message in MessageFormat syntax. By default, this message is used for generating the ID. Considering the example above, the catalog would be fulfilled by these entries:
+
+```js
+const catalog = [
+  {
+    id: "uxV9Xq",
+    message: "LinguiJS example",
+  },
+  {
+    id: "9/omjw",
+    message: "Hello <0>{name}</0>.",
+  },
+];
+```
+
+### With non-JSX macro
+
+In the following example, the message `Hello World` will be extracted and used to create an ID.
+
+```jsx
+import { msg } from "@lingui/macro";
+
+msg`Hello World`;
+```
+
+### Context {#context}
+
+By default, when using generated IDs, the same text elements are extracted with the same ID, and then translated once. This, however, may not always be desired because the same text can have different meaning and translation: For example, consider the word "right" and its two possible meanings:
+
+- correct as in "you are right"
+- direction as in "turn right"
+
+To distinguish these two cases, you can add `context` to messages. The same text elements with different contexts are extracted with different IDs. Then, they can be translated differently and merged back into the application as different translation entries.
+
+Regardless of whether you use generated IDs or not, adding context makes the translation process less challenging and helps translators interpret the source accurately. You, in return, get translations of better quality faster and decrease the number of context-related issues you would need to solve.
+
+#### Providing context for a message
+
+```jsx
+import { Trans } from "@lingui/macro";
+<Trans context="direction">right</Trans>;
+<Trans context="correctness">right</Trans>;
+
+// ↓ ↓ ↓ ↓ ↓ ↓
+
+import { Trans } from "@lingui/react";
+<Trans id={"d1wX4r"} message="right" />;
+<Trans id={"16eaSK"} message="right" />;
+```
+
+or with non-jsx macro
+
+```jsx
+import { msg } from "@lingui/macro";
+
+const ex1 = msg({
+  message: `right`,
+  context: "direction",
+});
+
+const ex2 = msg({
+  message: `right`,
+  context: "correctness",
+});
+
+// ↓ ↓ ↓ ↓ ↓ ↓
+const ex1 = {
+  id: "d1wX4r",
+  message: `right`,
+};
+const ex2 = {
+  id: "16eaSK",
+  message: `right`,
+};
+```
+
+## Using custom ID
+
+### With [`Trans`](/docs/ref/macro.md#trans)
+
+If you're using custom IDs in your project, add `id` prop to i18n components:
+
+```jsx
+import { Trans } from "@lingui/macro";
+
+function render() {
+  return (
+    <>
+      <h1>
+        <Trans id="msg.header">LinguiJS example</Trans>
+      </h1>
+      <p>
+        <Trans id="msg.hello">
+          Hello <a href="/profile">{name}</a>.
+        </Trans>
+      </p>
+    </>
+  );
+}
+```
+
+Messages `msg.header` and `msg.hello` will be extracted with default values `LinguiJS example` and `Hello <0>{name}</0>.`.
+
+### With non-JSX macro
+
+If you're using custom IDs in your project, call [`msg`](/docs/ref/macro.md#definemessage) with a message descriptor object and pass ID as `id` prop:
+
+```jsx
+import { msg } from "@lingui/macro";
+
+msg({ id: "msg.greeting", message: `Hello World` });
+```
+
+Message `msg.greeting` will be extracted with default value `Hello World`.
+
+For all other js macros ([`plural`](/docs/ref/macro.md#plural), [`select`](/docs/ref/macro.md#select), [`selectOrdinal`](/docs/ref/macro.md#selectordinal), use them inside [`msg`](/docs/ref/macro.md#definemessage) macro to pass ID (in this case, `'msg.caption'`).
+
+```jsx
+import { msg, plural } from "@lingui/macro";
+
+msg({
+  id: "msg.caption",
+  message: plural(count, {
+    one: "# image caption",
+    other: "# image captions",
+  }),
+});
+```

--- a/website/docs/tutorials/react-patterns.md
+++ b/website/docs/tutorials/react-patterns.md
@@ -29,121 +29,6 @@ function render() {
 
 You don't need anything special to use [`Trans`](/docs/ref/macro.md#trans) inside your app (except of wrapping the root component in [`I18nProvider`](/docs/ref/react.md#i18nprovider)).
 
-## Choosing between generated and explicit ID
-
-Using generated IDs provides more scalability and gives a better developer experience. On the other hand, explicit IDs for phrases make it easier to identify phrases out of context and to track where they're used. IDs usually follow a naming scheme that includes _where_ the phrase is used.
-
-### Using ID generated from message
-
-#### With [`Trans`](/docs/ref/macro.md#trans)
-
-In the example code above, the content of [`Trans`](/docs/ref/macro.md#trans) is transformed into a message in MessageFormat syntax. By default, this message is used for generating the ID. Considering the example above, the catalog would be fulfilled by these entries:
-
-```js
-const catalog = [
-  {
-    id: "uxV9Xq",
-    message: "LinguiJS example",
-  },
-  {
-    id: "9/omjw",
-    message: "Hello <0>{name}</0>.",
-  },
-];
-```
-
-#### With [`t`](/docs/ref/macro.md#t)
-
-In the following example, the message `Image caption` will be extracted and used to create an ID.
-
-```jsx
-import { t } from "@lingui/macro";
-
-export default function ImageWithCaption() {
-  return <img src="..." alt={t`Image caption`} />;
-}
-```
-
-#### Providing context for a message
-
-Use `context` to add more contextual information for translators. It also influences the ID generation: the same text elements with different contexts are extracted with different IDs.
-
-See [Context](/ref/macro#context) for more details.
-
-```jsx
-import { Trans } from "@lingui/macro";
-<Trans context="direction">right</Trans>;
-<Trans context="correctness">right</Trans>;
-
-// ↓ ↓ ↓ ↓ ↓ ↓
-
-import { Trans } from "@lingui/react";
-<Trans id={"d1wX4r"} message="right" />;
-<Trans id={"16eaSK"} message="right" />;
-```
-
-### Using custom ID
-
-#### With [`Trans`](/docs/ref/macro.md#trans)
-
-If you're using custom IDs in your project, add `id` prop to i18n components:
-
-```jsx
-import { Trans } from "@lingui/macro";
-
-function render() {
-  return (
-    <>
-      <h1>
-        <Trans id="msg.header">LinguiJS example</Trans>
-      </h1>
-      <p>
-        <Trans id="msg.hello">
-          Hello <a href="/profile">{name}</a>.
-        </Trans>
-      </p>
-    </>
-  );
-}
-```
-
-Messages `msg.header` and `msg.hello` will be extracted with default values `LinguiJS example` and `Hello <0>{name}</0>.`.
-
-#### With [`t`](/docs/ref/macro.md#t)
-
-If you're using custom IDs in your project, call [`t`](/docs/ref/macro.md#t) with a message descriptor object and pass ID as `id` prop:
-
-```jsx
-import { t } from "@lingui/macro";
-
-export default function ImageWithCaption() {
-  return <img src="..." alt={t({ id: "msg.caption", message: `Image caption` })} />;
-}
-```
-
-Message `msg.caption` will be extracted with default value `Image caption`.
-
-For all other js macros ([`plural`](/docs/ref/macro.md#plural), [`select`](/docs/ref/macro.md#select), [`selectOrdinal`](/docs/ref/macro.md#selectordinal), use them inside [`t`](/docs/ref/macro.md#t) macro to pass ID (in this case, `'msg.caption'`).
-
-```jsx
-import { t, plural } from "@lingui/macro";
-
-export default function ImageWithCaption({ count }) {
-  return (
-    <img
-      src="..."
-      alt={t({
-        id: "msg.caption",
-        message: plural(count, {
-          one: "# image caption",
-          other: "# image captions",
-        }),
-      })}
-    />
-  );
-}
-```
-
 ## Element attributes and string-only translations
 
 Sometimes you can't use [`Trans`](/docs/ref/macro.md#trans) component, for example when translating element attributes:
@@ -152,67 +37,80 @@ Sometimes you can't use [`Trans`](/docs/ref/macro.md#trans) component, for examp
 <img src="..." alt="Image caption" />
 ```
 
-In such case you need to use [`t`](/docs/ref/macro.md#t) macro to wrap message. [`t`](/docs/ref/macro.md#t) is equivalent for [`Trans`](/docs/ref/macro.md#trans), [`plural`](/docs/ref/macro.md#plural) is equivalent to [`Plural`](/docs/ref/macro.md#plural-1).
-You also need to use `useLingui` hook to subscribe your component for locale updates.
+In such case you need to use [`useLingui()`](/docs/ref/react.md#uselingui) hook with [`msg`](/docs/ref/macro.md#definemessage) macro.
 
 ```jsx
-import { t } from "@lingui/macro";
+import { msg } from "@lingui/macro";
 import { useLingui } from "@lingui/react";
 
 export default function ImageWithCaption() {
-  useLingui();
+  const { _ } = useLingui();
 
-  return <img src="..." alt={t`Image caption`} />;
+  return <img src="..." alt={_(msg`Image caption`)} />;
 }
 ```
 
 ## Translations outside React components
 
-Another common pattern is when you need to access translations outside React components, for example inside `redux-saga`. You can use [`t`](/docs/ref/macro.md#t) macro outside React context as usual:
+Another common pattern is when you need to access translations outside React components. You can use [`t`](/docs/ref/macro.md#t) macro outside React context as usual:
 
 ```jsx
 import { t } from "@lingui/macro";
 
-export function alert() {
-  // use t as if you were inside a React component
+export function showAlert() {
   alert(t`...`);
 }
 ```
 
+:::caution
+When you use [`t`](/docs/ref/macro.md#t) macro (and [`plural`](/docs/ref/macro.md#plural), [`select`](/docs/ref/macro.md#select), [`selectOrdinal`](/docs/ref/macro.md#selectordinal)), it uses a global `i18n` instance. While this generally works, there are situations, like in server-side rendering (SSR) applications, where it may not be the best fit.
+
+For better control and flexibility, it's a good idea to avoid the global `i18n` instance and instead use a specific instance tailored to your needs.
+
+```ts
+import { msg } from "@lingui/macro";
+import { I18n } from "@lingui/core";
+
+export function showAlert(i18n: I18n) {
+  alert(t(i18n)`...`);
+}
+
+function MyComponent() {
+  // get i18n instance from React Context
+  const { i18n } = useLingui();
+
+  // pass instance outside
+  showAlert(i18n);
+}
+```
+
+:::
+
 :::note
-The [`t`](/docs/ref/macro.md#t) macro can only be used in a reactive or re-executable context.
+The all js macros such as [`t`](/docs/ref/macro.md#t) [`plural`](/docs/ref/macro.md#plural), [`select`](/docs/ref/macro.md#select), [`selectOrdinal`](/docs/ref/macro.md#selectordinal) cannot be used on the module level.
 
 ```jsx
 import { t } from "@lingui/macro";
 
 // ❌ Bad! This won't work because the `t` macro is used at the module level.
 // The `t` macro returns a string, and once this string is assigned, it won't react to changes.
-const alertProps = {
-  header: t`Alert`,
-  subHeader: t`Important message`,
-  message: t`This is an alert!`,
-  buttons: [t`OK`],
-};
+const colors = [t`Red`, t`Orange`, t`Yellow`, t`Green`];
 
 // ✅ Good! Every time the function is executed, the `t` macro will be re-executed as well,
 // and the actual result will be returned.
-function getAlertProps() {
-  return {
-    header: t`Alert`,
-    subHeader: t`Important message`,
-    message: t`This is an alert!`,
-    buttons: [t`OK`],
-  };
+function getColors() {
+  return [t`Red`, t`Orange`, t`Yellow`, t`Green`];
 }
 ```
 
-Another option would be to use the Lazy Translations pattern described in the following paragraph.
+There is an [ESLint Rule](https://github.com/lingui/eslint-plugin#t-call-in-function) designed to check for this misusage.
 
+Better option would be to use the Lazy Translations pattern described in the following paragraph.
 :::
 
 ## Lazy Translations
 
-Messages don't have to be declared at the same code location where they're displayed. Tag a string with the [`defineMessage`](/docs/ref/macro.md#definemessage) macro, and you've created a "message descriptor", which can then be passed around as a variable, and can be displayed as a translated string by passing its `id` to [`Trans`](/docs/ref/macro.md#trans) as its `id` prop:
+Messages don't have to be declared at the same code location where they're displayed. Tag a string with the [`msg`](/docs/ref/macro.md#definemessage) macro, and you've created a "message descriptor", which can then be passed around as a variable, and can be displayed as a translated string by passing its `id` to [`Trans`](/docs/ref/macro.md#trans) as its `id` prop:
 
 ```jsx
 import { msg } from "@lingui/macro";
@@ -232,6 +130,10 @@ export default function ColorList() {
   );
 }
 ```
+
+:::note
+Note that we import `<Trans>` component from `@lingui/react`, because we want to use a runtime version here, not a macro.
+:::
 
 Or to render the message descriptor as a string-only translation, pass it to the [`i18n._()`](/docs/ref/core.md#i18n._) method:
 
@@ -267,10 +169,10 @@ export function LoginLogoutButtons(props) {
 }
 ```
 
-If you need the prop to be displayed as a string-only translation, you can pass a message tagged with the [`t`](/docs/ref/macro.md#t) macro:
+If you need the prop to be displayed as a string-only translation, you can pass a message tagged with the [`msg`](/docs/ref/macro.md#defineMessage) macro:
 
 ```jsx
-import { t } from "@lingui/macro";
+import { msg } from "@lingui/macro";
 import { useLingui } from "@lingui/react";
 
 export default function ImageWithCaption(props) {
@@ -278,12 +180,12 @@ export default function ImageWithCaption(props) {
 }
 
 export function HappySad(props) {
-  useLingui();
+  const { _ } = useLingui();
 
   return (
     <div>
-      <ImageWithCaption caption={t`I'm so happy!`} />
-      <ImageWithCaption caption={t`I'm so sad.`} />
+      <ImageWithCaption caption={_(msg`I'm so happy!`)} />
+      <ImageWithCaption caption={_(msg`I'm so sad.`)} />
     </div>
   );
 }
@@ -293,7 +195,7 @@ export function HappySad(props) {
 
 Sometimes you need to pick between different messages to display, depending on the value of a variable. For example, imagine you have a numeric "status" code that comes from an API, and you need to display a message representing the current status.
 
-A simple way to do this, is to make an object that maps the possible values of "status" to message descriptors (tagged with the [`defineMessage`](/docs/ref/macro.md#definemessage) macro), and render them as needed with deferred translation:
+A simple way to do this, is to make an object that maps the possible values of "status" to message descriptors (tagged with the [`msg`](/docs/ref/macro.md#definemessage) macro), and render them as needed with deferred translation:
 
 ```jsx
 import { msg } from "@lingui/macro";
@@ -307,8 +209,8 @@ const statusMessages = {
 };
 
 export default function StatusDisplay({ statusCode }) {
-  const { i18n } = useLingui();
-  return <div>{i18n._(statusMessages[statusCode])}</div>;
+  const { _ } = useLingui();
+  return <div>{_(statusMessages[statusCode])}</div>;
 }
 ```
 

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -41,6 +41,11 @@ const sidebar = [
       },
       {
         type: "doc",
+        label: "Explicit vs Generated IDs",
+        id: "tutorials/explicit-vs-generated-ids",
+      },
+      {
+        type: "doc",
         label: "React Native",
         id: "tutorials/react-native",
       },


### PR DESCRIPTION
# Description

The main goal was to remove inconsistency in string-only macro usage (`t` and etc) 

Because of historical reasons we have many different ways to achieve the same result. Some of these approaches a considered harmful and it's better to avoid them and not advertise in the docs. 

For example these are gives mostly the same result: 

```ts
t`Hello`
t(i18n)(`Hello`)
i18n.t(msg`Hello`)
i18n._(msg`Hello`)

// in react context
const { _ } = useLingui();
_(msg`Hello`)

const { i18n } = useLingui();
i18n.t(msg`Hello`)
i18n._(msg`Hello`)
```

Where usage of global `t` is very confusing and bring "delayed" issues, which then hard to fix. 

So I propose to gradually removing global usage from docs, and encourage developers to always use i18n methods on a particular instance. 

While working on achieving this goal, i've found that  "explicit vs generated id" could be extracted from "React Patterns" because it's more general.  And also could be a good place to gather related information which is currently spread across the whole docs.

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
