### PR TITLE
feat: collect and print placeholders in Po files for better translation context

### DIFF
--- a/packages/babel-plugin-extract-messages/src/index.ts
+++ b/packages/babel-plugin-extract-messages/src/index.ts
@@ -8,7 +8,6 @@ import {
   isObjectExpression,
 } from "@babel/types"
 import type { PluginObj, PluginPass, NodePath } from "@babel/core"
-import {} from "@babel/core"
 import type { Hub } from "@babel/traverse"
 
 type BabelTypes = typeof BabelTypesNamespace

--- a/packages/babel-plugin-extract-messages/src/index.ts
+++ b/packages/babel-plugin-extract-messages/src/index.ts
@@ -5,8 +5,10 @@ import {
   Node,
   ObjectExpression,
   ObjectProperty,
+  isObjectExpression,
 } from "@babel/types"
 import type { PluginObj, PluginPass, NodePath } from "@babel/core"
+import {} from "@babel/core"
 import type { Hub } from "@babel/traverse"
 
 type BabelTypes = typeof BabelTypesNamespace
@@ -19,6 +21,7 @@ export type ExtractedMessage = {
   origin?: Origin
 
   comment?: string
+  placeholders?: Record<string, string>
 }
 
 export type ExtractPluginOpts = {
@@ -30,6 +33,7 @@ type RawMessage = {
   message?: string
   comment?: string
   context?: string
+  placeholders?: Record<string, string>
 }
 
 export type Origin = [filename: string, line: number, column?: number]
@@ -52,6 +56,7 @@ function collectMessage(
     message: props.message,
     context: props.context,
     comment: props.comment,
+    placeholders: props.placeholders || {},
     origin: [ctx.file.opts.filename, line, column],
   })
 }
@@ -109,19 +114,67 @@ function getTextFromExpression(
   }
 }
 
