### PR TITLE
fix: allow parentheses in catalog pathnames

### DIFF
--- a/packages/cli/src/api/catalog/getCatalogs.test.ts
+++ b/packages/cli/src/api/catalog/getCatalogs.test.ts
@@ -407,4 +407,22 @@ describe("getCatalogForFile", () => {
       catalog,
     })
   })
+
+  it("should allow parentheses in path names", async () => {
+    const catalog = new Catalog(
+      {
+        name: null,
+        path: "./src/locales/(asd)/{locale}",
+        include: ["./src/"],
+        format,
+      },
+      mockConfig({ format: "po", rootDir: "." })
+    )
+    const catalogs = [catalog]
+
+    expect(getCatalogForFile("./src/locales/(asd)/en.po", catalogs)).toEqual({
+      locale: "en",
+      catalog,
+    })
+  })
 })

--- a/packages/cli/src/api/catalog/getCatalogs.ts
+++ b/packages/cli/src/api/catalog/getCatalogs.ts
@@ -132,10 +132,13 @@ export function getCatalogForFile(file: string, catalogs: Catalog[]) {
   for (const catalog of catalogs) {
     const catalogFile = `${catalog.path}${catalog.format.getCatalogExtension()}`
     const catalogGlob = replacePlaceholders(catalogFile, { locale: "*" })
-    const match = micromatch.capture(
-      normalizeRelativePath(path.relative(catalog.config.rootDir, catalogGlob)),
-      normalizeRelativePath(file)
+    const matchPattern = normalizeRelativePath(
+      path.relative(catalog.config.rootDir, catalogGlob)
     )
+      .replace("(", "\\(")
+      .replace(")", "\\)")
+
+    const match = micromatch.capture(matchPattern, normalizeRelativePath(file))
     if (match) {
       return {
         locale: match[0],


### PR DESCRIPTION
# Description

Escape parentheses in the pathname pattern according to the following issue: https://github.com/micromatch/micromatch/issues/123
The solution uses the simplest possible approach: the String#replace method. I considered the `escape-string-regexp` package, but it seems that `parentheses` are the only problematic characters.


[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Fixes #1819

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs (NOTE: I managed to run `yarn test`, but `yarn release:test` fails with the following message: `The filename, directory name, or volume label syntax is incorrect. command not found: test:tsd`. I believe this is unrelated to my changes and may warrant its own issue.)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
