### PR TITLE
feat(format-po): configure header attributes in PO file formatter

### DIFF
--- a/packages/format-po/README.md
+++ b/packages/format-po/README.md
@@ -76,6 +76,13 @@ export type PoFormatterOptions = {
    * @default false
    */
   explicitIdAsDefault?: boolean
+  
+  /**
+   * Custom attributes to append to the PO file header
+   *
+   * @default {}
+   */
+  customHeaderAttributes?: { [key: string]: string }
 }
 ```
 

--- a/packages/format-po/src/po.test.ts
+++ b/packages/format-po/src/po.test.ts
@@ -442,4 +442,23 @@ describe("pofile format", () => {
 
     `)
   })
+
+  it("should include custom header attributes", () => {
+    const format = createFormatter({ customHeaderAttributes: { 'X-Custom-Attribute': 'custom-value' }})
+    const catalog: CatalogType = {}
+    const actual = format.serialize(catalog, defaultSerializeCtx)
+
+    expect(actual).toMatchInlineSnapshot(`
+      msgid ""
+      msgstr ""
+      "POT-Creation-Date: 2018-08-27 10:00+0000\\n"
+      "MIME-Version: 1.0\\n"
+      "Content-Type: text/plain; charset=utf-8\\n"
+      "Content-Transfer-Encoding: 8bit\\n"
+      "X-Generator: @lingui/cli\\n"
+      "Language: en\\n"
+      "X-Custom-Attribute: custom-value\\n"
+
+    `)
+  })
 })

--- a/packages/format-po/src/po.test.ts
+++ b/packages/format-po/src/po.test.ts
@@ -444,7 +444,9 @@ describe("pofile format", () => {
   })
 
   it("should include custom header attributes", () => {
-    const format = createFormatter({ customHeaderAttributes: { 'X-Custom-Attribute': 'custom-value' }})
+    const format = createFormatter({
+      customHeaderAttributes: { "X-Custom-Attribute": "custom-value" },
+    })
     const catalog: CatalogType = {}
     const actual = format.serialize(catalog, defaultSerializeCtx)
 

--- a/packages/format-po/src/po.ts
+++ b/packages/format-po/src/po.ts
@@ -58,13 +58,22 @@ export type PoFormatterOptions = {
    * @default false
    */
   explicitIdAsDefault?: boolean
+  /**
+   * Custom attributes to append to the PO file header
+   *
+   * @default {}
+   */
+  customHeaderAttributes?: { [key: string]: string }
 }
 
 function isGeneratedId(id: string, message: MessageType): boolean {
   return id === generateMessageId(message.message, message.context)
 }
 
-function getCreateHeaders(language: string): PO["headers"] {
+function getCreateHeaders(
+  language: string,
+  customHeaderAttributes: PoFormatterOptions['customHeaderAttributes']
+): PO["headers"] {
   return {
     "POT-Creation-Date": formatDate(new Date(), "yyyy-MM-dd HH:mmxxxx"),
     "MIME-Version": "1.0",
@@ -72,6 +81,7 @@ function getCreateHeaders(language: string): PO["headers"] {
     "Content-Transfer-Encoding": "8bit",
     "X-Generator": "@lingui/cli",
     ...(language ? { Language: language } : {}),
+    ...(customHeaderAttributes ?? {}),
   }
 }
 
@@ -198,7 +208,7 @@ export function formatter(options: PoFormatterOptions = {}): CatalogFormatter {
         po = PO.parse(ctx.existing)
       } else {
         po = new PO()
-        po.headers = getCreateHeaders(ctx.locale)
+        po.headers = getCreateHeaders(ctx.locale, options.customHeaderAttributes)
         // accessing private property
         ;(po as any).headerOrder = Object.keys(po.headers)
       }

--- a/packages/format-po/src/po.ts
+++ b/packages/format-po/src/po.ts
@@ -72,7 +72,7 @@ function isGeneratedId(id: string, message: MessageType): boolean {
 
 function getCreateHeaders(
   language: string,
-  customHeaderAttributes: PoFormatterOptions['customHeaderAttributes']
+  customHeaderAttributes: PoFormatterOptions["customHeaderAttributes"]
 ): PO["headers"] {
   return {
     "POT-Creation-Date": formatDate(new Date(), "yyyy-MM-dd HH:mmxxxx"),
@@ -208,7 +208,10 @@ export function formatter(options: PoFormatterOptions = {}): CatalogFormatter {
         po = PO.parse(ctx.existing)
       } else {
         po = new PO()
-        po.headers = getCreateHeaders(ctx.locale, options.customHeaderAttributes)
+        po.headers = getCreateHeaders(
+          ctx.locale,
+          options.customHeaderAttributes
+        )
         // accessing private property
         ;(po as any).headerOrder = Object.keys(po.headers)
       }


### PR DESCRIPTION
# Description

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

Support adding custom header attributes to the PO message catalog via the PO formatter config

This is particularly useful for localization tools that require custom PO file headers. For instance, CrowdIn requires the addition of a custom header attribute to enable a specific PO file parsing setting (more [here](https://store.crowdin.com/gnu-gettext#translating-gnu-gettext-po))

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
