### PR TITLE
chore: remove the deprecated 'isTranslated' property

### DIFF
--- a/packages/react/src/Trans.test.tsx
+++ b/packages/react/src/Trans.test.tsx
@@ -305,7 +305,6 @@ describe("Trans component", () => {
         message: "Default",
         translation: "Translation",
         children: "Translation",
-        isTranslated: true,
       })
     })
 
@@ -369,7 +368,6 @@ describe("Trans component", () => {
       expect(element).toEqual(`<div id="Headline">value</div>`)
       expect(propsSpy).toHaveBeenCalledWith({
         id: "Headline",
-        isTranslated: false,
         message: undefined,
         translation: "Headline",
         children: "Headline",
@@ -388,8 +386,6 @@ describe("Trans component", () => {
         {props.translation && (
           <div data-testid="translation">{props.translation}</div>
         )}
-
-        <div data-testid="is-translated">{String(props.isTranslated)}</div>
       </>
     )
 
@@ -405,21 +401,6 @@ describe("Trans component", () => {
       expect(markup.queryByTestId("translation")?.innerHTML).toEqual(
         "Translation"
       )
-      expect(markup.queryByTestId("is-translated")?.innerHTML).toEqual("true")
-    })
-
-    it("should pass isTranslated: false if no translation", () => {
-      const markup = render(
-        <I18nProvider i18n={i18n} defaultComponent={DefaultComponent}>
-          <Trans id="NO_ID" message="Some message" />
-        </I18nProvider>
-      )
-
-      expect(markup.queryByTestId("id")?.innerHTML).toEqual("NO_ID")
-      expect(markup.queryByTestId("translation")?.innerHTML).toEqual(
-        "Some message"
-      )
-      expect(markup.queryByTestId("is-translated")?.innerHTML).toEqual("false")
     })
 
     describe("TransNoContext", () => {

--- a/packages/react/src/TransNoContext.tsx
+++ b/packages/react/src/TransNoContext.tsx
@@ -9,10 +9,6 @@ export type TransRenderProps = {
   translation: React.ReactNode
   children: React.ReactNode
   message?: string | null
-  /**
-   * @deprecated isTranslated prop is undocumented and buggy. It'll be removed in v5 release.
-   * */
-  isTranslated: boolean
 }
 
 export type TransRenderCallbackOrComponent =
@@ -110,8 +106,6 @@ export function TransNoContext(
     id,
     message,
     translation,
-    // TODO vonovak - remove isTranslated prop in v5 release
-    isTranslated: id !== translation && message !== translation,
     children: translation, // for type-compatibility with `component` prop
   }
 


### PR DESCRIPTION
# Description

The `isTranslated` prop is undocumented and buggy.

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
