### PR TITLE
fix: warnings about invalid dependencies on Windows

### DIFF
--- a/packages/loader/src/webpackLoader.ts
+++ b/packages/loader/src/webpackLoader.ts
@@ -47,7 +47,7 @@ Please check that \`catalogs.path\` is filled properly.\n`
 
   const { locale, catalog } = fileCatalog
   const dependency = await getCatalogDependentFiles(catalog, locale)
-  dependency.forEach((file) => this.addDependency(file))
+  dependency.forEach((file) => this.addDependency(path.normalize(file)))
 
   const messages = await catalog.getTranslations(locale, {
     fallbackLocales: config.fallbackLocales,


### PR DESCRIPTION
# Description

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

The build emits warnings on Windows as described in detail at https://discord.com/channels/974702239358783608/974704045346394172/1141002196398391436.

This PR contains the fix described here https://discord.com/channels/974702239358783608/1136285611087626250/1141022716237987980.

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

Fixes https://github.com/lingui/js-lingui/issues/1705.

After this fix, Windows no longer emits the warnings. 

Tests are not affected.

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
