### PR TITLE
docs: Update cli.md

### DIFF
--- a/website/docs/ref/cli.md
+++ b/website/docs/ref/cli.md
@@ -178,7 +178,7 @@ Overwrite source locale translations from source.
 
 #### `--strict` {#compile-strict}
 
-Fail if a catalog has missing translations.
+Disable defaults for missing translations.
 
 #### `--format <format>` {#compile-format}
 


### PR DESCRIPTION
Update description for `--strict` to align with CLI output.

# Description

The docs are seemingly out of date here. I've updated the ref for `lingui compile --strict` to match that of the CLI.

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Documentation fix

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