-function extractFromObjectExpression(
+function getNodeSource(fileContents: string, node: Node) {
+  return fileContents.slice(node.start, node.end)
+}
+
+function valuesObjectExpressionToPlaceholdersRecord(
   t: BabelTypes,
   exp: ObjectExpression,
-  hub: Hub,
-  keys: readonly string[]
+  hub: Hub
 ) {
   const props: Record<string, string> = {}
 
   ;(exp.properties as ObjectProperty[]).forEach(({ key, value }, i) => {
+    let name: string
+
+    if (t.isStringLiteral(key) || t.isNumericLiteral(key)) {
+      name = key.value.toString()
+    } else if (t.isIdentifier(key)) {
+      name = key.name
+    } else {
+      console.warn(
+        hub.buildError(
+          exp,
+          `Could not extract values to placeholders. The key #${i} has unsupported syntax`,
+          SyntaxError
+        ).message
+      )
+    }
+
+    if (name) {
+      props[name] = getNodeSource(hub.getCode(), value)
+    }
+  })
+
+  return props
+}
+
+function extractFromObjectExpression(
+  t: BabelTypes,
+  exp: ObjectExpression,
+  hub: Hub
+) {
+  const props: RawMessage = {}
+
+  const textKeys = ["id", "message", "comment", "context"] as const
+
+  ;(exp.properties as ObjectProperty[]).forEach(({ key, value }, i) => {
     const name = (key as Identifier).name
 
-    if (!keys.includes(name as any)) return
-    props[name] = getTextFromExpression(t, value as Expression, hub)
+    if (name === "values" && isObjectExpression(value)) {
+      props.placeholders = valuesObjectExpressionToPlaceholdersRecord(
+        t,
+        value,
+        hub
+      )
+    } else if (textKeys.includes(name as any)) {
+      props[name as (typeof textKeys)[number]] = getTextFromExpression(
+        t,
+        value as Expression,
+        hub
+      )
+    }
   })
 
   return props
@@ -167,12 +220,7 @@ export default function ({ types: t }: { types: BabelTypes }): PluginObj {
     path: NodePath<ObjectExpression>,
     ctx: PluginPass
   ) => {
-    const props = extractFromObjectExpression(t, path.node, ctx.file.hub, [
-      "id",
-      "message",
-      "comment",
-      "context",
-    ])
+    const props = extractFromObjectExpression(t, path.node, ctx.file.hub)
 
     if (!props.id) {
       console.warn(
@@ -200,7 +248,7 @@ export default function ({ types: t }: { types: BabelTypes }): PluginObj {
           return
         }
 
-        const props = attrs.reduce<Record<string, unknown>>((acc, item) => {
+        const props = attrs.reduce<RawMessage>((acc, item) => {
           if (t.isJSXSpreadAttribute(item)) {
             return acc
           }
@@ -221,6 +269,19 @@ export default function ({ types: t }: { types: BabelTypes }): PluginObj {
               acc[key] = item.value.expression.value
             }
           }
+
+          if (
+            key === "values" &&
+            t.isJSXExpressionContainer(item.value) &&
+            isObjectExpression(item.value.expression)
+          ) {
+            acc.placeholders = valuesObjectExpressionToPlaceholdersRecord(
+              t,
+              item.value.expression,
+              ctx.file.hub
+            )
+          }
+
           return acc
         }, {})
 
@@ -266,7 +327,7 @@ export default function ({ types: t }: { types: BabelTypes }): PluginObj {
           return
         } else {
           // i18n._(id, variables, descriptor)
-          let props = {
+          let props: RawMessage = {
             id: getTextFromExpression(
               t,
               firstArgument.node as Expression,
@@ -279,16 +340,21 @@ export default function ({ types: t }: { types: BabelTypes }): PluginObj {
             return
           }
 
+          const secondArgument = path.node.arguments[1]
+          if (secondArgument && t.isObjectExpression(secondArgument)) {
+            props.placeholders = valuesObjectExpressionToPlaceholdersRecord(
+              t,
+              secondArgument,
+              ctx.file.hub
+            )
+          }
+
           const msgDescArg = path.node.arguments[2]
 
           if (t.isObjectExpression(msgDescArg)) {
             props = {
               ...props,
-              ...extractFromObjectExpression(t, msgDescArg, ctx.file.hub, [
-                "message",
-                "comment",
-                "context",
-              ]),
+              ...extractFromObjectExpression(t, msgDescArg, ctx.file.hub),
             }
           }
 

--- a/packages/babel-plugin-extract-messages/test/__snapshots__/index.ts.snap
+++ b/packages/babel-plugin-extract-messages/test/__snapshots__/index.ts.snap
@@ -133,7 +133,7 @@ exports[`@lingui/babel-plugin-extract-messages MessageDescriptor should extract 
   {
     comment: undefined,
     context: undefined,
-    id: Values {param} {0} {name},
+    id: Values {param} {0} {name} {value},
     message: undefined,
     origin: [
       js-message-descriptor.js,
@@ -143,6 +143,9 @@ exports[`@lingui/babel-plugin-extract-messages MessageDescriptor should extract 
       0: user.getName(),
       name: "foo",
       param: param,
+      value: user
+      ? user.name
+      : null,
     },
   },
   {
@@ -152,7 +155,7 @@ exports[`@lingui/babel-plugin-extract-messages MessageDescriptor should extract 
     message: undefined,
     origin: [
       js-message-descriptor.js,
-      15,
+      23,
     ],
     placeholders: {},
   },
@@ -163,7 +166,7 @@ exports[`@lingui/babel-plugin-extract-messages MessageDescriptor should extract 
     message: undefined,
     origin: [
       js-message-descriptor.js,
-      17,
+      25,
     ],
     placeholders: {},
   },

--- a/packages/babel-plugin-extract-messages/test/__snapshots__/index.ts.snap
+++ b/packages/babel-plugin-extract-messages/test/__snapshots__/index.ts.snap
@@ -11,6 +11,7 @@ exports[`@lingui/babel-plugin-extract-messages CallExpression i18n._() should ex
       js-call-expression.js,
       1,
     ],
+    placeholders: {},
   },
   {
     comment: description,
@@ -21,6 +22,7 @@ exports[`@lingui/babel-plugin-extract-messages CallExpression i18n._() should ex
       js-call-expression.js,
       3,
     ],
+    placeholders: {},
   },
   {
     comment: undefined,
@@ -31,6 +33,7 @@ exports[`@lingui/babel-plugin-extract-messages CallExpression i18n._() should ex
       js-call-expression.js,
       5,
     ],
+    placeholders: {},
   },
   {
     comment: undefined,
@@ -41,6 +44,9 @@ exports[`@lingui/babel-plugin-extract-messages CallExpression i18n._() should ex
       js-call-expression.js,
       7,
     ],
+    placeholders: {
+      param: param,
+    },
   },
   {
     comment: undefined,
@@ -51,6 +57,7 @@ exports[`@lingui/babel-plugin-extract-messages CallExpression i18n._() should ex
       js-call-expression.js,
       9,
     ],
+    placeholders: {},
   },
   {
     comment: My comment,
@@ -61,6 +68,7 @@ exports[`@lingui/babel-plugin-extract-messages CallExpression i18n._() should ex
       js-call-expression.js,
       12,
     ],
+    placeholders: {},
   },
   {
     comment: undefined,
@@ -71,6 +79,7 @@ exports[`@lingui/babel-plugin-extract-messages CallExpression i18n._() should ex
       js-call-expression.js,
       19,
     ],
+    placeholders: {},
   },
   {
     comment: My comment,
@@ -81,6 +90,7 @@ exports[`@lingui/babel-plugin-extract-messages CallExpression i18n._() should ex
       js-call-expression.js,
       22,
     ],
+    placeholders: {},
   },
 ]
 `;
@@ -96,6 +106,7 @@ exports[`@lingui/babel-plugin-extract-messages MessageDescriptor should extract 
       js-message-descriptor.js,
       1,
     ],
+    placeholders: {},
   },
   {
     comment: description,
@@ -106,6 +117,7 @@ exports[`@lingui/babel-plugin-extract-messages MessageDescriptor should extract 
       js-message-descriptor.js,
       3,
     ],
+    placeholders: {},
   },
   {
     comment: undefined,
@@ -116,16 +128,33 @@ exports[`@lingui/babel-plugin-extract-messages MessageDescriptor should extract 
       js-message-descriptor.js,
       5,
     ],
+    placeholders: {},
   },
   {
     comment: undefined,
     context: undefined,
-    id: Values {param},
+    id: Values {param} {0} {name},
     message: undefined,
     origin: [
       js-message-descriptor.js,
       7,
     ],
+    placeholders: {
+      0: user.getName(),
+      name: "foo",
+      param: param,
+    },
+  },
+  {
+    comment: undefined,
+    context: undefined,
+    id: Values {param} {0},
+    message: undefined,
+    origin: [
+      js-message-descriptor.js,
+      15,
+    ],
+    placeholders: {},
   },
   {
     comment: undefined,
@@ -134,8 +163,9 @@ exports[`@lingui/babel-plugin-extract-messages MessageDescriptor should extract 
     message: undefined,
     origin: [
       js-message-descriptor.js,
-      9,
+      17,
     ],
+    placeholders: {},
   },
 ]
 `;
@@ -151,6 +181,9 @@ exports[`@lingui/babel-plugin-extract-messages should extract Plural messages fr
       jsx-without-trans.js,
       2,
     ],
+    placeholders: {
+      count: count,
+    },
   },
   {
     comment: undefined,
@@ -161,6 +194,9 @@ exports[`@lingui/babel-plugin-extract-messages should extract Plural messages fr
       jsx-without-trans.js,
       3,
     ],
+    placeholders: {
+      count: count,
+    },
   },
 ]
 `;
@@ -176,6 +212,7 @@ exports[`@lingui/babel-plugin-extract-messages should extract all messages from 
       js-with-macros.js,
       4,
     ],
+    placeholders: {},
   },
   {
     comment: undefined,
@@ -186,6 +223,7 @@ exports[`@lingui/babel-plugin-extract-messages should extract all messages from 
       js-with-macros.js,
       6,
     ],
+    placeholders: {},
   },
   {
     comment: description,
@@ -196,6 +234,7 @@ exports[`@lingui/babel-plugin-extract-messages should extract all messages from 
       js-with-macros.js,
       8,
     ],
+    placeholders: {},
   },
   {
     comment: undefined,
@@ -206,6 +245,7 @@ exports[`@lingui/babel-plugin-extract-messages should extract all messages from 
       js-with-macros.js,
       13,
     ],
+    placeholders: {},
   },
   {
     comment: undefined,
@@ -216,6 +256,9 @@ exports[`@lingui/babel-plugin-extract-messages should extract all messages from 
       js-with-macros.js,
       18,
     ],
+    placeholders: {
+      param: param,
+    },
   },
   {
     comment: undefined,
@@ -226,6 +269,7 @@ exports[`@lingui/babel-plugin-extract-messages should extract all messages from 
       js-with-macros.js,
       20,
     ],
+    placeholders: {},
   },
   {
     comment: undefined,
@@ -236,6 +280,7 @@ exports[`@lingui/babel-plugin-extract-messages should extract all messages from 
       js-with-macros.js,
       25,
     ],
+    placeholders: {},
   },
   {
     comment: undefined,
@@ -246,6 +291,7 @@ exports[`@lingui/babel-plugin-extract-messages should extract all messages from 
       js-with-macros.js,
       29,
     ],
+    placeholders: {},
   },
   {
     comment: undefined,
@@ -256,6 +302,7 @@ exports[`@lingui/babel-plugin-extract-messages should extract all messages from 
       js-with-macros.js,
       34,
     ],
+    placeholders: {},
   },
   {
     comment: undefined,
@@ -266,6 +313,7 @@ exports[`@lingui/babel-plugin-extract-messages should extract all messages from 
       js-with-macros.js,
       39,
     ],
+    placeholders: {},
   },
   {
     comment: undefined,
@@ -276,6 +324,7 @@ exports[`@lingui/babel-plugin-extract-messages should extract all messages from 
       js-with-macros.js,
       44,
     ],
+    placeholders: {},
   },
   {
     comment: undefined,
@@ -286,6 +335,7 @@ exports[`@lingui/babel-plugin-extract-messages should extract all messages from 
       js-with-macros.js,
       49,
     ],
+    placeholders: {},
   },
   {
     comment: undefined,
@@ -296,6 +346,7 @@ exports[`@lingui/babel-plugin-extract-messages should extract all messages from 
       js-with-macros.js,
       54,
     ],
+    placeholders: {},
   },
   {
     comment: undefined,
@@ -306,6 +357,9 @@ exports[`@lingui/babel-plugin-extract-messages should extract all messages from 
       js-with-macros.js,
       57,
     ],
+    placeholders: {
+      0: users.length,
+    },
   },
 ]
 `;
@@ -321,6 +375,9 @@ exports[`@lingui/babel-plugin-extract-messages should extract all messages from 
       jsx-with-macros.js,
       3,
     ],
+    placeholders: {
+      name: name,
+    },
   },
   {
     comment: undefined,
@@ -331,6 +388,7 @@ exports[`@lingui/babel-plugin-extract-messages should extract all messages from 
       jsx-with-macros.js,
       4,
     ],
+    placeholders: {},
   },
   {
     comment: undefined,
@@ -341,6 +399,7 @@ exports[`@lingui/babel-plugin-extract-messages should extract all messages from 
       jsx-with-macros.js,
       5,
     ],
+    placeholders: {},
   },
   {
     comment: undefined,
@@ -351,6 +410,7 @@ exports[`@lingui/babel-plugin-extract-messages should extract all messages from 
       jsx-with-macros.js,
       6,
     ],
+    placeholders: {},
   },
   {
     comment: undefined,
@@ -361,6 +421,7 @@ exports[`@lingui/babel-plugin-extract-messages should extract all messages from 
       jsx-with-macros.js,
       7,
     ],
+    placeholders: {},
   },
   {
     comment: undefined,
@@ -371,6 +432,9 @@ exports[`@lingui/babel-plugin-extract-messages should extract all messages from 
       jsx-with-macros.js,
       9,
     ],
+    placeholders: {
+      count: count,
+    },
   },
 ]
 `;
@@ -386,6 +450,7 @@ exports[`@lingui/babel-plugin-extract-messages should extract all messages from 
       jsx-without-macros.js,
       5,
     ],
+    placeholders: {},
   },
   {
     comment: undefined,
@@ -396,6 +461,7 @@ exports[`@lingui/babel-plugin-extract-messages should extract all messages from 
       jsx-without-macros.js,
       6,
     ],
+    placeholders: {},
   },
   {
     comment: undefined,
@@ -406,6 +472,7 @@ exports[`@lingui/babel-plugin-extract-messages should extract all messages from 
       jsx-without-macros.js,
       7,
     ],
+    placeholders: {},
   },
   {
     comment: undefined,
@@ -416,6 +483,7 @@ exports[`@lingui/babel-plugin-extract-messages should extract all messages from 
       jsx-without-macros.js,
       8,
     ],
+    placeholders: {},
   },
   {
     comment: undefined,
@@ -426,6 +494,7 @@ exports[`@lingui/babel-plugin-extract-messages should extract all messages from 
       jsx-without-macros.js,
       9,
     ],
+    placeholders: {},
   },
   {
     comment: undefined,
@@ -436,6 +505,7 @@ exports[`@lingui/babel-plugin-extract-messages should extract all messages from 
       jsx-without-macros.js,
       10,
     ],
+    placeholders: {},
   },
   {
     comment: undefined,
@@ -446,6 +516,9 @@ exports[`@lingui/babel-plugin-extract-messages should extract all messages from 
       jsx-without-macros.js,
       11,
     ],
+    placeholders: {
+      count: count,
+    },
   },
 ]
 `;

--- a/packages/babel-plugin-extract-messages/test/fixtures/js-message-descriptor.js
+++ b/packages/babel-plugin-extract-messages/test/fixtures/js-message-descriptor.js
@@ -5,8 +5,16 @@ const withDescription = /*i18n*/ { id: "Description", comment: "description" }
 const withId = /*i18n*/ { id: "ID", message: "Message with id" }
 
 const withValues = /*i18n*/ {
-  id: "Values {param} {0} {name}",
-  values: { param: param, 0: user.getName(), ["name"]: "foo" },
+  id: "Values {param} {0} {name} {value}",
+  values: {
+    param: param,
+    0: user.getName(),
+    ["name"]: "foo",
+    // prettier-ignore
+    value: user
+      ? user.name
+      : null,
+  },
 }
 /**
  * With values passed as variable

--- a/packages/babel-plugin-extract-messages/test/fixtures/js-message-descriptor.js
+++ b/packages/babel-plugin-extract-messages/test/fixtures/js-message-descriptor.js
@@ -1,9 +1,17 @@
-const msg = /*i18n*/{id: 'Message'}
+const msg = /*i18n*/ { id: "Message" }
 
-const withDescription = /*i18n*/{id: 'Description', comment: "description"}
+const withDescription = /*i18n*/ { id: "Description", comment: "description" }
 
-const withId = /*i18n*/{id: 'ID', message: 'Message with id'}
+const withId = /*i18n*/ { id: "ID", message: "Message with id" }
 
-const withValues = /*i18n*/{id: 'Values {param}', values: { param: param }}
+const withValues = /*i18n*/ {
+  id: "Values {param} {0} {name}",
+  values: { param: param, 0: user.getName(), ["name"]: "foo" },
+}
+/**
+ * With values passed as variable
+ */
+const values = {}
+const withValues2 = /*i18n*/ { id: "Values {param} {0}", values }
 
-const withContext = /*i18n*/{id: 'Some id', context: 'Context1'}
+const withContext = /*i18n*/ { id: "Some id", context: "Context1" }

--- a/packages/cli/src/api/__snapshots__/catalog.test.ts.snap
+++ b/packages/cli/src/api/__snapshots__/catalog.test.ts.snap
@@ -19,6 +19,7 @@ exports[`Catalog collect should extract messages from source files 1`] = `
         1,
       ],
     ],
