### PR TITLE
feat(cli): support multiple locales in extract command

### DIFF
--- a/packages/cli/src/api/catalog.test.ts
+++ b/packages/cli/src/api/catalog.test.ts
@@ -93,7 +93,7 @@ describe("Catalog", () => {
       // Everything should be empty
       expect(await catalog.readAll()).toMatchSnapshot()
 
-      await catalog.make({ ...defaultMakeOptions, locale: "en" })
+      await catalog.make({ ...defaultMakeOptions, locale: ["en"] })
       expect(await catalog.readAll()).toMatchSnapshot()
     })
 

--- a/packages/cli/src/api/catalog.ts
+++ b/packages/cli/src/api/catalog.ts
@@ -105,7 +105,7 @@ export class Catalog {
 
     const sortedCatalogs = cleanAndSort(catalogs)
 
-    const locales = options.locale ? [options.locale] : this.locales
+    const locales = options.locale ? options.locale : this.locales
     await Promise.all(
       locales.map((locale) => this.write(locale, sortedCatalogs[locale]))
     )

--- a/packages/cli/src/lingui-extract.ts
+++ b/packages/cli/src/lingui-extract.ts
@@ -16,7 +16,7 @@ export type CliExtractOptions = {
   files?: string[]
   clean: boolean
   overwrite: boolean
-  locale: string
+  locale: string[]
   prevFormat: string | null
   watch?: boolean
 }
@@ -103,7 +103,7 @@ type CliOptions = {
   files?: string[]
   clean: boolean
   overwrite: boolean
-  locale: string
+  locale: string[]
   prevFormat: string | null
   watch?: boolean
 }
@@ -111,7 +111,13 @@ type CliOptions = {
 if (require.main === module) {
   program
     .option("--config <path>", "Path to the config file")
-    .option("--locale <locale>", "Only extract the specified locale")
+    .option(
+      "--locale <locale, [...]>",
+      "Only extract the specified locales",
+      (value) => {
+        return value.split(",")
+      }
+    )
     .option("--overwrite", "Overwrite translations for source locale")
     .option("--clean", "Remove obsolete translations")
     .option(
@@ -148,10 +154,16 @@ if (require.main === module) {
     process.exit(1)
   }
 
-  if (options.locale && !config.locales.includes(options.locale)) {
-    hasErrors = true
-    console.error(`Locale ${chalk.bold(options.locale)} does not exist.`)
-    console.error()
+  if (options.locale) {
+    const missingLocale = options.locale.find(
+      (l) => !config.locales.includes(l)
+    )
+
+    if (missingLocale) {
+      hasErrors = true
+      console.error(`Locale ${chalk.bold(missingLocale)} does not exist.`)
+      console.error()
+    }
   }
 
   if (hasErrors) process.exit(1)

--- a/packages/cli/src/lingui-extract.ts
+++ b/packages/cli/src/lingui-extract.ts
@@ -117,8 +117,8 @@ if (require.main === module) {
       (value) => {
         return value
           .split(",")
-          .filter(Boolean)
           .map((s) => s.trim())
+          .filter(Boolean)
       }
     )
     .option("--overwrite", "Overwrite translations for source locale")

--- a/packages/cli/src/lingui-extract.ts
+++ b/packages/cli/src/lingui-extract.ts
@@ -115,7 +115,7 @@ if (require.main === module) {
       "--locale <locale, [...]>",
       "Only extract the specified locales",
       (value) => {
-        return value.split(",")
+        return value.split(",").filter(Boolean)
       }
     )
     .option("--overwrite", "Overwrite translations for source locale")

--- a/packages/cli/src/lingui-extract.ts
+++ b/packages/cli/src/lingui-extract.ts
@@ -115,7 +115,10 @@ if (require.main === module) {
       "--locale <locale, [...]>",
       "Only extract the specified locales",
       (value) => {
-        return value.split(",").filter(Boolean)
+        return value
+          .split(",")
+          .filter(Boolean)
+          .map((s) => s.trim())
       }
     )
     .option("--overwrite", "Overwrite translations for source locale")

--- a/website/docs/ref/cli.md
+++ b/website/docs/ref/cli.md
@@ -49,7 +49,7 @@ lingui extract [files...]
         [--clean]
         [--overwrite]
         [--format <format>]
-        [--locale <locale>]
+        [--locale <locale, [...]>]
         [--convert-from <format>]
         [--verbose]
         [--watch [--debounce <delay>]]
@@ -95,9 +95,9 @@ Update translations for [`sourceLocale`](/docs/ref/conf.md#sourcelocale) from so
 
 Format of message catalogs (see [`format`](/docs/ref/conf.md#format) option).
 
-#### `--locale <locale>` {#extract-locale}
+#### `--locale <locale, [...]>` {#extract-locale}
 
-Only extract data for the specified locale.
+Only extract data for the specified locales.
 
 #### `--convert-from <format>` {#extract-convert-from}
 


### PR DESCRIPTION
# Description
Adds multiple locales support for `--locale` option, similar to the experimental extract implementation.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Examples update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
