### PR TITLE
docs: add `catalogsMergePath` in Lingui Configuration

### DIFF
--- a/website/docs/ref/conf.md
+++ b/website/docs/ref/conf.md
@@ -189,40 +189,11 @@ Specify the path to merge translated catalogs into a single file per locale duri
 
 #### Example
 
-Let's assume we have separate catalogs for `locales: ["en", "cs"]` per component placed inside shared directory:
+Let's assume we have [separate catalogs for `locales: ["en", "cs"]` per component placed inside shared directory](#separate-catalogs-per-component-placed-inside-shared-directory).
 
-```json
-{
-  "catalogs": [
-    {
-      "path": "locale/{locale}/{name}",
-      "include": "components/{name}/"
-    }
-  ]
-}
-```
+Using `catalogsMergePath`, separate catalogs can be merged during compile:
 
-```shell
-.
-├── locale/
-│   ├── en/
-│   │   ├── RegistrationForm.po
-│   │   └── LoginForm.po
-│   └── cs/
-│       ├── RegistrationForm.po
-│       └── LoginForm.po
-└── components/
-    ├── RegistrationForm/
-    │   ├── RegistrationForm.test.js
-    │   └── RegistrationForm.js
-    └── LoginForm/
-        ├── LoginForm.test.js
-        └── LoginForm.js
-```
-
-Separate catalogs can be merged during compile using `catalogsMergePath`:
-
-```json
+```diff
 {
   "catalogs": [
     {
@@ -230,29 +201,33 @@ Separate catalogs can be merged during compile using `catalogsMergePath`:
       "include": "components/{name}/"
     }
   ],
-  "catalogsMergePath": "locales/{locale}"
++ "catalogsMergePath": "locales/{locale}"
 }
 ```
 
-```shell
+```diff
 .
-├── locale/
-│   ├── en/
-│   │   ├── RegistrationForm.po
-│   │   └── LoginForm.po
-│   └── cs/
-│       ├── RegistrationForm.po
-│       └── LoginForm.po
-├── locales/
-│   ├── en.js
-│   └── cs.js
-└── components/
-    ├── RegistrationForm/
-    │   ├── RegistrationForm.test.js
-    │   └── RegistrationForm.js
-    └── LoginForm/
-        ├── LoginForm.test.js
-        └── LoginForm.js
+  ├── locale/
+  │   ├── en/
+  │   │   ├── RegistrationForm.po
+- │   │   ├── RegistrationForm.js
+  │   │   ├── LoginForm.po
+- │   │   └── LoginForm.js
+  │   └── cs/
+  │       ├── RegistrationForm.po
+- │       ├── RegistrationForm.js
+  │       ├── LoginForm.po
+- │       └── LoginForm.js
++ ├── locales/
++ │   ├── en.js
++ │   └── cs.js
+  └── components/
+      ├── RegistrationForm/
+      │   ├── RegistrationForm.test.js
+      │   └── RegistrationForm.js
+      └── LoginForm/
+          ├── LoginForm.test.js
+          └── LoginForm.js
 ```
 
 ## compileNamespace

--- a/website/docs/ref/conf.md
+++ b/website/docs/ref/conf.md
@@ -189,18 +189,70 @@ Specify the path to merge translated catalogs into a single file per locale duri
 
 #### Example
 
+Let's assume we have separate catalogs for `locales: ["en", "cs"]` per component placed inside shared directory:
+
 ```json
 {
+  "catalogs": [
+    {
+      "path": "locale/{locale}/{name}",
+      "include": "components/{name}/"
+    }
+  ]
+}
+```
+
+```shell
+.
+├── locale/
+│   ├── en/
+│   │   ├── RegistrationForm.po
+│   │   └── LoginForm.po
+│   └── cs/
+│       ├── RegistrationForm.po
+│       └── LoginForm.po
+└── components/
+    ├── RegistrationForm/
+    │   ├── RegistrationForm.test.js
+    │   └── RegistrationForm.js
+    └── LoginForm/
+        ├── LoginForm.test.js
+        └── LoginForm.js
+```
+
+Separate catalogs can be merged during compile using `catalogsMergePath`:
+
+```json
+{
+  "catalogs": [
+    {
+      "path": "/locale/{locale}/{name}",
+      "include": "components/{name}/"
+    }
+  ],
   "catalogsMergePath": "locales/{locale}"
 }
 ```
 
