### PR TITLE
feat: `id` syntax for t macro

### DIFF
--- a/packages/babel-plugin-extract-messages/test/__snapshots__/index.ts.snap
+++ b/packages/babel-plugin-extract-messages/test/__snapshots__/index.ts.snap
@@ -287,6 +287,16 @@ exports[`@lingui/babel-plugin-extract-messages should extract all messages from 
       48,
     ],
   },
+  {
+    comment: undefined,
+    context: undefined,
+    id: Some Some Id,
+    message: Message with id some,
+    origin: [
+      js-with-macros.js,
+      50,
+    ],
+  },
 ]
 `;
 

--- a/packages/babel-plugin-extract-messages/test/fixtures/js-with-macros.js
+++ b/packages/babel-plugin-extract-messages/test/fixtures/js-with-macros.js
@@ -46,3 +46,5 @@ const defineMessageAlias = msg({
 })
 
 const defineMessageAlias2 = msg`TplLiteral`
+
+const withIdMsg = t`Some Some Id``Message with id some`;

--- a/packages/babel-plugin-extract-messages/test/fixtures/js-with-macros.js
+++ b/packages/babel-plugin-extract-messages/test/fixtures/js-with-macros.js
@@ -47,4 +47,4 @@ const defineMessageAlias = msg({
 
 const defineMessageAlias2 = msg`TplLiteral`
 
-const withIdMsg = t`Some Some Id``Message with id some`;
+const withIdMsg = t('Some Some Id')`Message with id some`

--- a/packages/macro/index.d.ts
+++ b/packages/macro/index.d.ts
@@ -73,6 +73,19 @@ export function t(
 ): string
 
 /**
+ * Translates a template string using the global I18n instance and given id
+ *
+ * @example
+ * ```
+ * import { t } from "@lingui/macro";
+ * const message = t('some.id')`Hello ${name}`;
+ * ```
+ */
+export function t(id: string): {
+  (literals: TemplateStringsArray, ...placeholders: any[]): string
+}
+
+/**
  * Translates a template string or message descriptor using a given I18n instance
  *
  * @example

--- a/website/docs/ref/macro.md
+++ b/website/docs/ref/macro.md
@@ -140,6 +140,20 @@ i18n._(
 ```
 
 ```js
+t`attachment.saved``Attachment ${name} saved`;
+
+// ↓ ↓ ↓ ↓ ↓ ↓
+
+i18n._(
+  /*i18n*/ {
+    id: "attachment.saved",
+    message: "Attachment {name} saved",
+    values: { name },
+  }
+);
+```
+
+```js
 t(customI18n)`Refresh inbox`;
 
 // ↓ ↓ ↓ ↓ ↓ ↓

--- a/website/docs/ref/macro.md
+++ b/website/docs/ref/macro.md
@@ -140,7 +140,7 @@ i18n._(
 ```
 
 ```js
-t`attachment.saved``Attachment ${name} saved`;
+t('attachment.saved')`Attachment ${name} saved`;
 
 // ↓ ↓ ↓ ↓ ↓ ↓
 


### PR DESCRIPTION
```
t('some.id')`message`;
```

New short syntax to set id and message in the same time. In our project we giving ids to every message we have, and all the time I lack short `t` syntax with id.

# Description

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
