### PR TITLE
fix: exclude .scss files from extract-experimental build

### DIFF
--- a/packages/cli/src/extract-experimental/bundleSource.ts
+++ b/packages/cli/src/extract-experimental/bundleSource.ts
@@ -32,6 +32,7 @@ export async function bundleSource(
     "png",
     "css",
     "sass",
+    "scss",
     "less",
     "jpg",
   ]


### PR DESCRIPTION
# Description

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)
Prevents esbuild from erroring on `.scss` files during `lingui extract-experimental`. Although this can be solved locally with `experimental.extractor.excludeExtensions`, I figured the `.scss` extension is common enough that this PR may help someone else further on.

Below is the error I got when running the build:
```
✘ [ERROR] No loader is configured for ".scss" files: someStyle.scss

    someJSFile.js:7:19:
      7 │ import styles from './someStyle.scss';
        ╵                    ~~~~~~~~~~~~~~~~~~~~
```

When I add `.scss` to the excluded extensions, message extraction proceeds as expected.

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