-For `locales: ["en", "cs"]` the catalogs will be compiled into `locales/en.js` and `locales/cs.js`:
-
-```bash
-locales
-├── en.js
-└── cs.js
+```shell
+.
+├── locale/
+│   ├── en/
+│   │   ├── RegistrationForm.po
+│   │   └── LoginForm.po
+│   └── cs/
+│       ├── RegistrationForm.po
+│       └── LoginForm.po
+├── locales/
+│   ├── en.js
+│   └── cs.js
+└── components/
+    ├── RegistrationForm/
+    │   ├── RegistrationForm.test.js
+    │   └── RegistrationForm.js
+    └── LoginForm/
+        ├── LoginForm.test.js
+        └── LoginForm.js
 ```
 
 ## compileNamespace

--- a/website/docs/ref/conf.md
+++ b/website/docs/ref/conf.md
@@ -27,6 +27,7 @@ Default config:
       "exclude": ["**/node_modules/**"]
     }
   ],
+  "catalogMergePath": "",
   "compileNamespace": "cjs",
   "extractorParserOptions": {},
   "compilerBabelOptions": {},
@@ -178,6 +179,26 @@ components/
     └── LoginForm/
         ├── LoginForm.test.js
         └── LoginForm.js
+```
+
+## catalogsMergePath
+
+Default: `""`
+
+Specify the path to merge translated catalogs into a single file per locale during compile
+
+#### Example
+
+```json
+{
+  "catalogsMergePath": "locales/{locale}"
+}
+```
+The catalogs will be compiled to `locales/en.js` and `locales/cs.js`
+```bash
+locales
+├── en.js
+└── cs.js
 ```
 
 ## compileNamespace

--- a/website/docs/ref/conf.md
+++ b/website/docs/ref/conf.md
@@ -185,7 +185,7 @@ components/
 
 Default: `""`
 
-Specify the path to merge translated catalogs into a single file per locale during compile
+Specify the path to merge translated catalogs into a single file per locale during compile.
 
 #### Example
 
@@ -195,7 +195,7 @@ Specify the path to merge translated catalogs into a single file per locale duri
 }
 ```
 
-The catalogs will be compiled to `locales/en.js` and `locales/cs.js`
+For `locales: ["en", "cs"]` the catalogs will be compiled into `locales/en.js` and `locales/cs.js`:
 
 ```bash
 locales

--- a/website/docs/ref/conf.md
+++ b/website/docs/ref/conf.md
@@ -27,7 +27,7 @@ Default config:
       "exclude": ["**/node_modules/**"]
     }
   ],
-  "catalogMergePath": "",
+  "catalogsMergePath": "",
   "compileNamespace": "cjs",
   "extractorParserOptions": {},
   "compilerBabelOptions": {},

--- a/website/docs/ref/conf.md
+++ b/website/docs/ref/conf.md
@@ -128,7 +128,7 @@ locales
   "catalogs": [
     {
       "path": "components/{name}/locale/{locale}",
-      "include": "components/{name}/"
+      "include": ["components/{name}/"]
     }
   ]
 }
@@ -157,7 +157,7 @@ components/
   "catalogs": [
     {
       "path": "locale/{locale}/{name}",
-      "include": "components/{name}/"
+      "include": ["components/{name}/"]
     }
   ]
 }
@@ -198,7 +198,7 @@ Using `catalogsMergePath`, separate catalogs can be merged during [`compile`](/d
   "catalogs": [
     {
       "path": "/locale/{locale}/{name}",
-      "include": "components/{name}/"
+      "include": ["components/{name}/"]
     }
   ],
 + "catalogsMergePath": "locales/{locale}"

--- a/website/docs/ref/conf.md
+++ b/website/docs/ref/conf.md
@@ -194,7 +194,9 @@ Specify the path to merge translated catalogs into a single file per locale duri
   "catalogsMergePath": "locales/{locale}"
 }
 ```
+
 The catalogs will be compiled to `locales/en.js` and `locales/cs.js`
+
 ```bash
 locales
 ├── en.js

--- a/website/docs/ref/conf.md
+++ b/website/docs/ref/conf.md
@@ -191,7 +191,7 @@ Specify the path to merge translated catalogs into a single file per locale duri
 
 Let's assume we have [separate catalogs for `locales: ["en", "cs"]` per component placed inside shared directory](#separate-catalogs-per-component-placed-inside-shared-directory).
 
-Using `catalogsMergePath`, separate catalogs can be merged during compile:
+Using `catalogsMergePath`, separate catalogs can be merged during [`compile`](/docs/ref/cli.md#compile):
 
 ```diff
 {


### PR DESCRIPTION
# Description

Include `catalogsMergePath` in [Lingui Configuration](https://lingui.dev/ref/conf) reference section in docs

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Examples update

Fixes #1879 

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
