### PR TITLE
docs: update lingui.config.js to use ES modules for consistency and specify namespace

### DIFF
--- a/website/docs/tutorials/react.md
+++ b/website/docs/tutorials/react.md
@@ -175,7 +175,7 @@ We need to create the `lingui.config.js` file:
 
 ```js title="lingui.config.js"
 /** @type {import('@lingui/conf').LinguiConfig} */
-module.exports = {
+const config = {
   locales: ["cs", "en"],
   catalogs: [
     {
@@ -183,7 +183,10 @@ module.exports = {
       include: ["src"],
     },
   ],
+  compileNamespace: "es",
 };
+
+export default config;
 ```
 
 After adding the configuration file, let's run [`extract`](/docs/ref/cli.md#extract) command again:


### PR DESCRIPTION
# Description

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

When following the tutorial, I encountered an issue where the messages compiled with Lingui used the default CommonJS syntax, while the rest of my Vite React project used ES modules. To resolve my import issues, I edited `lingui.config.js` accordingly. However, I'm unsure about removing the JSDoc string.

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Examples update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
