### PR TITLE
refactor(macro): remove whitespace cleaning from js macro

### DIFF
--- a/packages/babel-plugin-lingui-macro/src/macroJsx.ts
+++ b/packages/babel-plugin-lingui-macro/src/macroJsx.ts
@@ -298,12 +298,7 @@ export class MacroJSX {
     const expressions = exp.get("expressions") as NodePath<Expression>[]
 
     return exp.get("quasis").flatMap(({ node: text }, i) => {
-      // if it's an unicode we keep the cooked value because it's the parsed value by babel (without unicode chars)
-      // This regex will detect if a string contains unicode chars, when they're we should interpolate them
-      // why? because platforms like react native doesn't parse them, just doing a JSON.parse makes them UTF-8 friendly
-      const value = /\\u[a-fA-F0-9]{4}|\\x[a-fA-F0-9]{2}/g.test(text.value.raw)
-        ? text.value.cooked
-        : text.value.raw
+      const value = text.value.cooked
 
       let argTokens: Token[] = []
       const currExp = expressions[i]
@@ -314,10 +309,7 @@ export class MacroJSX {
           : [this.tokenizeExpression(currExp)]
       }
 
-      return [
-        ...(value ? [this.tokenizeText(this.clearBackslashes(value))] : []),
-        ...argTokens,
-      ]
+      return [...(value ? [this.tokenizeText(value)] : []), ...argTokens]
     })
   }
 
@@ -464,14 +456,6 @@ export class MacroJSX {
 
   expressionToArgument(path: NodePath<Expression | Node>): string {
     return path.isIdentifier() ? path.node.name : String(this.expressionIndex())
-  }
-
-  /**
-   * We clean '//\` ' to just '`'
-   **/
-  clearBackslashes(value: string): string {
-    // if not we replace the extra scaped literals
-    return value.replace(/\\`/g, "`")
   }
 
   isLinguiComponent = (

--- a/packages/babel-plugin-lingui-macro/test/fixtures/js-t-continuation-character.js
+++ b/packages/babel-plugin-lingui-macro/test/fixtures/js-t-continuation-character.js
@@ -1,4 +1,4 @@
 import { t } from "@lingui/core/macro"
 
 t`Multiline\
-  with continuation`
+ with continuation`

--- a/packages/babel-plugin-lingui-macro/test/js-t.ts
+++ b/packages/babel-plugin-lingui-macro/test/js-t.ts
@@ -116,7 +116,7 @@ const cases: TestCase[] = [
     name: "Variables with escaped double quotes are correctly formatted",
     input: `
         import { t } from '@lingui/core/macro';
-        t\`Variable \"name\" \`;
+        t\`Variable \"name\"\`;
     `,
     expected: `
        import { i18n as _i18n } from "@lingui/core";
@@ -153,32 +153,33 @@ const cases: TestCase[] = [
     name: "Anything variables except simple identifiers are used as positional arguments",
     input: `
         import { t } from '@lingui/core/macro';
-        t\`
-          Property \${props.name},\\
-          function \${random()},\\
-          array \${array[index]},\\
-          constant \${42},\\
-          object \${new Date()}\\
-          anything \${props.messages[index].value()}
-        \`
-    `,
+        t\`\
+ Property \${props.name},\
+ function \${random()},\
+ array \${array[index]},\
+ constant \${42},\
+ object \${new Date()}\
+ anything \${props.messages[index].value()}\
+\`
+`,
     expected: `
-        import { i18n as _i18n } from "@lingui/core";
-        _i18n._(
-          /*i18n*/
-          {
-            id: "X1jIKa",
-            message: "Property {0}, function {1}, array {2}, constant {3}, object {4} anything {5}",
+      import { i18n as _i18n } from "@lingui/core";
+      _i18n._(
+        /*i18n*/
+        {
+            id: "vVZNZ5",
+            message:
+              " Property {0}, function {1}, array {2}, constant {3}, object {4} anything {5}",
             values: {
-              0: props.name,
-              1: random(),
-              2: array[index],
-              3: 42,
-              4: new Date(),
-              5: props.messages[index].value(),
-            },
-          }
-        );
+            0: props.name,
+            1: random(),
+            2: array[index],
+            3: 42,
+            4: new Date(),
+            5: props.messages[index].value(),
+          },
+        }
+      );
     `,
   },
   {
@@ -193,8 +194,8 @@ const cases: TestCase[] = [
         _i18n._(
           /*i18n*/
           {
-            id: "EfogM+",
-            message: "Multiline\\nstring",
+            id: "+8iwDA",
+            message: "Multiline\\n          string",
           }
         );
       `,


### PR DESCRIPTION
# Description

As other developers noted, whitespace trimming is in JS macro redundant and counterintuitive. 

If i write: 

```ts
t`Hello 
world`
```

I'm expecting to get a message with a line break in the middle, and don't expect this to be trimmed. 

Another example:

```ts
t`Label: ` + value
```
Note the space after ":", it's expected to be there, but "normalization" will remove it.

Other example would be a markdown, or just a whatever purpose user want to have an original formatting. 

This PR completely remove whitespace trimming from JS macro, and left the value as-is. 

## Second important change

There was an unclear logic around unicode escaping in template literals, which I also removed in favor of always "cooked" value.

The template literal has 2 values, [raw and cooked](https://exploringjs.com/impatient-js/ch_template-literals.html#template-strings-cooked-vs-raw). For some historical reasons, the macro took a "raw" property (i followed git history up to creation of the file to see how this code developed over time). 

Then some additional cleanup happened over the "raw", for example double backslashes were removed to make line breaks works. 

Then someone reported (https://github.com/lingui/js-lingui/issues/1098) that unicode sequences doesn't work, and an additional layer of logic was added. Now when there were any unicode sequences the code took "cooked" and "raw" when it's not. 

Some of this "fixes" for "raw" string happened in the whitespace normalization process and become broken when I removed it. 

I dug into that a little bit more, and found that using "cooked" value always give a correct result. 

I'm a little bit concerned about this comment: 

> // if it's an unicode we keep the cooked value because it's the parsed value by babel (without unicode chars)
> // This regex will detect if a string contains unicode chars, when they're we should interpolate them
> // why? because platforms like react native doesn't parse them, just doing a JSON.parse makes them UTF-8 friendly
      
Since i didn't find any test covering this. @vonovak may be you can test these changes in React Native? 

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

Fixes https://github.com/lingui/js-lingui/issues/1799

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
