### PR TITLE
fix(cli): import type as type

### DIFF
--- a/packages/cli/src/lingui-compile.ts
+++ b/packages/cli/src/lingui-compile.ts
@@ -94,7 +94,7 @@ export async function command(
           const typescriptPath = compiledPath.replace(/\.ts?$/, "") + ".d.ts"
           fs.writeFileSync(
             typescriptPath,
-            `import { Messages } from '@lingui/core';
+            `import type { Messages } from '@lingui/core';
           declare const messages: Messages;
           export { messages };
           `


### PR DESCRIPTION
# Description

This patch removes the following warning when I build my Project (TypeScript/Svelte/SvelteKit/svelte-i18n-lingui):
```
src/locales/en.d.ts (1:9) "Messages" is not exported by "node_modules/@lingui/core/dist/index.mjs", imported by "src/locales/en.d.ts".
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)