### PR TITLE
docs: fix typo in react-intl.md

### DIFF
--- a/website/docs/misc/react-intl.md
+++ b/website/docs/misc/react-intl.md
@@ -129,7 +129,7 @@ Using [Lingui](https://github.com/lingui/js-lingui) macros, we could combine [`T
 
 ```jsx
 <Trans id="welcome">
-  Hello <b>{name}</b>, you have {i18n.number(undreadCount)} <Plural one="message" other="messages" />
+  Hello <b>{name}</b>, you have {i18n.number(unreadCount)} <Plural one="message" other="messages" />
 </Trans>
 ```
 
@@ -157,12 +157,12 @@ It's good to mention here that this isn't the best example of using plurals. Mak
   value={number}
   one={
     <>
-      Hello <b>{name}</b>, you have {i18n.number(undreadMessages)} message.
+      Hello <b>{name}</b>, you have {i18n.number(unreadMessages)} message.
     </>
   }
   other={
     <>
-      Hello <b>{name}</b>, you have {i18n.number(undreadMessages)} messages.
+      Hello <b>{name}</b>, you have {i18n.number(unreadMessages)} messages.
     </>
   }
 />


### PR DESCRIPTION
fixed typo in the docs

# Description

I changed a small typo in your documentation. 

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
