### PR TITLE
fix: return a single node when applicable

### DIFF
--- a/packages/react/src/Trans.test.tsx
+++ b/packages/react/src/Trans.test.tsx
@@ -238,10 +238,11 @@ describe("Trans component", () => {
     expect(translation).toEqual(`Read <a href="/docs">the docs</a>`)
   })
 
-  it('should render nested elements with `asChild` pattern', () => {
-    const ComponentThatExpectsSingleElementChild: React.FC<{ asChild: boolean, children?: React.ReactElement }> = (
-      props
-    ) => {
+  it("should render nested elements with `asChild` pattern", () => {
+    const ComponentThatExpectsSingleElementChild: React.FC<{
+      asChild: boolean
+      children?: React.ReactElement
+    }> = (props) => {
       if (props.asChild && React.isValidElement(props.children)) {
         return props.children
       }
@@ -250,10 +251,13 @@ describe("Trans component", () => {
     }
 
     const translation = html(
-      <Trans id="please <0><1>sign in again</1></0>" components={{
-        0: <ComponentThatExpectsSingleElementChild asChild />,
-        1: <a href="/login" />
-      }} />
+      <Trans
+        id="please <0><1>sign in again</1></0>"
+        components={{
+          0: <ComponentThatExpectsSingleElementChild asChild />,
+          1: <a href="/login" />,
+        }}
+      />
     )
     expect(translation).toEqual(`please <a href="/login">sign in again</a>`)
   })

--- a/packages/react/src/Trans.test.tsx
+++ b/packages/react/src/Trans.test.tsx
@@ -238,6 +238,26 @@ describe("Trans component", () => {
     expect(translation).toEqual(`Read <a href="/docs">the docs</a>`)
   })
 
+  it('should render nested elements with `asChild` pattern', () => {
+    const ComponentThatExpectsSingleElementChild: React.FC<{ asChild: boolean, children?: React.ReactElement }> = (
+      props
+    ) => {
+      if (props.asChild && React.isValidElement(props.children)) {
+        return props.children
+      }
+
+      return <div />
+    }
+
+    const translation = html(
+      <Trans id="please <0><1>sign in again</1></0>" components={{
+        0: <ComponentThatExpectsSingleElementChild asChild />,
+        1: <a href="/login" />
+      }} />
+    )
+    expect(translation).toEqual(`please <a href="/login">sign in again</a>`)
+  })
+
   it("should render translation inside custom component", () => {
     const Component = (props: PropsWithChildren) => (
       <p className="lead">{props.children}</p>

--- a/packages/react/src/format.test.tsx
+++ b/packages/react/src/format.test.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import { render } from "@testing-library/react"
+import assert from "node:assert"
 import { formatElements } from "./format"
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { mockConsole } from "@lingui/jest-mocks"
@@ -138,13 +139,21 @@ describe("formatElements", function () {
     const elements = formatElements("<div><0/><0/></div>", {
       div: <div />,
       0: <span>hi</span>,
-    }) as Array<React.ReactElement>
+    })
 
-    expect(elements).toHaveLength(1)
-    const childElements = elements[0]!.props.children
+    expect(React.isValidElement(elements)).toBe(true)
+
+    assert.ok(React.isValidElement<{
+      children: React.ReactElement[]
+    }>(elements))
+
+    const childElements = elements.props.children
     const childKeys = childElements
-      .map((el: React.ReactElement) => el?.key)
+      .map((el) => el?.key)
       .filter(Boolean)
+
+    assert.ok(typeof childKeys[0] === 'string' && typeof childKeys[1] === 'string')
+
     expect(cleanPrefix(childKeys[0])).toBeLessThan(cleanPrefix(childKeys[1]))
   })
 })

--- a/packages/react/src/format.test.tsx
+++ b/packages/react/src/format.test.tsx
@@ -143,16 +143,18 @@ describe("formatElements", function () {
 
     expect(React.isValidElement(elements)).toBe(true)
 
-    assert.ok(React.isValidElement<{
-      children: React.ReactElement[]
-    }>(elements))
+    assert.ok(
+      React.isValidElement<{
+        children: React.ReactElement[]
+      }>(elements)
+    )
 
     const childElements = elements.props.children
-    const childKeys = childElements
-      .map((el) => el?.key)
-      .filter(Boolean)
+    const childKeys = childElements.map((el) => el?.key).filter(Boolean)
 
-    assert.ok(typeof childKeys[0] === 'string' && typeof childKeys[1] === 'string')
+    assert.ok(
+      typeof childKeys[0] === "string" && typeof childKeys[1] === "string"
+    )
 
     expect(cleanPrefix(childKeys[0])).toBeLessThan(cleanPrefix(childKeys[1]))
   })

--- a/packages/react/src/format.test.tsx
+++ b/packages/react/src/format.test.tsx
@@ -1,6 +1,5 @@
-import * as React from "react"
 import { render } from "@testing-library/react"
-import assert from "node:assert"
+import * as React from "react"
 import { formatElements } from "./format"
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { mockConsole } from "@lingui/jest-mocks"
@@ -143,19 +142,13 @@ describe("formatElements", function () {
 
     expect(React.isValidElement(elements)).toBe(true)
 
-    assert.ok(
-      React.isValidElement<{
-        children: React.ReactElement[]
-      }>(elements)
-    )
-
-    const childElements = elements.props.children
+    const childElements = (
+      elements as React.ReactElement<{ children: React.ReactElement[] }>
+    ).props.children
     const childKeys = childElements.map((el) => el?.key).filter(Boolean)
 
-    assert.ok(
-      typeof childKeys[0] === "string" && typeof childKeys[1] === "string"
+    expect(cleanPrefix(childKeys[0] as string)).toBeLessThan(
+      cleanPrefix(childKeys[1] as string)
     )
-
-    expect(cleanPrefix(childKeys[0])).toBeLessThan(cleanPrefix(childKeys[1]))
   })
 })

--- a/packages/react/src/format.ts
+++ b/packages/react/src/format.ts
@@ -87,7 +87,7 @@ function formatElements(
     if (after) tree.push(after)
   }
 
-  return tree
+  return tree.length === 1 ? tree[0] : tree;
 }
 
 /*

--- a/packages/react/src/format.ts
+++ b/packages/react/src/format.ts
@@ -35,7 +35,7 @@ const voidElementTags = {
 function formatElements(
   value: string,
   elements: { [key: string]: React.ReactElement } = {}
-): string | Array<React.ReactElement | string> {
+): string | React.ReactElement | Array<React.ReactElement | string> {
   const uniqueId = makeCounter(0, "$lingui$")
   const parts = value.replace(nlRe, "").split(tagRe)
 
@@ -87,7 +87,7 @@ function formatElements(
     if (after) tree.push(after)
   }
 
-  return tree.length === 1 ? tree[0] : tree;
+  return tree.length === 1 ? tree[0]! : tree;
 }
 
 /*

--- a/packages/react/src/format.ts
+++ b/packages/react/src/format.ts
@@ -87,7 +87,7 @@ function formatElements(
     if (after) tree.push(after)
   }
 
-  return tree.length === 1 ? tree[0]! : tree;
+  return tree.length === 1 ? tree[0]! : tree
 }
 
 /*


### PR DESCRIPTION
# Description


Fixes an issue where `<Trans>` didn't work as expected when using `asChild`, which is most commonly used with [Radix](https://www.radix-ui.com/primitives) (and [shadcn/ui](https://ui.shadcn.com/), which is based on it).

Fixes https://github.com/lingui/js-lingui/issues/2015

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

Fixes #2015

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