+    placeholders: {},
   },
   Component B: {
     comments: [],
@@ -30,6 +31,7 @@ exports[`Catalog collect should extract messages from source files 1`] = `
         1,
       ],
     ],
+    placeholders: {},
   },
   Hello World: {
     comments: [
@@ -53,6 +55,7 @@ exports[`Catalog collect should extract messages from source files 1`] = `
         1,
       ],
     ],
+    placeholders: {},
   },
   custom.id: {
     comments: [],
@@ -64,6 +67,7 @@ exports[`Catalog collect should extract messages from source files 1`] = `
         4,
       ],
     ],
+    placeholders: {},
   },
 }
 `;
@@ -80,6 +84,7 @@ exports[`Catalog collect should extract only files passed on options 1`] = `
         1,
       ],
     ],
+    placeholders: {},
   },
   Hello World: {
     comments: [
@@ -103,6 +108,7 @@ exports[`Catalog collect should extract only files passed on options 1`] = `
         1,
       ],
     ],
+    placeholders: {},
   },
   custom.id: {
     comments: [],
@@ -114,6 +120,7 @@ exports[`Catalog collect should extract only files passed on options 1`] = `
         4,
       ],
     ],
+    placeholders: {},
   },
 }
 `;
@@ -132,6 +139,7 @@ exports[`Catalog collect should support JSX and Typescript 1`] = `
         12,
       ],
     ],
+    placeholders: {},
   },
   MHrjPM: {
     comments: [],
@@ -143,6 +151,7 @@ exports[`Catalog collect should support JSX and Typescript 1`] = `
         20,
       ],
     ],
