### PR TITLE
fix: make sure extra plugins are included

### DIFF
--- a/packages/cli/src/api/extractors/babel.ts
+++ b/packages/cli/src/api/extractors/babel.ts
@@ -144,6 +144,7 @@ export async function extractFromFileWithBabel(
           },
         } satisfies ExtractPluginOpts,
       ],
+      ...[...parserOpts.plugins ?? []]
     ],
   })
 


### PR DESCRIPTION
# Description

Include extra babel plugins from config in extract function. This makes it easier to build extractors with custom babel plugins. This feature was supposed to be built in already from the looks of it, but the plugins weren't actually added.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Fixes # (issue)

https://github.com/lingui/js-lingui/issues/1717

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
