### PR TITLE
fix: unicode parsing

### DIFF
--- a/packages/core/src/i18n.test.ts
+++ b/packages/core/src/i18n.test.ts
@@ -332,17 +332,6 @@ describe("I18n", () => {
     })
   })
 
-  it("._ should parse unicode sequences", () => {
-    const messages = {
-      "Software development": "Software\\u00ADentwicklung",
-    }
-    const i18n = setupI18n({
-      locale: "de",
-      messages: { de: messages },
-    })
-    expect(i18n._("Software development")).toEqual("Software­entwicklung")
-  })
-
   it("._ should parse unicode sequences even if the same string goes twice in a row", () => {
     const messages = {
       "Software development": "Software\\u00ADentwicklung",

--- a/packages/core/src/i18n.test.ts
+++ b/packages/core/src/i18n.test.ts
@@ -331,4 +331,27 @@ describe("I18n", () => {
       expect(missing).toHaveBeenCalledWith("en", "missing")
     })
   })
+
+  it("._ should parse unicode sequences", () => {
+    const messages = {
+      "Software development": "Software\\u00ADentwicklung",
+    }
+    const i18n = setupI18n({
+      locale: "de",
+      messages: { de: messages },
+    })
+    expect(i18n._("Software development")).toEqual("Software­entwicklung")
+  })
+
+  it("._ should parse unicode sequences even if the same string goes twice in a row", () => {
+    const messages = {
+      "Software development": "Software\\u00ADentwicklung",
+    }
+    const i18n = setupI18n({
+      locale: "de",
+      messages: { de: messages },
+    })
+    expect(i18n._("Software development")).toEqual("Software­entwicklung")
+    expect(i18n._("Software development")).toEqual("Software­entwicklung")
+  })
 })

--- a/packages/core/src/interpolate.test.ts
+++ b/packages/core/src/interpolate.test.ts
@@ -201,4 +201,14 @@ describe("interpolate", () => {
       "Hey Joeª!"
     )
   })
+
+  it("should not crash on a unicode sequences if the same string goes twice in a row", () => {
+    const cache = compile("Hey {name}!")
+    expect(interpolate(cache, "en", [])({ name: "Joe\\xaa" })).toEqual(
+      "Hey Joeª!"
+    )
+    expect(interpolate(cache, "en", [])({ name: "Joe\\xaa" })).toEqual(
+      "Hey Joeª!"
+    )
+  })
 })

--- a/packages/core/src/interpolate.ts
+++ b/packages/core/src/interpolate.ts
@@ -4,7 +4,7 @@ import { isString } from "./essentials"
 import { unraw } from "unraw"
 import { CompiledIcuChoices } from "@lingui/message-utils/compileMessage"
 
-export const UNICODE_REGEX = /\\u[a-fA-F0-9]{4}|\\x[a-fA-F0-9]{2}/g
+export const UNICODE_REGEX = /\\u[a-fA-F0-9]{4}|\\x[a-fA-F0-9]{2}/
 
 const OCTOTHORPE_PH = "%__lingui_octothorpe__%"
 


### PR DESCRIPTION
# Description

In`js-lingui/packages/core/src/interpolate.ts` there is a regular expression to test if the string has unicode values inside, it has the `g` flag which makes that Regexp stateful. If you render the same string twice in a row, Lingui will not parse the string a second time, because the `lastIndex` for that string will be after the Unicode symbol at that point. And since there is no need to keep the `lastIndex` state, no need for a `g` flag here.

The bug is reproducible, for example, in React with the [StrictMode](https://react.dev/reference/react/StrictMode) enabled.

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

Fixes https://github.com/lingui/js-lingui/issues/2028

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)