### PR TITLE
feat(macro): support transforming member expressions to named args

### DIFF
--- a/packages/macro/src/macroJs.ts
+++ b/packages/macro/src/macroJs.ts
@@ -10,6 +10,7 @@ import {
   SourceLocation,
   StringLiteral,
   TemplateLiteral,
+  MemberExpression,
 } from "@babel/types"
 import { NodePath } from "@babel/traverse"
 
@@ -367,11 +368,31 @@ export default class MacroJs {
     }
   }
 
+  memberExpressionToArgument(exp: MemberExpression): string {
+    let parts: string[] = []
+
+    if (this.types.isThisExpression(exp.object)) {
+      // ignore this
+    } else {
+      parts.unshift(this.expressionToArgument(exp.object))
+    }
+
+    parts.push(
+      this.expressionToArgument(
+        this.types.isPrivateName(exp.property) ? exp.property.id : exp.property
+      )
+    )
+
+    return parts.join("_")
+  }
+
   expressionToArgument(exp: Expression): string {
     if (this.types.isIdentifier(exp)) {
       return exp.name
     } else if (this.types.isStringLiteral(exp)) {
       return exp.value
+    } else if (this.types.isMemberExpression(exp)) {
+      return this.memberExpressionToArgument(exp)
     } else {
       return String(this._expressionIndex())
     }


### PR DESCRIPTION
# Description

Helps extract complex member expressions to named arguments with `_` delimiter.
so `` t`Very {result.cool} Stuff` ``  results in `Very {result_cool} Stuff`

I wanted to add this because we have a lot of results from APIs that I really don't want to break down to different variables.

WIP, wanted to see thoughts of maintainers

TODO:
- Add opt-in option in the lingui config, because it will break previous extractions. name suggestion?
- Update tests
- Docs

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
