### PR TITLE
refactor(macro): use message descriptor for Trans

### DIFF
--- a/packages/babel-plugin-lingui-macro/src/constants.ts
+++ b/packages/babel-plugin-lingui-macro/src/constants.ts
@@ -1,6 +1,8 @@
 export const ID = "id"
 export const MESSAGE = "message"
 export const COMMENT = "comment"
+export const VALUES = "values"
+export const COMPONENTS = "components"
 export const EXTRACT_MARK = "i18n"
 export const CONTEXT = "context"
 export const MACRO_LEGACY_PACKAGE = "@lingui/macro"

--- a/packages/babel-plugin-lingui-macro/src/constants.ts
+++ b/packages/babel-plugin-lingui-macro/src/constants.ts
@@ -1,13 +1,16 @@
-export const ID = "id"
-export const MESSAGE = "message"
-export const COMMENT = "comment"
-export const VALUES = "values"
-export const COMPONENTS = "components"
 export const EXTRACT_MARK = "i18n"
-export const CONTEXT = "context"
 export const MACRO_LEGACY_PACKAGE = "@lingui/macro"
 export const MACRO_CORE_PACKAGE = "@lingui/core/macro"
 export const MACRO_REACT_PACKAGE = "@lingui/react/macro"
+
+export enum MsgDescriptorPropKey {
+  id = "id",
+  message = "message",
+  comment = "comment",
+  values = "values",
+  components = "components",
+  context = "context",
+}
 
 export enum JsMacroName {
   t = "t",

--- a/packages/babel-plugin-lingui-macro/src/macroJs.ts
+++ b/packages/babel-plugin-lingui-macro/src/macroJs.ts
@@ -32,6 +32,7 @@ import {
   MACRO_LEGACY_PACKAGE,
 } from "./constants"
 import { generateMessageId } from "@lingui/message-utils/generateMessageId"
+import { createMessageDescriptorFromTokens } from "./messageDescriptorUtils"
 
 function buildICUFromTokens(tokens: Tokens) {
   const messageFormat = new ICUMessageFormat()
@@ -76,7 +77,7 @@ export class MacroJs {
     linguiInstance?: babelTypes.Expression
   ) => {
     return this.createI18nCall(
-      this.createMessageDescriptorFromTokens(tokens, path.node.loc),
+      createMessageDescriptorFromTokens(tokens, path.node.loc),
       linguiInstance
     )
   }
@@ -102,7 +103,7 @@ export class MacroJs {
       this.isDefineMessage(path.get("tag"))
     ) {
       const tokens = this.tokenizeTemplateLiteral(path.get("quasi"))
-      return this.createMessageDescriptorFromTokens(tokens, path.node.loc)
+      return createMessageDescriptorFromTokens(tokens, path.node.loc)
     }
 
     if (path.isTaggedTemplateExpression()) {
@@ -255,7 +256,7 @@ export class MacroJs {
         if (currentPath.isTaggedTemplateExpression()) {
           const tokens = this.tokenizeTemplateLiteral(currentPath)
 
-          const descriptor = this.createMessageDescriptorFromTokens(
+          const descriptor = createMessageDescriptorFromTokens(
             tokens,
             currentPath.node.loc
           )
@@ -540,26 +541,6 @@ export class MacroJs {
         this.types.identifier("_")
       ),
       [messageDescriptor]
-    )
-  }
-
-  createMessageDescriptorFromTokens(tokens: Tokens, oldLoc?: SourceLocation) {
-    const { message, values } = buildICUFromTokens(tokens)
-
-    const properties: ObjectProperty[] = [
-      this.createIdProperty(message),
-
-      !this.stripNonEssentialProps
-        ? this.createObjectProperty(MESSAGE, this.types.stringLiteral(message))
-        : null,
-
-      this.createValuesProperty(values),
-    ]
-
-    return this.createMessageDescriptor(
-      properties,
-      // preserve line numbers for extractor
-      oldLoc
     )
   }
 

--- a/packages/babel-plugin-lingui-macro/src/macroJs.ts
+++ b/packages/babel-plugin-lingui-macro/src/macroJs.ts
@@ -350,12 +350,6 @@ export class MacroJs {
         comment: commentProperty?.node,
       }
     )
-
-    // if (!this.stripNonEssentialProps && commentProperty) {
-    //   properties.push(commentProperty.node)
-    // }
-
-    // return this.createMessageDescriptor(properties, descriptor.node.loc)
   }
 
   tokenizeNode(path: NodePath, ignoreExpression = false): Token[] {

--- a/packages/babel-plugin-lingui-macro/src/macroJs.ts
+++ b/packages/babel-plugin-lingui-macro/src/macroJs.ts
@@ -14,14 +14,11 @@ import { NodePath } from "@babel/traverse"
 import { ArgToken, TextToken, Token, Tokens } from "./icu"
 import { makeCounter } from "./utils"
 import {
-  COMMENT,
-  CONTEXT,
-  ID,
-  MESSAGE,
   MACRO_CORE_PACKAGE,
   JsMacroName,
   MACRO_REACT_PACKAGE,
   MACRO_LEGACY_PACKAGE,
+  MsgDescriptorPropKey,
 } from "./constants"
 import { createMessageDescriptorFromTokens } from "./messageDescriptorUtils"
 
@@ -313,20 +310,22 @@ export class MacroJs {
    *
    */
   processDescriptor = (descriptor: NodePath<ObjectExpression>) => {
-    const messageProperty = this.getObjectPropertyByKey(descriptor, MESSAGE)
-    const idProperty = this.getObjectPropertyByKey(descriptor, ID)
-    const contextProperty = this.getObjectPropertyByKey(descriptor, CONTEXT)
-    const commentProperty = this.getObjectPropertyByKey(descriptor, COMMENT)
-
-    // const properties: ObjectProperty[] = []
-    //
-    // if (idProperty) {
-    //   properties.push(idProperty.node)
-    // }
-    //
-    // if (!this.stripNonEssentialProps && contextProperty) {
-    //   properties.push(contextProperty.node)
-    // }
+    const messageProperty = this.getObjectPropertyByKey(
+      descriptor,
+      MsgDescriptorPropKey.message
+    )
+    const idProperty = this.getObjectPropertyByKey(
+      descriptor,
+      MsgDescriptorPropKey.id
+    )
+    const contextProperty = this.getObjectPropertyByKey(
+      descriptor,
+      MsgDescriptorPropKey.context
+    )
+    const commentProperty = this.getObjectPropertyByKey(
+      descriptor,
+      MsgDescriptorPropKey.comment
+    )
 
     let tokens: Token[] = []
 
@@ -339,31 +338,6 @@ export class MacroJs {
       tokens = messageValue.isTemplateLiteral()
         ? this.tokenizeTemplateLiteral(messageValue)
         : this.tokenizeNode(messageValue, true)
-
-      // let messageNode = messageValue.node as StringLiteral
-
-      // if (tokens) {
-      //   const { message, values } = buildICUFromTokens(tokens)
-      //   messageNode = this.types.stringLiteral(message)
-      //
-      //   properties.push(this.createValuesProperty(values))
-      // }
-
-      // if (!this.stripNonEssentialProps) {
-      //   properties.push(
-      //     this.createObjectProperty(MESSAGE, messageNode as Expression)
-      //   )
-      // }
-
-      // if (!idProperty && this.types.isStringLiteral(messageNode)) {
-      //   const context =
-      //     contextProperty &&
-      //     this.getTextFromExpression(
-      //       contextProperty.get("value").node as Expression
-      //     )
-      //
-      //   properties.push(this.createIdProperty(messageNode.value, context))
-      // }
     }
 
     return createMessageDescriptorFromTokens(

--- a/packages/babel-plugin-lingui-macro/src/macroJsx.ts
+++ b/packages/babel-plugin-lingui-macro/src/macroJsx.ts
@@ -61,14 +61,6 @@ export class MacroJSX {
     this.transImportName = opts.transImportName
   }
 
-  createStringJsxAttribute = (name: string, value: string) => {
-    // This handles quoted JSX attributes and html entities.
-    return this.types.jsxAttribute(
-      this.types.jsxIdentifier(name),
-      this.types.jsxExpressionContainer(this.types.stringLiteral(value))
-    )
-  }
-
   replacePath = (path: NodePath): false | Node => {
     if (!path.isJSXElement()) {
       return false
@@ -84,6 +76,10 @@ export class MacroJSX {
       path as NodePath<JSXElement>
     )
 
+    if (!tokens.length) {
+      throw new Error("Incorrect usage of Trans")
+    }
+
     const messageDescriptor = createMessageDescriptorFromTokens(
       tokens,
       path.node.loc,
@@ -94,10 +90,6 @@ export class MacroJSX {
         comment,
       }
     )
-
-    if (!id && !tokens) {
-      throw new Error("Incorrect usage of Trans")
-    }
 
     attributes.push(this.types.jsxSpreadAttribute(messageDescriptor))
 
@@ -228,7 +220,9 @@ export class MacroJSX {
     } else if (path.isJSXElement()) {
       return this.tokenizeNode(path)
     } else if (path.isJSXSpreadChild()) {
-      // just do nothing
+      throw new Error(
+        "Incorrect usage of Trans: Spread could not be used as Trans children"
+      )
     } else if (path.isJSXText()) {
       return [this.tokenizeText(cleanJSXElementLiteralChild(path.node.value))]
     } else {

--- a/packages/babel-plugin-lingui-macro/src/macroJsx.ts
+++ b/packages/babel-plugin-lingui-macro/src/macroJsx.ts
@@ -18,13 +18,10 @@ import { NodePath } from "@babel/traverse"
 import { ArgToken, ElementToken, TextToken, Token } from "./icu"
 import { makeCounter } from "./utils"
 import {
-  COMMENT,
-  CONTEXT,
-  ID,
-  MESSAGE,
   JsxMacroName,
   MACRO_REACT_PACKAGE,
   MACRO_LEGACY_PACKAGE,
+  MsgDescriptorPropKey,
 } from "./constants"
 import cleanJSXElementLiteralChild from "./utils/cleanJSXElementLiteralChild"
 import { createMessageDescriptorFromTokens } from "./messageDescriptorUtils"
@@ -129,12 +126,23 @@ export class MacroJSX {
 
   stripMacroAttributes = (path: NodePath<JSXElement>) => {
     const { attributes } = path.node.openingElement
-    const id = attributes.find(this.attrName([ID]))
-    const message = attributes.find(this.attrName([MESSAGE]))
-    const comment = attributes.find(this.attrName([COMMENT]))
-    const context = attributes.find(this.attrName([CONTEXT]))
+    const id = attributes.find(this.attrName([MsgDescriptorPropKey.id]))
+    const message = attributes.find(
+      this.attrName([MsgDescriptorPropKey.message])
+    )
+    const comment = attributes.find(
+      this.attrName([MsgDescriptorPropKey.comment])
+    )
+    const context = attributes.find(
+      this.attrName([MsgDescriptorPropKey.context])
+    )
 
-    let reserved = [ID, MESSAGE, COMMENT, CONTEXT]
+    let reserved: string[] = [
+      MsgDescriptorPropKey.id,
+      MsgDescriptorPropKey.message,
+      MsgDescriptorPropKey.comment,
+      MsgDescriptorPropKey.context,
+    ]
 
     if (this.isChoiceComponent(path)) {
       reserved = [
@@ -258,10 +266,10 @@ export class MacroJSX {
     const props = element.get("attributes").filter((attr) => {
       return this.attrName(
         [
-          ID,
-          COMMENT,
-          MESSAGE,
-          CONTEXT,
+          MsgDescriptorPropKey.id,
+          MsgDescriptorPropKey.comment,
+          MsgDescriptorPropKey.message,
+          MsgDescriptorPropKey.context,
           "key",
           // we remove <Trans /> react props that are not useful for translation
           "render",

--- a/packages/babel-plugin-lingui-macro/src/messageDescriptorUtils.ts
+++ b/packages/babel-plugin-lingui-macro/src/messageDescriptorUtils.ts
@@ -1,0 +1,112 @@
+import ICUMessageFormat, { Tokens, ParsedResult } from "./icu"
+import { SourceLocation, ObjectProperty, ObjectExpression } from "@babel/types"
+import { MESSAGE, ID, EXTRACT_MARK, COMMENT, CONTEXT } from "./constants"
+import * as types from "@babel/types"
+import { generateMessageId } from "@lingui/message-utils/generateMessageId"
+
+function buildICUFromTokens(tokens: Tokens) {
+  const messageFormat = new ICUMessageFormat()
+  return messageFormat.fromTokens(tokens)
+}
+
+export function createMessageDescriptorFromTokens(
+  tokens: Tokens,
+  oldLoc?: SourceLocation,
+  defaults: { id?: string; context?: string; comment?: string } = {},
+  stripNonEssentialProps = true
+) {
+  const { message, values, jsxElements } = buildICUFromTokens(tokens)
+
+  const properties: ObjectProperty[] = []
+
+  properties.push(
+    defaults.id
+      ? createStringObjectProperty(ID, defaults.id)
+      : createIdProperty(message, defaults.context)
+  )
+
+  if (!stripNonEssentialProps) {
+    properties.push(createStringObjectProperty(MESSAGE, message))
+
+    if (defaults.comment) {
+      properties.push(createStringObjectProperty(COMMENT, defaults.comment))
+    }
+
+    if (defaults.context) {
+      properties.push(createStringObjectProperty(CONTEXT, defaults.context))
+    }
+  }
+
+  properties.push(createValuesProperty(values))
+  properties.push(createComponentsProperty(jsxElements))
+
+  return createMessageDescriptor(
+    properties,
+    // preserve line numbers for extractor
+    oldLoc
+  )
+}
+
+function createIdProperty(message: string, context?: string) {
+  return createStringObjectProperty(ID, generateMessageId(message, context))
+}
+
+function createValuesProperty(values: ParsedResult["values"]) {
+  const valuesObject = Object.keys(values).map((key) =>
+    types.objectProperty(types.identifier(key), values[key])
+  )
+
+  if (!valuesObject.length) return
+
+  return types.objectProperty(
+    types.identifier("values"),
+    types.objectExpression(valuesObject)
+  )
+}
+
+function createComponentsProperty(values: ParsedResult["jsxElements"]) {
+  const valuesObject = Object.keys(values).map((key) =>
+    types.objectProperty(types.identifier(key), values[key])
+  )
+
+  if (!valuesObject.length) return
+
+  return types.objectProperty(
+    types.identifier("components"),
+    types.objectExpression(valuesObject)
+  )
+}
+
+// if (Object.keys(jsxElements).length) {
+//   attributes.push(
+//     this.types.jsxAttribute(
+//       this.types.jsxIdentifier("components"),
+//       this.types.jsxExpressionContainer(
+//         this.types.objectExpression(
+//           Object.keys(jsxElements).map((key) =>
+//             this.types.objectProperty(
+//               this.types.identifier(key),
+//               jsxElements[key]
+//             )
+//           )
+//         )
+//       )
+//     )
+//   )
+// }
+export function createStringObjectProperty(key: string, value: string) {
+  return types.objectProperty(types.identifier(key), types.stringLiteral(value))
+}
+
+function createMessageDescriptor(
+  properties: ObjectProperty[],
+  oldLoc?: SourceLocation
+): ObjectExpression {
+  const newDescriptor = types.objectExpression(properties.filter(Boolean))
+  types.addComment(newDescriptor, "leading", EXTRACT_MARK)
+  if (oldLoc) {
+    newDescriptor.loc = oldLoc
+  }
+
+  return newDescriptor
+}

--- a/packages/babel-plugin-lingui-macro/src/messageDescriptorUtils.ts
+++ b/packages/babel-plugin-lingui-macro/src/messageDescriptorUtils.ts
@@ -6,15 +6,7 @@ import {
   isObjectProperty,
   Expression,
 } from "@babel/types"
-import {
-  MESSAGE,
-  ID,
-  EXTRACT_MARK,
-  COMMENT,
-  CONTEXT,
-  VALUES,
-  COMPONENTS,
-} from "./constants"
+import { EXTRACT_MARK, MsgDescriptorPropKey } from "./constants"
 import * as types from "@babel/types"
 import { generateMessageId } from "@lingui/message-utils/generateMessageId"
 
@@ -46,7 +38,11 @@ export function createMessageDescriptorFromTokens(
     defaults.id
       ? isObjectProperty(defaults.id)
         ? defaults.id
-        : createStringObjectProperty(ID, defaults.id.text, defaults.id.loc)
+        : createStringObjectProperty(
+            MsgDescriptorPropKey.id,
+            defaults.id.text,
+            defaults.id.loc
+          )
       : createIdProperty(
           message,
           defaults.context
@@ -59,7 +55,9 @@ export function createMessageDescriptorFromTokens(
 
   if (!stripNonEssentialProps) {
     if (message) {
-      properties.push(createStringObjectProperty(MESSAGE, message))
+      properties.push(
+        createStringObjectProperty(MsgDescriptorPropKey.message, message)
+      )
     }
 
     if (defaults.comment) {
@@ -67,7 +65,7 @@ export function createMessageDescriptorFromTokens(
         isObjectProperty(defaults.comment)
           ? defaults.comment
           : createStringObjectProperty(
-              COMMENT,
+              MsgDescriptorPropKey.comment,
               defaults.comment.text,
               defaults.comment.loc
             )
@@ -79,7 +77,7 @@ export function createMessageDescriptorFromTokens(
         isObjectProperty(defaults.context)
           ? defaults.context
           : createStringObjectProperty(
-              CONTEXT,
+              MsgDescriptorPropKey.context,
               defaults.context.text,
               defaults.context.loc
             )
@@ -87,8 +85,10 @@ export function createMessageDescriptorFromTokens(
     }
   }
 
-  properties.push(createValuesProperty(VALUES, values))
-  properties.push(createValuesProperty(COMPONENTS, jsxElements))
+  properties.push(createValuesProperty(MsgDescriptorPropKey.values, values))
+  properties.push(
+    createValuesProperty(MsgDescriptorPropKey.components, jsxElements)
+  )
 
   return createMessageDescriptor(
     properties,
@@ -98,7 +98,10 @@ export function createMessageDescriptorFromTokens(
 }
 
 function createIdProperty(message: string, context?: string) {
-  return createStringObjectProperty(ID, generateMessageId(message, context))
+  return createStringObjectProperty(
+    MsgDescriptorPropKey.id,
+    generateMessageId(message, context)
+  )
 }
 
 function createValuesProperty(key: string, values: Record<string, Expression>) {

--- a/packages/babel-plugin-lingui-macro/test/__snapshots__/js-defineMessage.test.ts.snap
+++ b/packages/babel-plugin-lingui-macro/test/__snapshots__/js-defineMessage.test.ts.snap
@@ -35,10 +35,10 @@ const msg = defineMessage({
 const msg =
   /*i18n*/
   {
+    id: "oT92lS",
     values: {
       name: name,
     },
-    id: "oT92lS",
   };
 
 `;
@@ -59,8 +59,8 @@ const message1 =
 const message2 =
   /*i18n*/
   {
-    message: "Message",
     id: "xDAtGP",
+    message: "Message",
   };
 
 `;
@@ -80,12 +80,12 @@ const message = defineMessage2({
 const message =
   /*i18n*/
   {
+    id: "SlmyxX",
+    message: "{value, plural, one {book} other {books}}",
+    comment: "Description",
     values: {
       value: value,
     },
-    message: "{value, plural, one {book} other {books}}",
-    id: "SlmyxX",
-    comment: "Description",
   };
 
 `;
@@ -117,12 +117,12 @@ const message = defineMessage({
 const message =
   /*i18n*/
   {
+    id: "SlmyxX",
+    message: "{value, plural, one {book} other {books}}",
+    comment: "Description",
     values: {
       value: value,
     },
-    message: "{value, plural, one {book} other {books}}",
-    id: "SlmyxX",
-    comment: "Description",
   };
 
 `;
@@ -138,8 +138,8 @@ const message = defineMessage({
 const message =
   /*i18n*/
   {
-    message: "Message",
     id: "xDAtGP",
+    message: "Message",
   };
 
 `;
@@ -173,11 +173,11 @@ const message = defineMessage({
 const message =
   /*i18n*/
   {
+    id: "OVaF9k",
+    message: "Hello {name}",
     values: {
       name: name,
     },
-    message: "Hello {name}",
-    id: "OVaF9k",
   };
 
 `;
@@ -193,11 +193,11 @@ const message = defineMessage({
 const message =
   /*i18n*/
   {
+    id: "A2aVLF",
+    message: "Message {name}",
     values: {
       name: name,
     },
-    message: "Message {name}",
-    id: "A2aVLF",
   };
 
 `;

--- a/packages/babel-plugin-lingui-macro/test/__snapshots__/js-t.test.ts.snap
+++ b/packages/babel-plugin-lingui-macro/test/__snapshots__/js-t.test.ts.snap
@@ -41,17 +41,17 @@ import { i18n as _i18n } from "@lingui/core";
 _i18n._(
   /*i18n*/
   {
-    context: "my custom",
-    message: "Hello",
     id: "BYqAaU",
+    message: "Hello",
+    context: "my custom",
   }
 );
 _i18n._(
   /*i18n*/
   {
-    context: \`my custom\`,
-    message: "Hello",
     id: "BYqAaU",
+    message: "Hello",
+    context: \`my custom\`,
   }
 );
 
@@ -68,8 +68,8 @@ const msg = message.error(
   _i18n._(
     /*i18n*/
     {
-      message: "dasd",
       id: "9ZMZjU",
+      message: "dasd",
     }
   )
 );
@@ -145,12 +145,12 @@ const msg = _i18n._(
   /*i18n*/
   {
     id: "msgId",
+    message: "Hello {name}",
+    comment: "description for translators",
     context: "My Context",
     values: {
       name: name,
     },
-    message: "Hello {name}",
-    comment: "description for translators",
   }
 );
 
@@ -256,16 +256,16 @@ import { i18n as _i18n } from "@lingui/core";
 _i18n._(
   /*i18n*/
   {
-    message: "Hello",
     id: "uzTaYi",
+    message: "Hello",
   }
 );
 _i18n._(
   /*i18n*/
   {
-    context: "my custom",
-    message: "Hello",
     id: "BYqAaU",
+    message: "Hello",
+    context: "my custom",
   }
 );
 
@@ -286,11 +286,11 @@ const msg = _i18n._(
   /*i18n*/
   {
     id: "msgId",
+    message: "{val, plural, one {...} other {...}}",
+    comment: "description for translators",
     values: {
       val: val,
     },
-    message: "{val, plural, one {...} other {...}}",
-    comment: "description for translators",
   }
 );
 
@@ -323,10 +323,10 @@ const msg = _i18n._(
   /*i18n*/
   {
     id: "msgId",
+    message: "Some {value}",
     values: {
       value: value,
     },
-    message: "Some {value}",
   }
 );
 
@@ -368,11 +368,11 @@ import { i18n as _i18n } from "@lingui/core";
 const msg = _i18n._(
   /*i18n*/
   {
+    id: "OVaF9k",
+    message: "Hello {name}",
     values: {
       name: name,
     },
-    message: "Hello {name}",
-    id: "OVaF9k",
   }
 );
 
@@ -389,11 +389,11 @@ import { i18n } from "./lingui";
 const msg = i18n._(
   /*i18n*/
   {
+    id: "OVaF9k",
+    message: "Hello {name}",
     values: {
       name: name,
     },
-    message: "Hello {name}",
-    id: "OVaF9k",
   }
 );
 
@@ -408,11 +408,11 @@ const msg = t(global.i18n)({ message: \`Hello \${name}\` });
 const msg = global.i18n._(
   /*i18n*/
   {
+    id: "OVaF9k",
+    message: "Hello {name}",
     values: {
       name: name,
     },
-    message: "Hello {name}",
-    id: "OVaF9k",
   }
 );
 

--- a/packages/babel-plugin-lingui-macro/test/__snapshots__/js-useLingui.test.ts.snap
+++ b/packages/babel-plugin-lingui-macro/test/__snapshots__/js-useLingui.test.ts.snap
@@ -123,9 +123,9 @@ function MyComponent() {
   const a = _t(
     /*i18n*/
     {
-      context: "my custom",
-      message: "Hello",
       id: "BYqAaU",
+      message: "Hello",
+      context: "my custom",
     }
   );
 }

--- a/packages/babel-plugin-lingui-macro/test/__snapshots__/jsx-plural.test.ts.snap
+++ b/packages/babel-plugin-lingui-macro/test/__snapshots__/jsx-plural.test.ts.snap
@@ -14,16 +14,20 @@ import { Plural } from "@lingui/react/macro";
 
 import { Trans as _Trans } from "@lingui/react";
 <_Trans
-  id={"tYX0sm"}
-  message={
-    "{count, plural, offset:1 =0 {Zero items} few {{count} items} other {<0>A lot of them</0>}}"
+  {
+    /*i18n*/
+    ...{
+      id: "tYX0sm",
+      message:
+        "{count, plural, offset:1 =0 {Zero items} few {{count} items} other {<0>A lot of them</0>}}",
+      values: {
+        count: count,
+      },
+      components: {
+        0: <a href="/more" />,
+      },
+    }
   }
-  values={{
-    count: count,
-  }}
-  components={{
-    0: <a href="/more" />,
-  }}
 />;
 
 `;
@@ -48,17 +52,21 @@ import { Trans, Plural } from "@lingui/react/macro";
 
 import { Trans as _Trans } from "@lingui/react";
 <_Trans
-  id={"X8eyr1"}
-  message={
-    "{count, plural, one {<0>#</0> slot added} other {<1>#</1> slots added}}"
+  {
+    /*i18n*/
+    ...{
+      id: "X8eyr1",
+      message:
+        "{count, plural, one {<0>#</0> slot added} other {<1>#</1> slots added}}",
+      values: {
+        count: count,
+      },
+      components: {
+        0: <strong />,
+        1: <strong />,
+      },
+    }
   }
-  values={{
-    count: count,
-  }}
-  components={{
-    0: <strong />,
-    1: <strong />,
-  }}
 />;
 
 `;
@@ -80,16 +88,20 @@ import { Plural } from "@lingui/react/macro";
 import { Trans as _Trans } from "@lingui/react";
 <_Trans
   render="strong"
-  id="msg.plural"
-  message={
-    "{count, plural, offset:1 =0 {Zero items} few {{count} items} other {<0>A lot of them</0>}}"
+  {
+    /*i18n*/
+    ...{
+      id: "msg.plural",
+      message:
+        "{count, plural, offset:1 =0 {Zero items} few {{count} items} other {<0>A lot of them</0>}}",
+      values: {
+        count: count,
+      },
+      components: {
+        0: <a href="/more" />,
+      },
+    }
   }
-  values={{
-    count: count,
-  }}
-  components={{
-    0: <a href="/more" />,
-  }}
 />;
 
 `;
@@ -111,18 +123,22 @@ import { Trans, Plural } from "@lingui/react/macro";
 
 import { Trans as _Trans } from "@lingui/react";
 <_Trans
-  id="inner-id-removed"
-  message={
-    "Looking for {0, plural, offset:1 =0 {zero items} few {{1} items {2}} other {<0>a lot of them</0>}}"
+  {
+    /*i18n*/
+    ...{
+      id: "inner-id-removed",
+      message:
+        "Looking for {0, plural, offset:1 =0 {zero items} few {{1} items {2}} other {<0>a lot of them</0>}}",
+      values: {
+        0: items.length,
+        1: items.length,
+        2: 42,
+      },
+      components: {
+        0: <a href="/more" />,
+      },
+    }
   }
-  values={{
-    0: items.length,
-    1: items.length,
-    2: 42,
-  }}
-  components={{
-    0: <a href="/more" />,
-  }}
 />;
 
 `;
@@ -140,17 +156,21 @@ import { Plural } from "@lingui/react/macro";
 
 import { Trans as _Trans } from "@lingui/react";
 <_Trans
-  id={"EQvNfC"}
-  message={
-    "{count, plural, =0 {Zero items} one {{oneText}} other {<0>A lot of them</0>}}"
+  {
+    /*i18n*/
+    ...{
+      id: "EQvNfC",
+      message:
+        "{count, plural, =0 {Zero items} one {{oneText}} other {<0>A lot of them</0>}}",
+      values: {
+        count: count,
+        oneText: oneText,
+      },
+      components: {
+        0: <a href="/more" />,
+      },
+    }
   }
-  values={{
-    count: count,
-    oneText: oneText,
-  }}
-  components={{
-    0: <a href="/more" />,
-  }}
 />;
 
 `;
@@ -163,11 +183,16 @@ import { Plural as Plural2 } from "@lingui/react/macro";
 
 import { Trans as _Trans } from "@lingui/react";
 <_Trans
-  id={"EMgKyP"}
-  message={"{count, plural, one {...} other {...}}"}
-  values={{
-    count: count,
-  }}
+  {
+    /*i18n*/
+    ...{
+      id: "EMgKyP",
+      message: "{count, plural, one {...} other {...}}",
+      values: {
+        count: count,
+      },
+    }
+  }
 />;
 
 `;
@@ -191,18 +216,22 @@ import { Plural } from "@lingui/react/macro";
 import { Trans as _Trans } from "@lingui/react";
 <_Trans
   render={() => {}}
-  id="custom.id"
-  message={
-    "{count, plural, offset:1 =0 {Zero items} few {{count} items} other {<0>A lot of them</0>}}"
+  {
+    /*i18n*/
+    ...{
+      id: "custom.id",
+      message:
+        "{count, plural, offset:1 =0 {Zero items} few {{count} items} other {<0>A lot of them</0>}}",
+      comment: "Comment for translator",
+      context: "translation context",
+      values: {
+        count: count,
+      },
+      components: {
+        0: <a href="/more" />,
+      },
+    }
   }
-  comment="Comment for translator"
-  context="translation context"
-  values={{
-    count: count,
-  }}
-  components={{
-    0: <a href="/more" />,
-  }}
 />;
 
 `;
@@ -219,11 +248,16 @@ import { Trans, Plural } from "@lingui/react/macro";
 
 import { Trans as _Trans } from "@lingui/react";
 <_Trans
-  id={"oukcm6"}
-  message={"{count, plural, one {One hello} other {Other hello}}"}
-  values={{
-    count: count,
-  }}
+  {
+    /*i18n*/
+    ...{
+      id: "oukcm6",
+      message: "{count, plural, one {One hello} other {Other hello}}",
+      values: {
+        count: count,
+      },
+    }
+  }
 />;
 
 `;

--- a/packages/babel-plugin-lingui-macro/test/__snapshots__/jsx-select.test.ts.snap
+++ b/packages/babel-plugin-lingui-macro/test/__snapshots__/jsx-select.test.ts.snap
@@ -13,14 +13,19 @@ import { Select } from "@lingui/react/macro";
 
 import { Trans as _Trans } from "@lingui/react";
 <_Trans
-  id={"Imwef9"}
-  message={"{count, select, male {He} female {She} other {<0>Other</0>}}"}
-  values={{
-    count: count,
-  }}
-  components={{
-    0: <strong />,
-  }}
+  {
+    /*i18n*/
+    ...{
+      id: "Imwef9",
+      message: "{count, select, male {He} female {She} other {<0>Other</0>}}",
+      values: {
+        count: count,
+      },
+      components: {
+        0: <strong />,
+      },
+    }
+  }
 />;
 
 `;
@@ -41,14 +46,19 @@ import { Select } from "@lingui/react/macro";
 import { Trans as _Trans } from "@lingui/react";
 <_Trans
   render="strong"
-  id="msg.select"
-  message={"{0, select, male {He} female {She} other {<0>Other</0>}}"}
-  values={{
-    0: user.gender,
-  }}
-  components={{
-    0: <strong />,
-  }}
+  {
+    /*i18n*/
+    ...{
+      id: "msg.select",
+      message: "{0, select, male {He} female {She} other {<0>Other</0>}}",
+      values: {
+        0: user.gender,
+      },
+      components: {
+        0: <strong />,
+      },
+    }
+  }
 />;
 
 `;
@@ -69,12 +79,17 @@ import { Select } from "@lingui/react/macro";
 import { Trans as _Trans } from "@lingui/react";
 <_Trans
   render="strong"
-  id="msg.select"
-  message={"{0, select, male {He} female {She} other {{otherText}}}"}
-  values={{
-    0: user.gender,
-    otherText: otherText,
-  }}
+  {
+    /*i18n*/
+    ...{
+      id: "msg.select",
+      message: "{0, select, male {He} female {She} other {{otherText}}}",
+      values: {
+        0: user.gender,
+        otherText: otherText,
+      },
+    }
+  }
 />;
 
 `;
@@ -100,15 +115,21 @@ import { Select, Trans } from "@lingui/react/macro";
 
 import { Trans as _Trans } from "@lingui/react";
 <_Trans
-  id={"f1ZLwG"}
-  message={"{0, select, happy {Hooray! <0/>} sad {Oh no! <1/>} other {Dunno}}"}
-  values={{
-    0: "happy",
-  }}
-  components={{
-    0: <Icon />,
-    1: <Icon />,
-  }}
+  {
+    /*i18n*/
+    ...{
+      id: "f1ZLwG",
+      message:
+        "{0, select, happy {Hooray! <0/>} sad {Oh no! <1/>} other {Dunno}}",
+      values: {
+        0: "happy",
+      },
+      components: {
+        0: <Icon />,
+        1: <Icon />,
+      },
+    }
+  }
 />;
 
 `;

--- a/packages/babel-plugin-lingui-macro/test/__snapshots__/jsx-selectOrdinal.test.ts.snap
+++ b/packages/babel-plugin-lingui-macro/test/__snapshots__/jsx-selectOrdinal.test.ts.snap
@@ -17,16 +17,20 @@ import { Trans, SelectOrdinal } from "@lingui/react/macro";
 
 import { Trans as _Trans } from "@lingui/react";
 <_Trans
-  id={"3YEV8L"}
-  message={
-    "This is my {count, selectordinal, one {#st} two {#nd} other {<0>#rd</0>}} cat."
+  {
+    /*i18n*/
+    ...{
+      id: "3YEV8L",
+      message:
+        "This is my {count, selectordinal, one {#st} two {#nd} other {<0>#rd</0>}} cat.",
+      values: {
+        count: count,
+      },
+      components: {
+        0: <strong />,
+      },
+    }
   }
-  values={{
-    count: count,
-  }}
-  components={{
-    0: <strong />,
-  }}
 />;
 
 `;
@@ -48,16 +52,20 @@ import { Trans, SelectOrdinal } from "@lingui/react/macro";
 
 import { Trans as _Trans } from "@lingui/react";
 <_Trans
-  id={"Dz3XK1"}
-  message={
-    "This is my{count, selectordinal, one {#st} two {#nd} other {<0>#rd</0>}} cat."
+  {
+    /*i18n*/
+    ...{
+      id: "Dz3XK1",
+      message:
+        "This is my{count, selectordinal, one {#st} two {#nd} other {<0>#rd</0>}} cat.",
+      values: {
+        count: count,
+      },
+      components: {
+        0: <strong />,
+      },
+    }
   }
-  values={{
-    count: count,
-  }}
-  components={{
-    0: <strong />,
-  }}
 />;
 
 `;
@@ -79,16 +87,20 @@ import { Trans, SelectOrdinal } from "@lingui/react/macro";
 
 import { Trans as _Trans } from "@lingui/react";
 <_Trans
-  id={"CDpzE+"}
-  message={
-    "This is my {0, selectordinal, one {#st} two {#nd} other {<0>#rd</0>}} cat."
+  {
+    /*i18n*/
+    ...{
+      id: "CDpzE+",
+      message:
+        "This is my {0, selectordinal, one {#st} two {#nd} other {<0>#rd</0>}} cat.",
+      values: {
+        0: user.numCats,
+      },
+      components: {
+        0: <strong />,
+      },
+    }
   }
-  values={{
-    0: user.numCats,
-  }}
-  components={{
-    0: <strong />,
-  }}
 />;
 
 `;

--- a/packages/babel-plugin-lingui-macro/test/__snapshots__/jsx-trans.test.ts.snap
+++ b/packages/babel-plugin-lingui-macro/test/__snapshots__/jsx-trans.test.ts.snap
@@ -18,18 +18,23 @@ import { Trans } from "@lingui/react/macro";
 
 import { Trans as _Trans } from "@lingui/react";
 <_Trans
-  id={"k9gsHO"}
-  message={"Hello <0>World!</0><1/><2>My name is <3> <4>{name}</4></3></2>"}
-  values={{
-    name: name,
-  }}
-  components={{
-    0: <strong />,
-    1: <br />,
-    2: <p />,
-    3: <a href="/about" />,
-    4: <em />,
-  }}
+  {
+    /*i18n*/
+    ...{
+      id: "k9gsHO",
+      message: "Hello <0>World!</0><1/><2>My name is <3> <4>{name}</4></3></2>",
+      values: {
+        name: name,
+      },
+      components: {
+        0: <strong />,
+        1: <br />,
+        2: <p />,
+        3: <a href="/about" />,
+        4: <em />,
+      },
+    }
+  }
 />;
 
 `;
@@ -42,11 +47,16 @@ import { Trans } from "@lingui/react/macro";
 
 import { Trans as _Trans } from "@lingui/react";
 <_Trans
-  id={"1cZQQW"}
-  message={"<0>Component inside expression container</0>"}
-  components={{
-    0: <span />,
-  }}
+  {
+    /*i18n*/
+    ...{
+      id: "1cZQQW",
+      message: "<0>Component inside expression container</0>",
+      components: {
+        0: <span />,
+      },
+    }
+  }
 />;
 
 `;
@@ -59,11 +69,16 @@ import { Trans } from "@lingui/react/macro";
 
 import { Trans as _Trans } from "@lingui/react";
 <_Trans
-  id={"SCJtqt"}
-  message={"<0/>"}
-  components={{
-    0: <br />,
-  }}
+  {
+    /*i18n*/
+    ...{
+      id: "SCJtqt",
+      message: "<0/>",
+      components: {
+        0: <br />,
+      },
+    }
+  }
 />;
 
 `;
@@ -79,18 +94,22 @@ import { Trans } from "@lingui/react/macro";
 
 import { Trans as _Trans } from "@lingui/react";
 <_Trans
-  id={"HjKDmx"}
-  message={
-    "Property {0}, function {1}, array {2}, constant {3}, object {4}, everything {5}"
+  {
+    /*i18n*/
+    ...{
+      id: "HjKDmx",
+      message:
+        "Property {0}, function {1}, array {2}, constant {3}, object {4}, everything {5}",
+      values: {
+        0: props.name,
+        1: random(),
+        2: array[index],
+        3: 42,
+        4: new Date(),
+        5: props.messages[index].value(),
+      },
+    }
   }
-  values={{
-    0: props.name,
-    1: random(),
-    2: array[index],
-    3: 42,
-    4: new Date(),
-    5: props.messages[index].value(),
-  }}
 />;
 
 `;
@@ -102,7 +121,15 @@ import { Trans } from "@lingui/react/macro";
 ↓ ↓ ↓ ↓ ↓ ↓
 
 import { Trans as _Trans } from "@lingui/react";
-<_Trans id={"mY42CM"} message={"Hello World"} />;
+<_Trans
+  {
+    /*i18n*/
+    ...{
+      id: "mY42CM",
+      message: "Hello World",
+    }
+  }
+/>;
 
 `;
 
@@ -114,8 +141,25 @@ import { Trans } from "@lingui/react/macro";
 ↓ ↓ ↓ ↓ ↓ ↓
 
 import { Trans as _Trans } from "@lingui/react";
-<_Trans id={"mY42CM"} message={"Hello World"} />;
-<_Trans id={"SO/WB8"} message={"Hello World"} context="my context" />;
+<_Trans
+  {
+    /*i18n*/
+    ...{
+      id: "mY42CM",
+      message: "Hello World",
+    }
+  }
+/>;
+<_Trans
+  {
+    /*i18n*/
+    ...{
+      id: "SO/WB8",
+      message: "Hello World",
+      context: "my context",
+    }
+  }
+/>;
 
 `;
 
@@ -129,11 +173,16 @@ import { Trans } from "@lingui/react/macro";
 
 import { Trans as _Trans } from "@lingui/react";
 <_Trans
-  id={"K/1Xpr"}
-  message={"<0>This should work \\xA0</0>"}
-  components={{
-    0: <Text />,
-  }}
+  {
+    /*i18n*/
+    ...{
+      id: "K/1Xpr",
+      message: "<0>This should work \\xA0</0>",
+      components: {
+        0: <Text />,
+      },
+    }
+  }
 />;
 
 `;
@@ -145,7 +194,15 @@ import { Trans } from "@lingui/react/macro";
 ↓ ↓ ↓ ↓ ↓ ↓
 
 import { Trans as _Trans } from "@lingui/react";
-<_Trans id={"i0M2R8"} message={"Hello  World"} />;
+<_Trans
+  {
+    /*i18n*/
+    ...{
+      id: "i0M2R8",
+      message: "Hello  World",
+    }
+  }
+/>;
 
 `;
 
@@ -159,15 +216,36 @@ import { Trans } from "@lingui/react/macro";
 
 import { Trans as _Trans } from "@lingui/react";
 <_Trans
-  id={"UT5PlM"}
-  message={"Hello, {0}"}
-  values={{
-    0: props.world ? (
-      <_Trans id={"ELi2P3"} message={"world"} />
-    ) : (
-      <_Trans id={"39nd+2"} message={"guys"} />
-    ),
-  }}
+  {
+    /*i18n*/
+    ...{
+      id: "UT5PlM",
+      message: "Hello, {0}",
+      values: {
+        0: props.world ? (
+          <_Trans
+            {
+              /*i18n*/
+              ...{
+                id: "ELi2P3",
+                message: "world",
+              }
+            }
+          />
+        ) : (
+          <_Trans
+            {
+              /*i18n*/
+              ...{
+                id: "39nd+2",
+                message: "guys",
+              }
+            }
+          />
+        ),
+      },
+    }
+  }
 />;
 
 `;
@@ -189,17 +267,46 @@ import { Trans } from "@lingui/react/macro";
 
 import { Trans as _Trans } from "@lingui/react";
 <_Trans
-  id={"UT5PlM"}
-  message={"Hello, {0}"}
-  values={{
-    0: props.world ? (
-      <_Trans id={"ELi2P3"} message={"world"} />
-    ) : props.b ? (
-      <_Trans id={"lV+268"} message={"nested"} />
-    ) : (
-      <_Trans id={"39nd+2"} message={"guys"} />
-    ),
-  }}
+  {
+    /*i18n*/
+    ...{
+      id: "UT5PlM",
+      message: "Hello, {0}",
+      values: {
+        0: props.world ? (
+          <_Trans
+            {
+              /*i18n*/
+              ...{
+                id: "ELi2P3",
+                message: "world",
+              }
+            }
+          />
+        ) : props.b ? (
+          <_Trans
+            {
+              /*i18n*/
+              ...{
+                id: "lV+268",
+                message: "nested",
+              }
+            }
+          />
+        ) : (
+          <_Trans
+            {
+              /*i18n*/
+              ...{
+                id: "39nd+2",
+                message: "guys",
+              }
+            }
+          />
+        ),
+      },
+    }
+  }
 />;
 
 `;
@@ -211,7 +318,15 @@ import { Trans } from "@lingui/react/macro";
 ↓ ↓ ↓ ↓ ↓ ↓
 
 import { Trans as _Trans } from "@lingui/react";
-<_Trans id="msg.hello" message={"Hello World"} />;
+<_Trans
+  {
+    /*i18n*/
+    ...{
+      id: "msg.hello",
+      message: "Hello World",
+    }
+  }
+/>;
 
 `;
 
@@ -222,7 +337,15 @@ import { Trans } from "@lingui/react/macro";
 ↓ ↓ ↓ ↓ ↓ ↓
 
 import { Trans as _Trans } from "@lingui/react";
-<_Trans id="msg.hello" message={"Hello World"} />;
+<_Trans
+  {
+    /*i18n*/
+    ...{
+      id: "msg.hello",
+      message: "Hello World",
+    }
+  }
+/>;
 
 `;
 
@@ -233,7 +356,15 @@ import { Trans } from "@lingui/react/macro";
 ↓ ↓ ↓ ↓ ↓ ↓
 
 import { Trans as _Trans } from "@lingui/react";
-<_Trans id="msg.hello" message={"Hello World"} />;
+<_Trans
+  {
+    /*i18n*/
+    ...{
+      id: "msg.hello",
+      message: "Hello World",
+    }
+  }
+/>;
 
 `;
 
@@ -246,7 +377,16 @@ import { Trans } from "@lingui/react/macro";
 ↓ ↓ ↓ ↓ ↓ ↓
 
 import { Trans as _Trans } from "@lingui/react";
-<_Trans id="msg.hello" message={"Hello World"} comment="Hello World" />;
+<_Trans
+  {
+    /*i18n*/
+    ...{
+      id: "msg.hello",
+      message: "Hello World",
+      comment: "Hello World",
+    }
+  }
+/>;
 
 `;
 
@@ -260,7 +400,14 @@ import { Trans } from "@lingui/react/macro";
 ↓ ↓ ↓ ↓ ↓ ↓
 
 import { Trans as _Trans } from "@lingui/react";
-<_Trans id="msg.hello" />;
+<_Trans
+  {
+    /*i18n*/
+    ...{
+      id: "msg.hello",
+    }
+  }
+/>;
 
 `;
 
@@ -273,7 +420,14 @@ import { Trans } from "@lingui/react/macro";
 ↓ ↓ ↓ ↓ ↓ ↓
 
 import { Trans as _Trans } from "@lingui/react";
-<_Trans id="msg.hello" />;
+<_Trans
+  {
+    /*i18n*/
+    ...{
+      id: "msg.hello",
+    }
+  }
+/>;
 
 `;
 
@@ -285,8 +439,24 @@ import { Trans } from "@lingui/react/macro";
 ↓ ↓ ↓ ↓ ↓ ↓
 
 import { Trans as _Trans } from "@lingui/react";
-<_Trans id={"NWmRwM"} message={'Speak "friend"!'} />;
-<_Trans id="custom-id" message={'Speak "friend"!'} />;
+<_Trans
+  {
+    /*i18n*/
+    ...{
+      id: "NWmRwM",
+      message: 'Speak "friend"!',
+    }
+  }
+/>;
+<_Trans
+  {
+    /*i18n*/
+    ...{
+      id: "custom-id",
+      message: 'Speak "friend"!',
+    }
+  }
+/>;
 
 `;
 
@@ -298,7 +468,17 @@ const cmp = <Trans>Hello</Trans>;
 ↓ ↓ ↓ ↓ ↓ ↓
 
 import { Trans as _Trans } from "@lingui/react";
-const cmp = <_Trans id={"uzTaYi"} message={"Hello"} />;
+const cmp = (
+  <_Trans
+    {
+      /*i18n*/
+      ...{
+        id: "uzTaYi",
+        message: "Hello",
+      }
+    }
+  />
+);
 
 `;
 
@@ -318,10 +498,15 @@ import { Trans } from "@lingui/react/macro";
 import { Trans as _Trans } from "@lingui/react";
 <_Trans
   render={() => {}}
-  id="custom.id"
-  message={"Hello World"}
-  comment="Comment for translator"
-  context="translation context"
+  {
+    /*i18n*/
+    ...{
+      id: "custom.id",
+      message: "Hello World",
+      comment: "Comment for translator",
+      context: "translation context",
+    }
+  }
 />;
 
 `;
@@ -334,8 +519,13 @@ import { Trans } from "@lingui/react/macro";
 
 import { Trans as _Trans } from "@lingui/react";
 <_Trans
-  id={"U8dd/d"}
-  message={"hello {count, plural, one {world} other {worlds}}"}
+  {
+    /*i18n*/
+    ...{
+      id: "U8dd/d",
+      message: "hello {count, plural, one {world} other {worlds}}",
+    }
+  }
 />;
 
 `;
@@ -348,11 +538,16 @@ import { Trans } from "@lingui/react/macro";
 
 import { Trans as _Trans } from "@lingui/react";
 <_Trans
-  id={"tRMgLt"}
-  message={"Strip whitespace around arguments: '{name}'"}
-  values={{
-    name: name,
-  }}
+  {
+    /*i18n*/
+    ...{
+      id: "tRMgLt",
+      message: "Strip whitespace around arguments: '{name}'",
+      values: {
+        name: name,
+      },
+    }
+  }
 />;
 
 `;
@@ -367,11 +562,16 @@ import { Trans } from "@lingui/react/macro";
 
 import { Trans as _Trans } from "@lingui/react";
 <_Trans
-  id={"Ud4KOf"}
-  message={"Strip whitespace around tags, but keep <0>forced spaces</0>!"}
-  components={{
-    0: <strong />,
-  }}
+  {
+    /*i18n*/
+    ...{
+      id: "Ud4KOf",
+      message: "Strip whitespace around tags, but keep <0>forced spaces</0>!",
+      components: {
+        0: <strong />,
+      },
+    }
+  }
 />;
 
 `;
@@ -390,14 +590,18 @@ import { Trans } from "@lingui/react/macro";
 
 import { Trans as _Trans } from "@lingui/react";
 <_Trans
-  id={"3YVd0H"}
-  message={
-    "Wonderful framework <0>Next.js</0> say hi. And <1>Next.js</1> say hi."
+  {
+    /*i18n*/
+    ...{
+      id: "3YVd0H",
+      message:
+        "Wonderful framework <0>Next.js</0> say hi. And <1>Next.js</1> say hi.",
+      components: {
+        0: <a href="https://nextjs.org" />,
+        1: <a href="https://nextjs.org" />,
+      },
+    }
   }
-  components={{
-    0: <a href="https://nextjs.org" />,
-    1: <a href="https://nextjs.org" />,
-  }}
 />;
 
 `;
@@ -410,12 +614,17 @@ import { Trans } from "@lingui/react/macro";
 
 import { Trans as _Trans } from "@lingui/react";
 <_Trans
-  id={"exe3kM"}
-  message={"How much is {expression}? {count}"}
-  values={{
-    expression: expression,
-    count: count,
-  }}
+  {
+    /*i18n*/
+    ...{
+      id: "exe3kM",
+      message: "How much is {expression}? {count}",
+      values: {
+        expression: expression,
+        count: count,
+      },
+    }
+  }
 />;
 
 `;
@@ -427,7 +636,15 @@ import { Trans as Trans2 } from "@lingui/react/macro";
 ↓ ↓ ↓ ↓ ↓ ↓
 
 import { Trans as _Trans } from "@lingui/react";
-<_Trans id={"mY42CM"} message={"Hello World"} />;
+<_Trans
+  {
+    /*i18n*/
+    ...{
+      id: "mY42CM",
+      message: "Hello World",
+    }
+  }
+/>;
 
 `;
 
@@ -446,25 +663,30 @@ import { t } from "@lingui/core/macro";
 import { i18n as _i18n } from "@lingui/core";
 import { Trans as _Trans } from "@lingui/react";
 <_Trans
-  id={"QZyANg"}
-  message={"Read <0>more</0>"}
-  components={{
-    0: (
-      <a
-        href="/more"
-        title={_i18n._(
-          /*i18n*/
-          {
-            id: "qzc3IN",
-            message: "Full content of {articleName}",
-            values: {
-              articleName: articleName,
-            },
-          }
-        )}
-      />
-    ),
-  }}
+  {
+    /*i18n*/
+    ...{
+      id: "QZyANg",
+      message: "Read <0>more</0>",
+      components: {
+        0: (
+          <a
+            href="/more"
+            title={_i18n._(
+              /*i18n*/
+              {
+                id: "qzc3IN",
+                message: "Full content of {articleName}",
+                values: {
+                  articleName: articleName,
+                },
+              }
+            )}
+          />
+        ),
+      },
+    }
+  }
 />;
 
 `;
@@ -509,7 +731,15 @@ import { Trans } from "@lingui/react/macro";
 ↓ ↓ ↓ ↓ ↓ ↓
 
 import { Trans as _Trans } from "@lingui/react";
-<_Trans id={"EwTON7"} message={"&"} />;
+<_Trans
+  {
+    /*i18n*/
+    ...{
+      id: "EwTON7",
+      message: "&",
+    }
+  }
+/>;
 
 `;
 
@@ -523,12 +753,17 @@ import { Trans } from "@lingui/react/macro";
 
 import { Trans as _Trans } from "@lingui/react";
 <_Trans
-  id={"y10VRI"}
-  message={"Hi {yourName}, my name is {myName}"}
-  values={{
-    yourName: yourName,
-    myName: myName,
-  }}
+  {
+    /*i18n*/
+    ...{
+      id: "y10VRI",
+      message: "Hi {yourName}, my name is {myName}",
+      values: {
+        yourName: yourName,
+        myName: myName,
+      },
+    }
+  }
 />;
 
 `;
@@ -543,11 +778,16 @@ import { Trans } from "@lingui/react/macro";
 
 import { Trans as _Trans } from "@lingui/react";
 <_Trans
-  id={"+nhkwg"}
-  message={"{duplicate} variable {duplicate}"}
-  values={{
-    duplicate: duplicate,
-  }}
+  {
+    /*i18n*/
+    ...{
+      id: "+nhkwg",
+      message: "{duplicate} variable {duplicate}",
+      values: {
+        duplicate: duplicate,
+      },
+    }
+  }
 />;
 
 `;

--- a/packages/babel-plugin-lingui-macro/test/fixtures/jsx-keep-forced-newlines.expected.js
+++ b/packages/babel-plugin-lingui-macro/test/fixtures/jsx-keep-forced-newlines.expected.js
@@ -1,2 +1,10 @@
 import { Trans as _Trans } from "@lingui/react"
-;<_Trans id={"9xE5pD"} message={"Keep multiple\nforced\nnewlines!"} />
+;<_Trans
+  {
+    /*i18n*/
+    ...{
+      id: "9xE5pD",
+      message: "Keep multiple\nforced\nnewlines!",
+    }
+  }
+/>

--- a/packages/babel-plugin-lingui-macro/test/fixtures/jsx-plural-select-nested.expected.js
+++ b/packages/babel-plugin-lingui-macro/test/fixtures/jsx-plural-select-nested.expected.js
@@ -1,13 +1,17 @@
 import { Trans as _Trans } from "@lingui/react"
 ;<_Trans
-  id={"n0a/bN"}
-  message={
-    "{genderOfHost, select, female {{numGuests, plural, offset:1 =0 {{host} does not give a party.} =1 {{host} invites {guest} to her party.} =2 {{host} invites {guest} and one other person to her party.} other {{host} invites {guest} and # other people to her party.}}} male {{numGuests, plural, offset:1 =0 {{host} does not give a party.} =1 {{host} invites {guest} to his party.} =2 {{host} invites {guest} and one other person to his party.} other {{host} invites {guest} and # other people to his party.}}} other {{numGuests, plural, offset:1 =0 {{host} does not give a party.} =1 {{host} invites {guest} to their party.} =2 {{host} invites {guest} and one other person to their party.} other {{host} invites {guest} and # other people to their party.}}}}"
+  {
+    /*i18n*/
+    ...{
+      id: "n0a/bN",
+      message:
+        "{genderOfHost, select, female {{numGuests, plural, offset:1 =0 {{host} does not give a party.} =1 {{host} invites {guest} to her party.} =2 {{host} invites {guest} and one other person to her party.} other {{host} invites {guest} and # other people to her party.}}} male {{numGuests, plural, offset:1 =0 {{host} does not give a party.} =1 {{host} invites {guest} to his party.} =2 {{host} invites {guest} and one other person to his party.} other {{host} invites {guest} and # other people to his party.}}} other {{numGuests, plural, offset:1 =0 {{host} does not give a party.} =1 {{host} invites {guest} to their party.} =2 {{host} invites {guest} and one other person to their party.} other {{host} invites {guest} and # other people to their party.}}}}",
+      values: {
+        genderOfHost: genderOfHost,
+        numGuests: numGuests,
+        host: host,
+        guest: guest,
+      },
+    }
   }
-  values={{
-    genderOfHost: genderOfHost,
-    numGuests: numGuests,
-    host: host,
-    guest: guest,
-  }}
 />

--- a/packages/babel-plugin-lingui-macro/test/js-t.test.ts
+++ b/packages/babel-plugin-lingui-macro/test/js-t.test.ts
@@ -1,5 +1,7 @@
 import { macroTester } from "./macroTester"
 
+describe.skip("", () => {})
+
 macroTester({
   cases: [
     {

--- a/packages/babel-plugin-lingui-macro/test/jsx-trans.test.ts
+++ b/packages/babel-plugin-lingui-macro/test/jsx-trans.test.ts
@@ -1,4 +1,5 @@
 import { macroTester } from "./macroTester"
+describe.skip("", () => {})
 
 macroTester({
   cases: [


### PR DESCRIPTION
# Description

Use the same message descriptor with `/* i18n */` extraction mark in `<Trans>` component so extractor will support `TransNoContext` or [runtimeConfigModule](https://lingui.dev/ref/conf#runtimeconfigmodule) without explicit knowledge about them. 

Take the input: 
```ts
<Trans>Hello World</Trans>
```
Before
```tsx
<Trans id={"mY42CM"} message={"Hello World"} />;
```
After
```tsx
<Trans
  {
    /*i18n*/
    ...{
      id: "mY42CM",
      message: "Hello World",
    }
  }
/>
```

Where 
```ts
 /*i18n*/
    ...{
      id: "mY42CM",
      message: "Hello World",
    }
```

Is standard message descriptor used in `t` transformation. 

A side effect of this change is reduced code duplication between js and jsx macro. 

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
