### PR TITLE
fix: (lingui/core) i18n error if id is undefined

### DIFF
--- a/packages/core/src/i18n.test.ts
+++ b/packages/core/src/i18n.test.ts
@@ -290,6 +290,25 @@ describe("I18n", () => {
     expect(handler).toHaveBeenCalledTimes(2)
   })
 
+  it("._ should emit missing event for undefined id", () => {
+    const i18n = setupI18n({
+      locale: "en",
+      messages: { en: {} },
+    })
+
+    const messageID = undefined
+
+    const handler = jest.fn()
+    i18n.on("missing", handler)
+    // @ts-ignore
+    i18n._(messageID)
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(handler).toHaveBeenCalledWith({
+      id: undefined,
+      locale: "en",
+    })
+  })
+
   describe("params.missing - handling missing translations", () => {
     it("._ should return custom string for missing translations", () => {
       const i18n = setupI18n({

--- a/packages/core/src/i18n.test.ts
+++ b/packages/core/src/i18n.test.ts
@@ -296,15 +296,13 @@ describe("I18n", () => {
       messages: { en: {} },
     })
 
-    const messageID = undefined
-
     const handler = jest.fn()
     i18n.on("missing", handler)
     // @ts-expect-error 'id' should be of 'MessageDescriptor' or 'string' type.
-    i18n._(messageID)
+    i18n._()
     expect(handler).toHaveBeenCalledTimes(1)
     expect(handler).toHaveBeenCalledWith({
-      id: messageID,
+      id: "",
       locale: "en",
     })
   })

--- a/packages/core/src/i18n.test.ts
+++ b/packages/core/src/i18n.test.ts
@@ -300,11 +300,11 @@ describe("I18n", () => {
 
     const handler = jest.fn()
     i18n.on("missing", handler)
-    // @ts-ignore
+    // @ts-expect-error 'id' should be of 'MessageDescriptor' or 'string' type.
     i18n._(messageID)
     expect(handler).toHaveBeenCalledTimes(1)
     expect(handler).toHaveBeenCalledWith({
-      id: undefined,
+      id: messageID,
       locale: "en",
     })
   })

--- a/packages/core/src/i18n.ts
+++ b/packages/core/src/i18n.ts
@@ -213,7 +213,7 @@ export class I18n extends EventEmitter<Events> {
     options?: MessageOptions
   ): string {
     let message = options?.message
-    if (!isString(id)) {
+    if (id && !isString(id)) {
       values = id.values || values
       message = id.message
       id = id.id

--- a/packages/core/src/i18n.ts
+++ b/packages/core/src/i18n.ts
@@ -213,7 +213,12 @@ export class I18n extends EventEmitter<Events> {
     options?: MessageOptions
   ): string {
     let message = options?.message
-    if (id && !isString(id)) {
+
+    if (!id) {
+      id = ""
+    }
+
+    if (!isString(id)) {
       values = id.values || values
       message = id.message
       id = id.id


### PR DESCRIPTION
# Description

Lingui Core - i18n._(id) throws error if id param passed as undefined

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

 Fixes #1926 

- Added id check before checking its object values

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
