### PR TITLE
fix(message-utils): correctly handle multi-digit complex argument cases

### DIFF
--- a/packages/core/src/interpolate.test.ts
+++ b/packages/core/src/interpolate.test.ts
@@ -39,10 +39,12 @@ describe("interpolate", () => {
 
   it("should interpolate plurals", () => {
     const plural = prepare(
-      "{value, plural, one {{value} Book} other {# Books}}"
+      "{value, plural, one {{value} Book} =4 {Four books} =99 { Books with problems } other {# Books}}"
     )
     expect(plural({ value: 1 })).toEqual("1 Book")
     expect(plural({ value: 2 })).toEqual("2 Books")
+    expect(plural({ value: 4 })).toEqual("Four books")
+    expect(plural({ value: 99 })).toEqual("Books with problems")
 
     const offset = prepare(
       "{value, plural, offset:1 =0 {No Books} one {# Book} other {# Books}}"

--- a/packages/message-utils/src/compileMessage.test.ts
+++ b/packages/message-utils/src/compileMessage.test.ts
@@ -54,7 +54,7 @@ describe("compileMessage", () => {
 
   it("should compile plurals", () => {
     const tokens = compileMessage(
-      "{value, plural, offset:1 =0 {No Books} one {# Book} other {# Books}}"
+      "{value, plural, offset:1 =0 {No Books} one {# Book} other {# Books} =42 {FourtyTwo books} =99 {Books with problems}}"
     )
     expect(tokens).toMatchInlineSnapshot(`
       [
@@ -63,6 +63,8 @@ describe("compileMessage", () => {
           plural,
           {
             0: No Books,
+            42: FourtyTwo books,
+            99: Books with problems,
             offset: 1,
             one: [
               #,

--- a/packages/message-utils/src/compileMessage.ts
+++ b/packages/message-utils/src/compileMessage.ts
@@ -44,11 +44,9 @@ function processTokens(tokens: Token[], mapText?: MapTextFn): CompiledMessage {
 
     // complex argument with cases
     const formatProps: Record<string, CompiledMessage> = {}
-    token.cases.forEach((item) => {
-      formatProps[item.key.replace(/^=(.+)/, "$1")] = processTokens(
-        item.tokens,
-        mapText
-      )
+    token.cases.forEach(({ key, tokens }) => {
+      const prop = key[0] === "=" ? key.slice(1) : key
+      formatProps[prop] = processTokens(tokens, mapText)
     })
 
     return [

--- a/packages/message-utils/src/compileMessage.ts
+++ b/packages/message-utils/src/compileMessage.ts
@@ -45,7 +45,7 @@ function processTokens(tokens: Token[], mapText?: MapTextFn): CompiledMessage {
     // complex argument with cases
     const formatProps: Record<string, CompiledMessage> = {}
     token.cases.forEach((item) => {
-      formatProps[item.key.replace(/^=(.)+/, "$1")] = processTokens(
+      formatProps[item.key.replace(/^=(.+)/, "$1")] = processTokens(
         item.tokens,
         mapText
       )


### PR DESCRIPTION
# Description

Current version of lingui will not handle following pluralisation correctly: `{count, plural, one {One} other {#} =13 {thirteen}}`. This PR fixes that.

I also added some tests, but maybe some dedicated test should be made, I'm not sure what the maintainer expect here.

Did not report the issue separately, as I already had the fix.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