+    placeholders: {},
   },
   Nu4oKW: {
     comments: [
@@ -156,6 +165,7 @@ exports[`Catalog collect should support JSX and Typescript 1`] = `
         7,
       ],
     ],
+    placeholders: {},
   },
   YikuIL: {
     comments: [],
@@ -167,6 +177,7 @@ exports[`Catalog collect should support JSX and Typescript 1`] = `
         19,
       ],
     ],
+    placeholders: {},
   },
   d1Kdl3: {
     comments: [],
@@ -178,6 +189,11 @@ exports[`Catalog collect should support JSX and Typescript 1`] = `
         18,
       ],
     ],
+    placeholders: {
+      name: [
+        name,
+      ],
+    },
   },
   esnaQO: {
     comments: [],
@@ -189,6 +205,11 @@ exports[`Catalog collect should support JSX and Typescript 1`] = `
         22,
       ],
     ],
+    placeholders: {
+      count: [
+        count,
+      ],
+    },
   },
   xDAtGP: {
     comments: [],
@@ -200,6 +221,7 @@ exports[`Catalog collect should support JSX and Typescript 1`] = `
         5,
       ],
     ],
+    placeholders: {},
   },
 }
 `;

--- a/packages/cli/src/api/catalog.test.ts
+++ b/packages/cli/src/api/catalog.test.ts
@@ -214,6 +214,7 @@ describe("Catalog", () => {
                 15,
               ],
             ],
+            placeholders: {},
           },
         }
       `)

--- a/packages/cli/src/api/catalog/extractFromFiles.ts
+++ b/packages/cli/src/api/catalog/extractFromFiles.ts
@@ -9,6 +9,25 @@ import chalk from "chalk"
 import { prettyOrigin } from "../utils"
 import { MessageOrigin, ExtractedCatalogType } from "../types"
 
+function mergePlaceholders(
+  prev: Record<string, string[]>,
+  next: Record<string, string>
+) {
+  const res = { ...prev }
+
+  Object.entries(next).forEach(([key, value]) => {
+    if (!res[key]) {
+      res[key] = []
+    }
+
+    if (!res[key].includes(value)) {
+      res[key].push(value)
+    }
+  })
+
+  return res
+}
+
 export async function extractFromFiles(
   paths: string[],
   config: LinguiConfigNormalized
@@ -24,6 +43,7 @@ export async function extractFromFiles(
           messages[next.id] = {
             message: next.message,
             context: next.context,
+            placeholders: {},
             comments: [],
             origin: [],
           }
@@ -54,6 +74,7 @@ export async function extractFromFiles(
             ? [...prev.comments, next.comment]
             : prev.comments,
           origin: [...prev.origin, [filename, next.origin[1]]],
+          placeholders: mergePlaceholders(prev.placeholders, next.placeholders),
         }
       },
       config,

--- a/packages/cli/test/extract-po-format/expected/en.po
+++ b/packages/cli/test/extract-po-format/expected/en.po
@@ -7,6 +7,21 @@ msgstr ""
 "X-Generator: @lingui/cli\n"
 "Language: en\n"
 
+#. placeholder {0}: user.name
+#. placeholder {0}: author.name
+#. placeholder {0}: moderator.name
+#: fixtures/placeholders.ts:3
+#: fixtures/placeholders.ts:4
+#: fixtures/placeholders.ts:5
+msgid "Hello {0}"
+msgstr "Hello {0}"
+
+#. placeholder {0}: user.name
+#. placeholder {1}: user ? user.name : null
+#: fixtures/placeholders.ts:7
+msgid "Hello {userName} {0} {1}"
+msgstr "Hello {userName} {0} {1}"
+
 #. this is a comment
 #: fixtures/file-b.tsx:6
 msgid "Hello this is JSX Translation"

--- a/packages/cli/test/extract-po-format/expected/pl.po
+++ b/packages/cli/test/extract-po-format/expected/pl.po
@@ -7,6 +7,21 @@ msgstr ""
 "X-Generator: @lingui/cli\n"
 "Language: pl\n"
 
+#. placeholder {0}: user.name
+#. placeholder {0}: author.name
+#. placeholder {0}: moderator.name
+#: fixtures/placeholders.ts:3
+#: fixtures/placeholders.ts:4
+#: fixtures/placeholders.ts:5
+msgid "Hello {0}"
+msgstr ""
+
+#. placeholder {0}: user.name
+#. placeholder {1}: user ? user.name : null
+#: fixtures/placeholders.ts:7
+msgid "Hello {userName} {0} {1}"
+msgstr ""
+
 #. this is a comment
 #: fixtures/file-b.tsx:6
 msgid "Hello this is JSX Translation"

--- a/packages/cli/test/extract-po-format/fixtures/placeholders.ts
+++ b/packages/cli/test/extract-po-format/fixtures/placeholders.ts
@@ -1,0 +1,12 @@
+import { t } from "@lingui/core/macro"
+
+t`Hello ${user.name}`
+t`Hello ${author.name}`
+t`Hello ${moderator.name}`
+
+t`Hello ${userName} ${user.name} ${
+  // prettier-ignore
+  user
+    ? user.name
+    : null
+}`

--- a/packages/cli/test/index.test.ts
+++ b/packages/cli/test/index.test.ts
@@ -69,8 +69,8 @@ describe("E2E Extractor Test", () => {
         ┌─────────────┬─────────────┬─────────┐
         │ Language    │ Total count │ Missing │
         ├─────────────┼─────────────┼─────────┤
-        │ en (source) │      7      │    -    │
-        │ pl          │      7      │    7    │
+        │ en (source) │      9      │    -    │
+        │ pl          │      9      │    9    │
         └─────────────┴─────────────┴─────────┘
 
         (use "yarn extract" to update catalogs with new messages)

--- a/packages/conf/src/types.ts
+++ b/packages/conf/src/types.ts
@@ -36,6 +36,7 @@ export type ExtractedMessageType<Extra = CatalogExtra> = {
    * formatters can store additional data
    */
   extra?: Extra
+  placeholders?: Record<string, string>
 }
 export type MessageType<Extra = CatalogExtra> = ExtractedMessageType<Extra> & {
   translation: string

--- a/packages/conf/src/types.ts
+++ b/packages/conf/src/types.ts
@@ -36,7 +36,7 @@ export type ExtractedMessageType<Extra = CatalogExtra> = {
    * formatters can store additional data
    */
   extra?: Extra
-  placeholders?: Record<string, string>
+  placeholders?: Record<string, string[]>
 }
 export type MessageType<Extra = CatalogExtra> = ExtractedMessageType<Extra> & {
   translation: string
@@ -88,6 +88,7 @@ export type ExtractedMessage = {
   origin?: [filename: string, line: number, column?: number]
 
   comment?: string
+  placeholders?: Record<string, string>
 }
 
 export type CatalogFormatOptions = {

--- a/packages/extractor-vue/src/__snapshots__/extractor.test.ts.snap
+++ b/packages/extractor-vue/src/__snapshots__/extractor.test.ts.snap
@@ -12,6 +12,7 @@ exports[`vue extractor should extract message from functional component 1`] = `
       10,
       33,
     ],
