### PR TITLE
fix(extract): when files are used, don't overwrite obsolete

### DIFF
--- a/packages/cli/src/api/catalog/mergeCatalog.ts
+++ b/packages/cli/src/api/catalog/mergeCatalog.ts
@@ -49,7 +49,7 @@ export function mergeCatalog(
   const obsoleteMessages = obsoleteKeys.map((key) => ({
     [key]: {
       ...prevCatalog[key],
-      obsolete: !options.files,
+      ...(!options.files && { obsolete: true }),
     },
   }))
 

--- a/packages/cli/test/extract-partial-consistency/existing/en.po
+++ b/packages/cli/test/extract-partial-consistency/existing/en.po
@@ -1,0 +1,53 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2023-03-15 10:00+0000\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: en\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#. js-lingui-explicit-id
+#: fixtures/file-a.ts:11
+#~ msgid "custom.id"
+#~ msgstr "This message has custom id"
+
+#. js-lingui-explicit-id
+#: fixtures/file-a.ts:22
+#: fixtures/file-a.ts:23
+msgid "addToCart"
+msgstr "Add To Cart with change ignored"
+
+#. this is a comment
+#: fixtures/file-b.tsx:6
+msgid "Hello this is JSX Translation"
+msgstr "Hello this is JSX Translation"
+
+#: fixtures/file-b.tsx:11
+msgctxt "my context"
+msgid "Hello this is JSX Translation"
+msgstr "Hello this is JSX Translation"
+
+#: fixtures/file-a.ts:4
+msgid "Hello world"
+msgstr "Hello world"
+
+#: fixtures/file-a.ts:6
+msgctxt "custom context"
+msgid "Hello world"
+msgstr "Hello world"
+
+#: fixtures/file-a.ts:16
+msgid "Message in descriptor"
+msgstr "Message in descriptor"
+
+#. js-lingui-explicit-id
+#: fixtures/file-b.tsx:15
+msgid "jsx.custom.id"
+msgstr "This JSX element has custom id"

--- a/packages/cli/test/extract-partial-consistency/expected/en.po
+++ b/packages/cli/test/extract-partial-consistency/expected/en.po
@@ -1,0 +1,53 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2023-03-15 10:00+0000\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: en\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#. js-lingui-explicit-id
+#: fixtures/file-a.ts:11
+#~ msgid "custom.id"
+#~ msgstr "This message has custom id"
+
+#. js-lingui-explicit-id
+#: fixtures/file-a.ts:22
+#: fixtures/file-a.ts:23
+msgid "addToCart"
+msgstr "Add To Cart with change ignored"
+
+#. this is a comment
+#: fixtures/file-b.tsx:6
+msgid "Hello this is JSX Translation"
+msgstr "Hello this is JSX Translation"
+
+#: fixtures/file-b.tsx:11
+msgctxt "my context"
+msgid "Hello this is JSX Translation"
+msgstr "Hello this is JSX Translation"
+
+#: fixtures/file-a.ts:4
+msgid "Hello world"
+msgstr "Hello world"
+
+#: fixtures/file-a.ts:6
+msgctxt "custom context"
+msgid "Hello world"
+msgstr "Hello world"
+
+#: fixtures/file-a.ts:16
+msgid "Message in descriptor"
+msgstr "Message in descriptor"
+
+#. js-lingui-explicit-id
+#: fixtures/file-b.tsx:15
+msgid "jsx.custom.id"
+msgstr "This JSX element has custom id"

--- a/packages/cli/test/extract-partial-consistency/fixtures/file-a.ts
+++ b/packages/cli/test/extract-partial-consistency/fixtures/file-a.ts
@@ -1,0 +1,23 @@
+import { i18n } from "@lingui/core"
+import { defineMessage, t } from "@lingui/macro"
+
+const msg = t`Hello world`
+
+const msg2 = t({
+  message: "Hello world",
+  context: "custom context",
+})
+
+const msg3 = null /* original translation commented to mark message obsolete *//*t({
+  message: "This message has custom id",
+  id: "custom.id",
+})*/
+
+const msgDescriptor = defineMessage({
+  message: "Message in descriptor",
+})
+
+i18n._(msgDescriptor)
+
+i18n._("addToCart")
+i18n._({id: "addToCart", message: "Add To Cart with change ignored"})

--- a/packages/cli/test/extract-partial-consistency/fixtures/file-b.tsx
+++ b/packages/cli/test/extract-partial-consistency/fixtures/file-b.tsx
@@ -1,0 +1,16 @@
+import { Trans } from "@lingui/macro"
+import React from "react"
+
+export function MyComponent() {
+  return (
+    <Trans comment={"this is a comment"}>Hello this is JSX Translation</Trans>
+  )
+}
+
+export function MyComponent2() {
+  return <Trans context="my context">Hello this is JSX Translation</Trans>
+}
+
+export function MyComponent3() {
+  return <Trans id={"jsx.custom.id"}>This JSX element has custom id</Trans>
+}

--- a/packages/cli/test/index.test.ts
+++ b/packages/cli/test/index.test.ts
@@ -4,8 +4,8 @@ import extractExperimentalCommand from "../src/lingui-extract-experimental"
 import { command as compileCommand } from "../src/lingui-compile"
 import fs from "fs/promises"
 import os from "os"
-import nodepath from "path"
 import glob from "glob"
+import nodepath from "path"
 import { makeConfig } from "@lingui/conf"
 import { listingToHumanReadable, readFsToJson } from "../src/tests"
 import { getConsoleMockCalls, mockConsole } from "@lingui/jest-mocks"
@@ -180,12 +180,6 @@ describe("E2E Extractor Test", () => {
         "extractor-experimental"
       )
 
-      await fs.cp(
-        nodepath.join(rootDir, "existing"),
-        nodepath.join(rootDir, "actual"),
-        { recursive: true }
-      )
-
       await mockConsole(async (console) => {
         const config = makeConfig({
           rootDir: rootDir,
@@ -238,12 +232,6 @@ describe("E2E Extractor Test", () => {
     it("should extract and clean obsolete", async () => {
       const { rootDir, actualPath, expectedPath } = await prepare(
         "extractor-experimental-clean"
-      )
-
-      await fs.cp(
-        nodepath.join(rootDir, "existing"),
-        nodepath.join(rootDir, "actual"),
-        { recursive: true }
       )
 
       await mockConsole(async (console) => {
@@ -314,11 +302,10 @@ describe("E2E Extractor Test", () => {
         ],
       }),
       {
-        files: [nodepath.join(rootDir, "fixtures", "file-b.tsx")]
+        files: [nodepath.join(rootDir, "fixtures", "file-b.tsx")],
       }
     )
 
     compareFolders(actualPath, expectedPath)
   })
-
 })


### PR DESCRIPTION
# Description
When using `lingui extract <...files>` all translations in catalog that are not in the listed file get their obsolete flag to false, regardless if the obsolete flag was not set or already set to true.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

Fixes # (issue)
#1963

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
