### PR TITLE
chore: bump date-fns from 2.16.1/2.29.3 to 3.6.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -64,7 +64,7 @@
     "cli-table": "0.3.6",
     "commander": "^10.0.0",
     "convert-source-map": "^2.0.0",
-    "date-fns": "^2.16.1",
+    "date-fns": "^3.6.0",
     "esbuild": "^0.17.10",
     "glob": "^7.1.4",
     "inquirer": "^7.3.3",

--- a/packages/format-po/package.json
+++ b/packages/format-po/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@lingui/conf": "4.7.2",
     "@lingui/message-utils": "4.7.2",
-    "date-fns": "^2.29.3",
+    "date-fns": "^3.6.0",
     "pofile": "^1.1.4"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3256,7 +3256,7 @@ __metadata:
     cli-table: 0.3.6
     commander: ^10.0.0
     convert-source-map: ^2.0.0
-    date-fns: ^2.16.1
+    date-fns: ^3.6.0
     esbuild: ^0.17.10
     glob: ^7.1.4
     inquirer: ^7.3.3
@@ -3382,7 +3382,7 @@ __metadata:
     "@lingui/conf": 4.7.2
     "@lingui/jest-mocks": "workspace:^"
     "@lingui/message-utils": 4.7.2
-    date-fns: ^2.29.3
+    date-fns: ^3.6.0
     mockdate: ^3.0.5
     pofile: ^1.1.4
     tsd: ^0.28.0
@@ -6898,10 +6898,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"date-fns@npm:^2.16.1, date-fns@npm:^2.29.3":
-  version: 2.29.3
-  resolution: "date-fns@npm:2.29.3"
-  checksum: e01cf5b62af04e05dfff921bb9c9933310ed0e1ae9a81eb8653452e64dc841acf7f6e01e1a5ae5644d0337e9a7f936175fd2cb6819dc122fdd9c5e86c56be484
+"date-fns@npm:^3.6.0":
+  version: 3.6.0
+  resolution: "date-fns@npm:3.6.0"
+  checksum: 0daa1e9a436cf99f9f2ae9232b55e11f3dd46132bee10987164f3eebd29f245b2e066d7d7db40782627411ecf18551d8f4c9fcdf2226e48bb66545407d448ab7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

This PR upgrades date-fns dependency from 2.16.1/2.29.3 to 3.6.0.
Our project has migrated to date-fns 3 recently, but we also use js-lingui extensively and it would be nice to have only one version of date-fns. Having both if flaky in our setup for some reason.

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
