### PR TITLE
fix: compile should generate a TS file

### DIFF
--- a/packages/cli/src/api/__snapshots__/compile.test.ts.snap
+++ b/packages/cli/src/api/__snapshots__/compile.test.ts.snap
@@ -10,7 +10,7 @@ exports[`createCompiledCatalog options.namespace should compile with global 1`] 
 
 exports[`createCompiledCatalog options.namespace should compile with json 1`] = `{"messages":{"key":["Hello ",["name"]]}}`;
 
-exports[`createCompiledCatalog options.namespace should compile with ts 1`] = `/*eslint-disable*/export const messages=JSON.parse("{\\"key\\":[\\"Hello \\",[\\"name\\"]]}");`;
+exports[`createCompiledCatalog options.namespace should compile with ts 1`] = `/*eslint-disable*/import type{Messages}from"@lingui/core";export const messages:Messages=JSON.parse("{\\"key\\":[\\"Hello \\",[\\"name\\"]]}");`;
 
 exports[`createCompiledCatalog options.namespace should compile with window 1`] = `/*eslint-disable*/window.test={messages:JSON.parse("{\\"key\\":[\\"Hello \\",[\\"name\\"]]}")};`;
 

--- a/packages/cli/src/api/compile.ts
+++ b/packages/cli/src/api/compile.ts
@@ -70,7 +70,29 @@ function buildExportStatement(
   expression: t.Expression,
   namespace: CompiledCatalogNamespace
 ) {
-  if (namespace === "es" || namespace === "ts") {
+  if (namespace === "ts") {
+    // import type { Messages } from "@lingui/core";
+    const importMessagesTypeDeclaration = t.importDeclaration(
+      [t.importSpecifier(t.identifier("Messages"), t.identifier("Messages"))],
+      t.stringLiteral("@lingui/core")
+    )
+    importMessagesTypeDeclaration.importKind = "type"
+
+    // Create the exported `messages` identifier with a `Messages` TS type annotation
+    const messagesIdentifier = t.identifier("messages")
+    messagesIdentifier.typeAnnotation = t.tsTypeAnnotation(
+      t.tsTypeReference(t.identifier("Messages"))
+    )
+
+    // export const messages:Messages = { message: "Translation" }
+    const exportDeclaration = t.exportNamedDeclaration(
+      t.variableDeclaration("const", [
+        t.variableDeclarator(messagesIdentifier, expression),
+      ])
+    )
+
+    return t.program([importMessagesTypeDeclaration, exportDeclaration])
+  } else if (namespace === "es") {
     // export const messages = { message: "Translation" }
     return t.exportNamedDeclaration(
       t.variableDeclaration("const", [

--- a/packages/cli/src/lingui-compile.ts
+++ b/packages/cli/src/lingui-compile.ts
@@ -1,6 +1,5 @@
 import chalk from "chalk"
 import chokidar from "chokidar"
-import fs from "fs"
 import { program } from "commander"
 
 import { getConfig, LinguiConfigNormalized } from "@lingui/conf"
@@ -89,17 +88,6 @@ export async function command(
           compiledCatalog,
           namespace
         )
-
-        if (options.typescript) {
-          const typescriptPath = compiledPath.replace(/\.ts?$/, "") + ".d.ts"
-          fs.writeFileSync(
-            typescriptPath,
-            `import type { Messages } from '@lingui/core';
-          declare const messages: Messages;
-          export { messages };
-          `
-          )
-        }
 
         compiledPath = normalizeSlashes(
           nodepath.relative(config.rootDir, compiledPath)

--- a/website/docs/ref/cli.md
+++ b/website/docs/ref/cli.md
@@ -16,7 +16,7 @@
     {
       "scripts": {
         "extract": "lingui extract",
-        "compile": "lingui compile"
+        "compile": "lingui compile --typescript"
       }
     }
     ```
@@ -125,6 +125,7 @@ lingui compile
     [--strict]
     [--format <format>]
     [--verbose]
+    [--typescript]
     [--namespace <namespace>]
     [--watch [--debounce <delay>]]
 ```
@@ -161,7 +162,7 @@ Specify namespace for compiled message catalogs (also see [`compileNamespace`](/
 
 #### `--typescript` {#compile-typescript}
 
-Is the same as using [`compileNamespace`](/docs/ref/conf.md#compilenamespace) with the value "ts". Generates a `{compiledFile}.d.ts` and the compiled file is generated using the extension .ts
+Is the same as using [`compileNamespace`](/docs/ref/conf.md#compilenamespace) with the value "ts". Generates a `{compiledFile}.ts` file and the exported object is typed using TS.
 
 #### `--watch` {#compile-watch}
 

--- a/website/docs/ref/cli.md
+++ b/website/docs/ref/cli.md
@@ -16,10 +16,23 @@
     {
       "scripts": {
         "extract": "lingui extract",
-        "compile": "lingui compile --typescript"
+        "compile": "lingui compile"
       }
     }
     ```
+
+:::tip
+If you use TypeScript, you can add `--typescript` flag to `compile` script to produce compiled message catalogs with TypeScript types.
+
+```json title="package.json"
+{
+  "scripts": {
+    "compile": "lingui compile --typescript"
+  }
+}
+```
+
+:::
 
 ## Global options
 
@@ -58,7 +71,7 @@ lingui extract src/components
 
 Will extract only messages from `src/components/**/*` files, you can also pass multiple paths.
 
-It's useful if you want to run extract command on files that are staged, using for example `husky`, before commiting will extract messages from staged files:
+It's useful if you want to run extract command on files that are staged, using for example `husky`, before committing will extract messages from staged files:
 
 ```json title="package.json"
 {

--- a/website/docs/tutorials/react.md
+++ b/website/docs/tutorials/react.md
@@ -245,13 +245,13 @@ Catalog statistics:
 That's great! So, how we're going to load it into your app? [LinguiJS](https://github.com/lingui/js-lingui) introduces concept of compiled message catalogs. Before we load messages into our app, we need to compile them. As you see in the help in command output, we use [`compile`](/docs/ref/cli.md#compile) for that:
 
 ```bash
-> lingui compile
+> lingui compile --typescript
 
 Compiling message catalogs…
 Done!
 ```
 
-What just happened? If you look inside `locales/<locale>` directory, you'll see there's a new file for each locale: `messages.js`. This file contains compiled message catalog.
+What just happened? If you look inside `locales/<locale>` directory, you'll see there's a new file for each locale: `messages.ts`. This file contains compiled message catalog.
 
 Let's load this file into our app and set active language to `cs`:
 

--- a/website/docs/tutorials/react.md
+++ b/website/docs/tutorials/react.md
@@ -245,13 +245,17 @@ Catalog statistics:
 That's great! So, how we're going to load it into your app? [LinguiJS](https://github.com/lingui/js-lingui) introduces concept of compiled message catalogs. Before we load messages into our app, we need to compile them. As you see in the help in command output, we use [`compile`](/docs/ref/cli.md#compile) for that:
 
 ```bash
-> lingui compile --typescript
+> lingui compile
 
 Compiling message catalogs…
 Done!
 ```
 
-What just happened? If you look inside `locales/<locale>` directory, you'll see there's a new file for each locale: `messages.ts`. This file contains compiled message catalog.
+What just happened? If you look inside `locales/<locale>` directory, you'll see there's a new file for each locale: `messages.js`. This file contains compiled message catalog.
+
+:::tip
+If you use TypeScript, you can add `--typescript` flag to `compile` script to produce compiled message catalogs with TypeScript types.
+:::
 
 Let's load this file into our app and set active language to `cs`:
 

--- a/website/docs/tutorials/setup-react.md
+++ b/website/docs/tutorials/setup-react.md
@@ -60,7 +60,7 @@ This setup guide is for any project which uses React.
     {
       "scripts": {
         "extract": "lingui extract",
-        "compile": "lingui compile"
+        "compile": "lingui compile --typescript"
       }
     }
     ```

--- a/website/docs/tutorials/setup-react.md
+++ b/website/docs/tutorials/setup-react.md
@@ -60,10 +60,14 @@ This setup guide is for any project which uses React.
     {
       "scripts": {
         "extract": "lingui extract",
-        "compile": "lingui compile --typescript"
+        "compile": "lingui compile"
       }
     }
     ```
+
+:::tip
+If you use TypeScript, you can add `--typescript` flag to `compile` script to produce compiled message catalogs with TypeScript types.
+:::
 
 5.  Check the installation by running:
 


### PR DESCRIPTION
# Description

Currently, running `lingui compile --typescript` produces a `.ts` (which contains javascript code) file along with `.d.ts` file with typings.

However, TypeScript, at least on my machine, ignores the typings file - which kinda makes sense given that the source file already has `.ts` extension. 

So it looks like this:

<img width="460" alt="Screenshot 2024-02-14 at 20 02 03" src="https://github.com/lingui/js-lingui/assets/1566403/98faab72-4fa1-4f96-9f7f-0920697899e0">

AFAICT, we should not mix `.ts` with `.d.ts`. What this PR does is that it removes the generation of the `d.ts` file and instead puts the types into the generated `.ts` file. I believe this should not have any unintended side effects. If it does, we should keep the `.d.ts` file but change the `.ts` file extension.

Additionally, I made some docs changes to "promote" the `--typescript` flag more. I think most users are not aware of it, yet it's nice to have.

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