+    placeholders: {},
   },
 ]
 `;
@@ -28,6 +29,7 @@ exports[`vue extractor should extract message from vue file 1`] = `
       4,
       0,
     ],
+    placeholders: {},
   },
   {
     comment: undefined,
@@ -39,6 +41,7 @@ exports[`vue extractor should extract message from vue file 1`] = `
       19,
       20,
     ],
+    placeholders: {},
   },
   {
     comment: undefined,
@@ -50,6 +53,7 @@ exports[`vue extractor should extract message from vue file 1`] = `
       27,
       11,
     ],
+    placeholders: {},
   },
   {
     comment: Message comment,
@@ -61,6 +65,7 @@ exports[`vue extractor should extract message from vue file 1`] = `
       29,
       10,
     ],
+    placeholders: {},
   },
   {
     comment: undefined,
@@ -72,6 +77,7 @@ exports[`vue extractor should extract message from vue file 1`] = `
       35,
       5,
     ],
+    placeholders: {},
   },
   {
     comment: undefined,
@@ -83,6 +89,7 @@ exports[`vue extractor should extract message from vue file 1`] = `
       36,
       11,
     ],
+    placeholders: {},
   },
 ]
 `;

--- a/packages/format-po/README.md
+++ b/packages/format-po/README.md
@@ -39,7 +39,7 @@ export default {
 
 Possible options:
 
-```ts
+````ts
 export type PoFormatterOptions = {
   /**
    * Print places where message is used
@@ -54,14 +54,14 @@ export type PoFormatterOptions = {
    * @default true
    */
   lineNumbers?: boolean
-  
+
   /**
    * Print `js-lingui-id: Xs4as` statement in extracted comments section
    *
    * @default false
    */
   printLinguiId?: boolean
-  
+
   /**
    * By default, the po-formatter treats the pair `msgid` + `msgctx` as the source
    * for generating an ID by hashing its value.
@@ -76,8 +76,32 @@ export type PoFormatterOptions = {
    * @default false
    */
   explicitIdAsDefault?: boolean
+
+  /**
+   * Print values for unnamed placeholders as comments for each message.
+   *
+   * This can give more context to translators for better translations.
+   *
+   * By default first 3 placeholders are shown.
+   *
+   * Example:
+   *
+   * ```js
+   * t`Hello ${user.name} ${value}`
+   * ```
+   *
+   * This will be extracted as
+   *
+   * ```po
+   * #. placeholder {0}: user.name
+   * msgid "Hello {0} {value}"
+   * ```
+   *
+   * @default true
+   */
+  printPlaceholdersInComments?: boolean | { limit?: number }
 }
-```
+````
 
 ## License
 

--- a/packages/format-po/src/__snapshots__/po.test.ts.snap
+++ b/packages/format-po/src/__snapshots__/po.test.ts.snap
@@ -1,5 +1,75 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`pofile format printPlaceholdersInComments Should not print placeholders if printPlaceholdersInComments = false 1`] = `
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2018-08-27 10:00+0000\\n"
+"MIME-Version: 1.0\\n"
+"Content-Type: text/plain; charset=utf-8\\n"
+"Content-Transfer-Encoding: 8bit\\n"
+"X-Generator: @lingui/cli\\n"
+"Language: en\\n"
+
+#. js-lingui-explicit-id
+msgid "static"
+msgstr "Static message {0} {name}"
+
+`;
+
+exports[`pofile format printPlaceholdersInComments Should print printPlaceholdersInComments.limit amount of values for placeholder 1`] = `
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2018-08-27 10:00+0000\\n"
+"MIME-Version: 1.0\\n"
+"Content-Type: text/plain; charset=utf-8\\n"
+"Content-Transfer-Encoding: 8bit\\n"
+"X-Generator: @lingui/cli\\n"
+"Language: en\\n"
+
+#. js-lingui-explicit-id
+#. placeholder {0}: userName
+#. placeholder {1}: a
+msgid "static"
+msgstr "Static message {0} {1}"
+
+`;
+
+exports[`pofile format printPlaceholdersInComments should print unnamed placeholders as comments 1`] = `
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2018-08-27 10:00+0000\\n"
+"MIME-Version: 1.0\\n"
+"Content-Type: text/plain; charset=utf-8\\n"
+"Content-Transfer-Encoding: 8bit\\n"
+"X-Generator: @lingui/cli\\n"
+"Language: en\\n"
+
+#. js-lingui-explicit-id
+#. placeholder {0}: getValue()
+msgid "static"
+msgstr "Static message {0} {name}"
+
+#. placeholder: {0} = getValue()
+#. js-lingui-explicit-id
+#. placeholder {0}: getValue()
+msgid "static2"
+msgstr "Static message {0} {name}"
+
+#. js-lingui-explicit-id
+#. placeholder {0}: user ? user.name : null
+#. placeholder {0}: userName
+msgid "static3"
+msgstr "Static message {0}"
+
+#. js-lingui-explicit-id
+#. placeholder {0}: userName
+#. placeholder {0}: user.name
+#. placeholder {0}: profile.name
+msgid "static4"
+msgstr "Static message {0}"
+
+`;
+
 exports[`pofile format should correct badly used comments 1`] = `
 {
   withDescriptionAndComments: {
@@ -69,35 +139,6 @@ msgstr ""
 msgctxt "my context"
 msgid "with generated id"
 msgstr ""
-
-`;
-
-exports[`pofile format should print unnamed placeholders as comments 1`] = `
-msgid ""
-msgstr ""
-"POT-Creation-Date: 2018-08-27 10:00+0000\\n"
-"MIME-Version: 1.0\\n"
-"Content-Type: text/plain; charset=utf-8\\n"
-"Content-Transfer-Encoding: 8bit\\n"
-"X-Generator: @lingui/cli\\n"
-"Language: en\\n"
-
-#. js-lingui-explicit-id
-#. placeholder {0}: getValue()
-msgid "static"
-msgstr "Static message {0} {name}"
-
-#. placeholder: {0} = getValue()
-#. js-lingui-explicit-id
-#. placeholder {0}: getValue()
-msgid "static2"
-msgstr "Static message {0} {name}"
-
-#. js-lingui-explicit-id
-#. placeholder {0}: user ? user.name : null
-#. placeholder {0}: userName
-msgid "static3"
-msgstr "Static message {0}"
 
 `;
 

--- a/packages/format-po/src/__snapshots__/po.test.ts.snap
+++ b/packages/format-po/src/__snapshots__/po.test.ts.snap
@@ -72,6 +72,28 @@ msgstr ""
 
 `;
 
+exports[`pofile format should print unnamed placeholders as comments 1`] = `
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2018-08-27 10:00+0000\\n"
+"MIME-Version: 1.0\\n"
+"Content-Type: text/plain; charset=utf-8\\n"
+"Content-Transfer-Encoding: 8bit\\n"
+"X-Generator: @lingui/cli\\n"
+"Language: en\\n"
+
+#. js-lingui-explicit-id
+#. ph: {0} = getValue()
+msgid "static"
+msgstr "Static message {0} {name}"
+
+#. js-lingui-explicit-id
+#. ph: {0} = getValue()
+msgid "static2"
+msgstr "Static message {0} {name}"
+
+`;
+
 exports[`pofile format should read catalog in pofile format 1`] = `
 {
   obsolete: {

--- a/packages/format-po/src/__snapshots__/po.test.ts.snap
+++ b/packages/format-po/src/__snapshots__/po.test.ts.snap
@@ -83,14 +83,21 @@ msgstr ""
 "Language: en\\n"
 
 #. js-lingui-explicit-id
-#. ph: {0} = getValue()
+#. placeholder {0}: getValue()
 msgid "static"
 msgstr "Static message {0} {name}"
 
+#. placeholder: {0} = getValue()
 #. js-lingui-explicit-id
-#. ph: {0} = getValue()
+#. placeholder {0}: getValue()
 msgid "static2"
 msgstr "Static message {0} {name}"
+
+#. js-lingui-explicit-id
+#. placeholder {0}: user ? user.name : null
+#. placeholder {0}: userName
+msgid "static3"
+msgstr "Static message {0}"
 
 `;
 

--- a/packages/format-po/src/__snapshots__/utils.test.ts.snap
+++ b/packages/format-po/src/__snapshots__/utils.test.ts.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`normalizePlaceholderValue Should normalize whitespaces 1`] = `user ? user.name : null`;
+
+exports[`normalizePlaceholderValue Should normalize whitespaces 2`] = `userName`;

--- a/packages/format-po/src/po.test.ts
+++ b/packages/format-po/src/po.test.ts
@@ -443,39 +443,90 @@ describe("pofile format", () => {
     `)
   })
 
