### PR TITLE
fix: double render due to wrong assertion

### DIFF
--- a/examples/nextjs-swc/src/utils.ts
+++ b/examples/nextjs-swc/src/utils.ts
@@ -18,7 +18,7 @@ export function useLinguiInit(messages: Messages) {
     // to avoid calling loadAndActivate for (worst case) each request, but right now that's what we do
     i18n.loadAndActivate({ locale, messages })
   }
-  if (isClient && i18n.locale === undefined) {
+  if (isClient && !i18n.locale) {
     // first client render
     i18n.loadAndActivate({ locale, messages })
   }


### PR DESCRIPTION
# Description

Updated the assertion in `useLinguiInit` function to avoid double render in Next.js SWC example as per the suggestion given in #1814 

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Fixes #1814 

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
