### PR TITLE
fix(experimental-extractor): change default loader to tsx

### DIFF
--- a/packages/cli/src/extract-experimental/linguiEsbuildPlugin.ts
+++ b/packages/cli/src/extract-experimental/linguiEsbuildPlugin.ts
@@ -50,7 +50,7 @@ export const pluginLinguiMacro = (options: {
         ],
       })
 
-      return { contents: result.code, loader: "jsx" }
+      return { contents: result.code, loader: "tsx" }
     })
   },
 })

--- a/packages/cli/test/extractor-experimental/fixtures/pages/index.page.ts
+++ b/packages/cli/test/extractor-experimental/fixtures/pages/index.page.ts
@@ -1,6 +1,10 @@
 import { t } from "@lingui/core/macro"
 import { RED } from "../constants"
 
-const msg = t`index page message`
+const msg: string = t`index page message`
 console.log(msg)
 console.log(RED)
+
+function test(input: string): void {
+  console.log("Should support TS type annotation syntax")
+}


### PR DESCRIPTION
Because we use babel to process only macro in esbuild plugin and left rest of the syntax (including typescript) as-is we have to specify correct loader for esbuild.

I choosed tsx loader because it's a superset and do everything what js and ts and jsx loaders could do without relying on file extension

# Description

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

Fixes https://github.com/lingui/js-lingui/pull/1958#issuecomment-2212951631

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
