### PR TITLE
fix: include type cast on ts compilation

### DIFF
--- a/packages/cli/src/api/__snapshots__/compile.test.ts.snap
+++ b/packages/cli/src/api/__snapshots__/compile.test.ts.snap
@@ -10,7 +10,7 @@ exports[`createCompiledCatalog options.namespace should compile with global 1`] 
 
 exports[`createCompiledCatalog options.namespace should compile with json 1`] = `{"messages":{"key":["Hello ",["name"]]}}`;
 
-exports[`createCompiledCatalog options.namespace should compile with ts 1`] = `/*eslint-disable*/import type{Messages}from"@lingui/core";export const messages:Messages=JSON.parse("{\\"key\\":[\\"Hello \\",[\\"name\\"]]}");`;
+exports[`createCompiledCatalog options.namespace should compile with ts 1`] = `/*eslint-disable*/import type{Messages}from"@lingui/core";export const messages:Messages=(JSON.parse("{\\"key\\":[\\"Hello \\",[\\"name\\"]]}")as Messages);`;
 
 exports[`createCompiledCatalog options.namespace should compile with window 1`] = `/*eslint-disable*/window.test={messages:JSON.parse("{\\"key\\":[\\"Hello \\",[\\"name\\"]]}")};`;
 

--- a/packages/cli/src/api/__snapshots__/compile.test.ts.snap
+++ b/packages/cli/src/api/__snapshots__/compile.test.ts.snap
@@ -10,7 +10,7 @@ exports[`createCompiledCatalog options.namespace should compile with global 1`] 
 
 exports[`createCompiledCatalog options.namespace should compile with json 1`] = `{"messages":{"key":["Hello ",["name"]]}}`;
 
-exports[`createCompiledCatalog options.namespace should compile with ts 1`] = `/*eslint-disable*/import type{Messages}from"@lingui/core";export const messages:Messages=(JSON.parse("{\\"key\\":[\\"Hello \\",[\\"name\\"]]}")as Messages);`;
+exports[`createCompiledCatalog options.namespace should compile with ts 1`] = `/*eslint-disable*/import type{Messages}from"@lingui/core";export const messages=(JSON.parse("{\\"key\\":[\\"Hello \\",[\\"name\\"]]}")as Messages);`;
 
 exports[`createCompiledCatalog options.namespace should compile with window 1`] = `/*eslint-disable*/window.test={messages:JSON.parse("{\\"key\\":[\\"Hello \\",[\\"name\\"]]}")};`;
 

--- a/packages/cli/src/api/compile.ts
+++ b/packages/cli/src/api/compile.ts
@@ -84,10 +84,16 @@ function buildExportStatement(
       t.tsTypeReference(t.identifier("Messages"))
     )
 
-    // export const messages:Messages = { message: "Translation" }
+    // Also type case the expression to `Messages` for better compatibility
+    const typeCastExpression = t.tsAsExpression(
+      expression,
+      t.tsTypeReference(t.identifier("Messages"))
+    )
+
+    // export const messages:Messages = ({ message: "Translation" } as Messages)
     const exportDeclaration = t.exportNamedDeclaration(
       t.variableDeclaration("const", [
-        t.variableDeclarator(messagesIdentifier, expression),
+        t.variableDeclarator(messagesIdentifier, typeCastExpression),
       ])
     )
 

--- a/packages/cli/src/api/compile.ts
+++ b/packages/cli/src/api/compile.ts
@@ -78,22 +78,16 @@ function buildExportStatement(
     )
     importMessagesTypeDeclaration.importKind = "type"
 
-    // Create the exported `messages` identifier with a `Messages` TS type annotation
-    const messagesIdentifier = t.identifier("messages")
-    messagesIdentifier.typeAnnotation = t.tsTypeAnnotation(
-      t.tsTypeReference(t.identifier("Messages"))
-    )
-
-    // Also type case the expression to `Messages` for better compatibility
-    const typeCastExpression = t.tsAsExpression(
+    // Cast the expression to `Messages`
+    const castExpression = t.tsAsExpression(
       expression,
       t.tsTypeReference(t.identifier("Messages"))
     )
 
-    // export const messages:Messages = ({ message: "Translation" } as Messages)
+    // export const messages = ({ message: "Translation" } as Messages)
     const exportDeclaration = t.exportNamedDeclaration(
       t.variableDeclaration("const", [
-        t.variableDeclarator(messagesIdentifier, typeCastExpression),
+        t.variableDeclarator(t.identifier("messages"), castExpression),
       ])
     )
 


### PR DESCRIPTION
# Description
In typescript projects which are using [ts-reset](https://github.com/total-typescript/ts-reset) and `compileNamespace: "ts"`, the compiled output is invalid because the type of `JSON.parse` is changed to `unknown` from the normal `any`, meaning that you cannot just use a type annotation and must use an explicit cast. There doesn't seem to be any simple configuration that could fix this issue, so this PR with an explicit type cast seems to be a logical answer. 

It doesn't affect anyone who is not using `ts-reset`, and expands compatibility for those who are.

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