-  it("should print unnamed placeholders as comments", () => {
-    const format = createFormatter({ printPlaceholdersInComments: true })
+  describe("printPlaceholdersInComments", () => {
+    it("should print unnamed placeholders as comments", () => {
+      const format = createFormatter()
 
-    const catalog: CatalogType = {
-      static: {
-        message: "Static message {0} {name}",
-        translation: "Static message {0} {name}",
-        placeholders: {
-          0: ["getValue()"],
-          name: ["user.getName()"],
+      const catalog: CatalogType = {
+        static: {
+          message: "Static message {0} {name}",
+          translation: "Static message {0} {name}",
+          placeholders: {
+            0: ["getValue()"],
+            name: ["user.getName()"],
+          },
         },
-      },
-      // should not push placeholder comment twice
-      static2: {
-        message: "Static message {0} {name}",
-        translation: "Static message {0} {name}",
-        comments: ["placeholder: {0} = getValue()"],
-        placeholders: {
-          0: ["getValue()"],
-          name: ["user.getName()"],
+        // should not push placeholder comment twice
+        static2: {
+          message: "Static message {0} {name}",
+          translation: "Static message {0} {name}",
+          comments: ["placeholder: {0} = getValue()"],
+          placeholders: {
+            0: ["getValue()"],
+            name: ["user.getName()"],
+          },
         },
-      },
-      // multiline placeholder value + multiple entries
-      static3: {
-        message: "Static message {0}",
-        translation: "Static message {0}",
-        placeholders: {
-          0: ["user \n ? user.name \n : null", "userName"],
+        // multiline placeholder value + multiple entries
+        static3: {
+          message: "Static message {0}",
+          translation: "Static message {0}",
+          placeholders: {
+            0: ["user \n ? user.name \n : null", "userName"],
+          },
         },
-      },
-    }
 
-    const actual = format.serialize(catalog, defaultSerializeCtx)
-    expect(actual).toMatchSnapshot()
+        // should limit to 3 by default
+        static4: {
+          message: "Static message {0}",
+          translation: "Static message {0}",
+          placeholders: {
+            0: ["userName", "user.name", "profile.name", "authorName"],
+          },
+        },
+      }
+
+      const actual = format.serialize(catalog, defaultSerializeCtx)
+      expect(actual).toMatchSnapshot()
+    })
+
+    it("Should not print placeholders if printPlaceholdersInComments = false", () => {
+      const format = createFormatter({ printPlaceholdersInComments: false })
+
+      const catalog: CatalogType = {
+        static: {
+          message: "Static message {0} {name}",
+          translation: "Static message {0} {name}",
+          placeholders: {
+            0: ["getValue()"],
+            name: ["user.getName()"],
+          },
+        },
+      }
+
+      const actual = format.serialize(catalog, defaultSerializeCtx)
+      expect(actual).toMatchSnapshot()
+    })
+
+    it("Should print printPlaceholdersInComments.limit amount of values for placeholder", () => {
+      const format = createFormatter({
+        printPlaceholdersInComments: {
+          limit: 1,
+        },
+      })
+
+      const catalog: CatalogType = {
+        static: {
+          message: "Static message {0} {1}",
+          translation: "Static message {0} {1}",
+          placeholders: {
+            0: ["userName", "user.name", "profile.name", "authorName"],
+            1: ["a", "b", "c", "d"],
+          },
+        },
+      }
+
+      const actual = format.serialize(catalog, defaultSerializeCtx)
+      expect(actual).toMatchSnapshot()
+    })
   })
 })

--- a/packages/format-po/src/po.test.ts
+++ b/packages/format-po/src/po.test.ts
@@ -451,17 +451,26 @@ describe("pofile format", () => {
         message: "Static message {0} {name}",
         translation: "Static message {0} {name}",
         placeholders: {
-          0: "getValue()",
-          name: "user.getName()",
+          0: ["getValue()"],
+          name: ["user.getName()"],
         },
       },
+      // should not push placeholder comment twice
       static2: {
         message: "Static message {0} {name}",
         translation: "Static message {0} {name}",
-        comments: ["ph: {0} = getValue()"],
+        comments: ["placeholder: {0} = getValue()"],
         placeholders: {
-          0: "getValue()",
-          name: "user.getName()",
+          0: ["getValue()"],
+          name: ["user.getName()"],
+        },
+      },
+      // multiline placeholder value + multiple entries
+      static3: {
+        message: "Static message {0}",
+        translation: "Static message {0}",
+        placeholders: {
+          0: ["user \n ? user.name \n : null", "userName"],
         },
       },
     }

--- a/packages/format-po/src/po.test.ts
+++ b/packages/format-po/src/po.test.ts
@@ -442,4 +442,31 @@ describe("pofile format", () => {
 
     `)
   })
+
+  it("should print unnamed placeholders as comments", () => {
+    const format = createFormatter({ printPlaceholdersInComments: true })
+
+    const catalog: CatalogType = {
+      static: {
+        message: "Static message {0} {name}",
+        translation: "Static message {0} {name}",
+        placeholders: {
+          0: "getValue()",
+          name: "user.getName()",
+        },
+      },
+      static2: {
+        message: "Static message {0} {name}",
+        translation: "Static message {0} {name}",
+        comments: ["ph: {0} = getValue()"],
+        placeholders: {
+          0: "getValue()",
+          name: "user.getName()",
+        },
+      },
+    }
+
+    const actual = format.serialize(catalog, defaultSerializeCtx)
+    expect(actual).toMatchSnapshot()
+  })
 })

--- a/packages/format-po/src/po.ts
+++ b/packages/format-po/src/po.ts
@@ -76,7 +76,7 @@ export type PoFormatterOptions = {
    * This will be extracted as
    *
    * ```po
-   * #. ph: {0} = user.name
+   * #. placeholder {0}: user.name
    * msgid "Hello {0} {value}"
    * ```
    *

--- a/packages/format-po/src/po.ts
+++ b/packages/format-po/src/po.ts
@@ -58,6 +58,28 @@ export type PoFormatterOptions = {
    * @default false
    */
   explicitIdAsDefault?: boolean
+
+  /**
+   * Print values for unnamed placeholders as comments for each message.
+   *
+   * This can give more context to translators for better translations.
+   *
+   * Example:
+   *
+   * ```js
+   * t`Hello ${user.name} ${value}`
+   * ```
+   *
+   * This will be extracted as
+   *
+   * ```gettext
+   * #. ph: {0} = user.name
+   * msgid "Hello {0} {value}"
+   * ```
+   *
+   * @default true
+   */
+  printPlaceholdersInComments?: boolean
 }
 
 function isGeneratedId(id: string, message: MessageType): boolean {
@@ -119,6 +141,20 @@ const serialize = (catalog: CatalogType, options: PoFormatterOptions) => {
       }
 
       item.msgid = id
+    }
+
+    if (options.printPlaceholdersInComments) {
+      item.extractedComments = item.extractedComments.filter(
+        (comment) => !comment.startsWith("ph:")
+      )
+
+      if (message.placeholders) {
+        Object.entries(message.placeholders).forEach(([name, value]) => {
+          if (/^\d+$/.test(name)) {
+            item.extractedComments.push(`ph: {${name}} = ${value}`)
+          }
+        })
+      }
     }
 
     if (message.context) {

--- a/packages/format-po/src/po.ts
+++ b/packages/format-po/src/po.ts
@@ -72,7 +72,7 @@ export type PoFormatterOptions = {
    *
    * This will be extracted as
    *
-   * ```gettext
+   * ```po
    * #. ph: {0} = user.name
    * msgid "Hello {0} {value}"
    * ```
@@ -143,15 +143,18 @@ const serialize = (catalog: CatalogType, options: PoFormatterOptions) => {
       item.msgid = id
     }
 
-    if (options.printPlaceholdersInComments) {
+    if (options.printPlaceholdersInComments !== false) {
       item.extractedComments = item.extractedComments.filter(
-        (comment) => !comment.startsWith("ph:")
+        (comment) => !comment.startsWith("placeholder ")
       )
 
       if (message.placeholders) {
         Object.entries(message.placeholders).forEach(([name, value]) => {
           if (/^\d+$/.test(name)) {
-            item.extractedComments.push(`ph: {${name}} = ${value}`)
+            value.forEach((entry) => {
+              const cleared = entry.replace(/\n/g, " ").replace(/\s{2,}/g, " ")
+              item.extractedComments.push(`placeholder {${name}}: ${cleared}`)
+            })
           }
         })
       }

--- a/packages/format-po/src/utils.test.ts
+++ b/packages/format-po/src/utils.test.ts
@@ -1,0 +1,12 @@
+import { normalizePlaceholderValue } from "./utils"
+
+describe("normalizePlaceholderValue", () => {
+  it.each([
+    `user 
+    ? user.name 
+    : null`,
+    "userName",
+  ])("Should normalize whitespaces", (input) => {
+    expect(normalizePlaceholderValue(input)).toMatchSnapshot()
+  })
+})

--- a/packages/format-po/src/utils.ts
+++ b/packages/format-po/src/utils.ts
@@ -1,0 +1,3 @@
+export function normalizePlaceholderValue(text: string) {
+  return text.replace(/\n/g, " ").replace(/\s{2,}/g, " ")
+}


### PR DESCRIPTION
# Description

This feature serves similar purpose as in this PR https://github.com/lingui/js-lingui/pull/1874.

If the message contains unnamed placeholders, such as `{0}` print theirs values into PO comments, so translators got an idea what this placeholder is about. 

```js
t`Hello ${user.name} ${value}`
```

This will be extracted as

Before: 
```po
msgid "Hello {0} {value}"
```

After: 
```po
#. ph: {0} = user.name
msgid "Hello {0} {value}"
```

This benefit of this solution is that developers can reuse more translations, because different placeholder name will not create different translations keys. 

Also now placeholder metadata is available for formatters, so users can implement theirs own logic for placeholders (for example replace them to values)

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
