### PR TITLE
fix: Improve macro error

### DIFF
--- a/packages/babel-plugin-lingui-macro/src/index.ts
+++ b/packages/babel-plugin-lingui-macro/src/index.ts
@@ -42,7 +42,7 @@ function reportUnsupportedSyntax(path: NodePath, e: Error) {
   )
 
   // show stack trace where error originally happened
-  codeFrameError.stack = e.stack
+  codeFrameError.stack = codeFrameError.message + "\n" + e.stack
   throw codeFrameError
 }
 


### PR DESCRIPTION
# Description

webpack (and nextjs) for some reason doesn't read message from error but instead rethrow the first frame of the stacktrace

So this fix will turn error from this

```
wait  - compiling /examples (client and server)...
error - ./src/pages/examples.tsx
TypeError: Cannot read properties of undefined (reading 'find')
```

to this: 

<img width="887" alt="image" src="https://github.com/user-attachments/assets/8f053382-96ea-47ea-8a78-277ce20640c4">

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
