### PR TITLE
fix(extract): escape special regex characters used in file-based routing systems

### DIFF
--- a/packages/cli/src/api/__snapshots__/catalog.test.ts.snap
+++ b/packages/cli/src/api/__snapshots__/catalog.test.ts.snap
@@ -7,6 +7,44 @@ exports[`Catalog POT Flow Should get translations from template if locale file n
 }
 `;
 
+exports[`Catalog collect should extract files with special characters when passed in options 1`] = `
+{
+  Component C: {
+    comments: [],
+    context: undefined,
+    message: undefined,
+    origin: [
+      [
+        collect/(componentC)/index.js,
+        1,
+      ],
+    ],
+  },
+  Component D: {
+    comments: [],
+    context: undefined,
+    message: undefined,
+    origin: [
+      [
+        collect/[componentD]/index.js,
+        1,
+      ],
+    ],
+  },
+  Component E: {
+    comments: [],
+    context: undefined,
+    message: undefined,
+    origin: [
+      [
+        collect/$componentE/index.js,
+        1,
+      ],
+    ],
+  },
+}
+`;
+
 exports[`Catalog collect should extract messages from source files 1`] = `
 {
   Component A: {
@@ -27,6 +65,39 @@ exports[`Catalog collect should extract messages from source files 1`] = `
     origin: [
       [
         collect/componentB.js,
+        1,
+      ],
+    ],
+  },
+  Component C: {
+    comments: [],
+    context: undefined,
+    message: undefined,
+    origin: [
+      [
+        collect/(componentC)/index.js,
+        1,
+      ],
+    ],
+  },
+  Component D: {
+    comments: [],
+    context: undefined,
+    message: undefined,
+    origin: [
+      [
+        collect/[componentD]/index.js,
+        1,
+      ],
+    ],
+  },
+  Component E: {
+    comments: [],
+    context: undefined,
+    message: undefined,
+    origin: [
+      [
+        collect/$componentE/index.js,
         1,
       ],
     ],
@@ -422,6 +493,60 @@ exports[`Catalog make should merge with existing catalogs 2`] = `
       ],
       translation: ,
     },
+    Component C: {
+      comments: [
+        js-lingui-explicit-id,
+      ],
+      context: null,
+      extra: {
+        flags: [],
+        translatorComments: [],
+      },
+      obsolete: false,
+      origin: [
+        [
+          collect/(componentC)/index.js,
+          1,
+        ],
+      ],
+      translation: ,
+    },
+    Component D: {
+      comments: [
+        js-lingui-explicit-id,
+      ],
+      context: null,
+      extra: {
+        flags: [],
+        translatorComments: [],
+      },
+      obsolete: false,
+      origin: [
+        [
+          collect/[componentD]/index.js,
+          1,
+        ],
+      ],
+      translation: ,
+    },
+    Component E: {
+      comments: [
+        js-lingui-explicit-id,
+      ],
+      context: null,
+      extra: {
+        flags: [],
+        translatorComments: [],
+      },
+      obsolete: false,
+      origin: [
+        [
+          collect/$componentE/index.js,
+          1,
+        ],
+      ],
+      translation: ,
+    },
     Hello World: {
       comments: [
         Comment A,
@@ -514,6 +639,60 @@ exports[`Catalog make should merge with existing catalogs 2`] = `
       origin: [
         [
           collect/componentB.js,
+          1,
+        ],
+      ],
+      translation: ,
+    },
+    Component C: {
+      comments: [
+        js-lingui-explicit-id,
+      ],
+      context: null,
+      extra: {
+        flags: [],
+        translatorComments: [],
+      },
+      obsolete: false,
+      origin: [
+        [
+          collect/(componentC)/index.js,
+          1,
+        ],
+      ],
+      translation: ,
+    },
+    Component D: {
+      comments: [
+        js-lingui-explicit-id,
+      ],
+      context: null,
+      extra: {
+        flags: [],
+        translatorComments: [],
+      },
+      obsolete: false,
+      origin: [
+        [
+          collect/[componentD]/index.js,
+          1,
+        ],
+      ],
+      translation: ,
+    },
+    Component E: {
+      comments: [
+        js-lingui-explicit-id,
+      ],
+      context: null,
+      extra: {
+        flags: [],
+        translatorComments: [],
+      },
+      obsolete: false,
+      origin: [
+        [
+          collect/$componentE/index.js,
           1,
         ],
       ],

--- a/packages/cli/src/api/catalog.test.ts
+++ b/packages/cli/src/api/catalog.test.ts
@@ -293,6 +293,28 @@ describe("Catalog", () => {
       expect(messages).toMatchSnapshot()
     })
 
+    it("should extract files with special characters when passed in options", async () => {
+      const catalog = new Catalog(
+        {
+          name: "messages",
+          path: "locales/{locale}",
+          include: [fixture("collect")],
+          exclude: [],
+          format,
+        },
+        mockConfig()
+      )
+
+      const messages = await catalog.collect({
+        files: [
+          fixture("collect/(componentC)/index.js"),
+          fixture("collect/[componentD]/index.js"),
+          fixture("collect/$componentE/index.js"),
+        ],
+      })
+      expect(messages).toMatchSnapshot()
+    })
+
     it("should throw an error when duplicate identifier with different defaults found", async () => {
       const catalog = new Catalog(
         {

--- a/packages/cli/src/api/catalog.ts
+++ b/packages/cli/src/api/catalog.ts
@@ -18,6 +18,7 @@ import { mergeCatalog } from "./catalog/mergeCatalog"
 import { extractFromFiles } from "./catalog/extractFromFiles"
 import {
   isDirectory,
+  makePathRegexSafe,
   normalizeRelativePath,
   replacePlaceholders,
   writeFile,
@@ -132,7 +133,9 @@ export class Catalog {
   ): Promise<ExtractedCatalogType | undefined> {
     let paths = this.sourcePaths
     if (options.files) {
-      options.files = options.files.map((p) => normalize(p, false))
+      options.files = options.files.map((p) =>
+        makePathRegexSafe(normalize(p, false))
+      )
       const regex = new RegExp(options.files.join("|"), "i")
       paths = paths.filter((path: string) => regex.test(path))
     }

--- a/packages/cli/src/api/fixtures/collect/$componentE/index.js
+++ b/packages/cli/src/api/fixtures/collect/$componentE/index.js
@@ -1,0 +1,1 @@
+/*i18n*/ i18n._("Component E")

--- a/packages/cli/src/api/fixtures/collect/(componentC)/index.js
+++ b/packages/cli/src/api/fixtures/collect/(componentC)/index.js
@@ -1,0 +1,1 @@
+/*i18n*/ i18n._("Component C")

--- a/packages/cli/src/api/fixtures/collect/[componentD]/index.js
+++ b/packages/cli/src/api/fixtures/collect/[componentD]/index.js
@@ -1,0 +1,1 @@
+/*i18n*/ i18n._("Component D")

--- a/packages/cli/src/api/utils.test.ts
+++ b/packages/cli/src/api/utils.test.ts
@@ -1,4 +1,8 @@
-import { normalizeRelativePath, replacePlaceholders } from "./utils"
+import {
+  makePathRegexSafe,
+  normalizeRelativePath,
+  replacePlaceholders,
+} from "./utils"
 import mockFs from "mock-fs"
 
 describe("replacePlaceholders", () => {
@@ -61,5 +65,73 @@ describe("normalizeRelativePath", () => {
     expect(normalizeRelativePath("./componentA")).toEqual("componentA/")
     // ComponentB is a file shouldn't add ending slash
     expect(normalizeRelativePath("./componentB")).toEqual("componentB")
+  })
+})
+
+describe("makePathRegexSafe", () => {
+  it("should not modify paths without special characters", () => {
+    const path = "src/components/test.tsx"
+    expect(makePathRegexSafe(path)).toBe(path)
+  })
+
+  it("should escape parentheses", () => {
+    const path = "src/(components)/test.tsx"
+    expect(makePathRegexSafe(path)).toBe("src/\\(components\\)/test.tsx")
+  })
+
+  it("should escape square brackets", () => {
+    const path = "src/[components]/test.tsx"
+    expect(makePathRegexSafe(path)).toBe("src/\\[components\\]/test.tsx")
+  })
+
+  it("should escape curly braces", () => {
+    const path = "src/{components}/test.tsx"
+    expect(makePathRegexSafe(path)).toBe("src/\\{components\\}/test.tsx")
+  })
+
+  it("should escape caret symbol", () => {
+    const path = "src/^components/test.tsx"
+    expect(makePathRegexSafe(path)).toBe("src/\\^components/test.tsx")
+  })
+
+  it("should escape dollar sign", () => {
+    const path = "src/$components/test.tsx"
+    expect(makePathRegexSafe(path)).toBe("src/\\$components/test.tsx")
+  })
+
+  it("should escape plus sign", () => {
+    const path = "src/+components/test.tsx"
+    expect(makePathRegexSafe(path)).toBe("src/\\+components/test.tsx")
+  })
+
+  it("should handle multiple special characters", () => {
+    const path = "src/components/test(1)[2]{3}^$+.tsx"
+    expect(makePathRegexSafe(path)).toBe(
+      "src/components/test\\(1\\)\\[2\\]\\{3\\}\\^\\$\\+.tsx"
+    )
+  })
+
+  it("should handle paths with spaces", () => {
+    const path = "src/components/test component.tsx"
+    expect(makePathRegexSafe(path)).toBe("src/components/test component.tsx")
+  })
+
+  it("should handle empty string", () => {
+    expect(makePathRegexSafe("")).toBe("")
+  })
+
+  it("should handle root-level path", () => {
+    const path = "test.tsx"
+    expect(makePathRegexSafe(path)).toBe("test.tsx")
+  })
+
+  it("should handle relative paths", () => {
+    const path = "./src/components/test[1].tsx"
+    expect(makePathRegexSafe(path)).toBe("./src/components/test\\[1\\].tsx")
+  })
+
+  it("should handle paths with consecutive special characters", () => {
+    const path = "src/components/test[[]].tsx"
+    expect(makePathRegexSafe(path)).toBe("src/components/test\\[\\[\\]\\].tsx")
   })
 })

--- a/packages/cli/src/api/utils.ts
+++ b/packages/cli/src/api/utils.ts
@@ -115,3 +115,10 @@ export function normalizeRelativePath(sourcePath: string): string {
     (isDir ? "/" : "")
   )
 }
+
+/**
+ * Escape special regex characters used in file-based routing systems
+ */
+export function makePathRegexSafe(path: string) {
+  return path.replace(/[(){}[\]^$+]/g, "\\$&")
+}


### PR DESCRIPTION
# Description

We recently migrated to [TanStack Router](https://github.com/TanStack/router), which uses file-based routing with several [file naming conventions](https://tanstack.com/router/latest/docs/framework/react/guide/file-based-routing#file-naming-conventions). The `lingui extract --watch` command stopped working on any routes with these special characters. However, `lingui extract` continued to work.

Debugging revealed that `--watch` sets `options.files`, and these paths are formed into a regular expression. If any of these paths contains a character with special regex meaning, like `$`, then `paths` won't be correctly filtered.

```
if (options.files) {
    options.files = options.files.map((p) =>normalize(p, false))
    const regex = new RegExp(options.files.join("|"), "i")
    paths = paths.filter((path: string) => regex.test(path))
}
```

To fix this, I created a new utility that escapes characters allowed in file paths, but with special regex meaning. I'm not sure if I captured all possible characters used in file-based routing conventions, or if I over specified too many.

I added tests for both the utility itself and the extractor's `collect` function. If you remove `makePathRegexSafe` from `collect`, you should see components C, D, and E removed from the snapshot because the extractor fails to handle them.

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
