### PR TITLE
fix(cli): sorting issue when different locales are used on host machines

### DIFF
--- a/packages/cli/src/api/catalog.ts
+++ b/packages/cli/src/api/catalog.ts
@@ -342,7 +342,7 @@ export function orderByMessage<T extends ExtractedCatalogType>(messages: T): T {
     .sort((a, b) => {
       const aMsg = messages[a].message || ""
       const bMsg = messages[b].message || ""
-      return aMsg.localeCompare(bMsg)
+      return aMsg.localeCompare(bMsg, "en-US")
     })
     .reduce((acc, key) => {
       ;(acc as any)[key] = messages[key]


### PR DESCRIPTION
# Description

`localeCompare` produces different sort output based on user machine locales

e.g. colleague in Denmark `da-DK`, me `en-US`
examples:
```
"Opening Entry".localeCompare("Opening entry"); // 1 (en-US)
"Opening Entry".localeCompare("Opening entry"); // -1 (da-DK)
```
this was causing different orders of messages committed by different users (we are using format-json minimal)
we have translations like examples above when difference is only in casing
`Opening Entry` vs `Opening entry`

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
