### PR TITLE
refactor: remove strings support from `LinguiConfig.extractors`

### DIFF
--- a/packages/cli/src/api/extractors/index.ts
+++ b/packages/cli/src/api/extractors/index.ts
@@ -20,16 +20,7 @@ export default async function extract(
 ): Promise<boolean> {
   const extractorsToExtract = options.extractors ?? DEFAULT_EXTRACTORS
 
-  for (let e of extractorsToExtract) {
-    let ext: ExtractorType = e
-    if (typeof e === "string") {
-      // in case of the user using require.resolve in their extractors, we require that module
-      ext = require(e)
-    }
-    if ((ext as any).default) {
-      ext = (ext as any).default
-    }
-
+  for (let ext of extractorsToExtract) {
     if (!ext.match(filename)) continue
 
     try {

--- a/packages/conf/__typetests__/index.test-d.tsx
+++ b/packages/conf/__typetests__/index.test-d.tsx
@@ -48,7 +48,6 @@ expectAssignable<LinguiConfig>({
 expectAssignable<LinguiConfig>({
   locales: ["en", "pl"],
   extractors: [
-    "babel",
     {
       match: (fileName: string) => false,
       extract: (

--- a/packages/conf/src/types.ts
+++ b/packages/conf/src/types.ts
@@ -199,7 +199,7 @@ export type LinguiConfig = {
   }
   compilerBabelOptions?: any
   fallbackLocales?: FallbackLocales | false
-  extractors?: (string | ExtractorType)[]
+  extractors?: ExtractorType[]
   prevFormat?: CatalogFormat
   localeDir?: string
   format?: CatalogFormat | CatalogFormatter

--- a/website/docs/releases/migration-5.md
+++ b/website/docs/releases/migration-5.md
@@ -203,3 +203,4 @@ You'll need to [re-compile](/docs/ref/cli.md#compile) your messages in the new f
 ## Deprecations and Removals
 
 - Removed the deprecated `isTranslated` prop from the React `Trans` component.
+- Removed support of the module path strings in `LinguiConfig.extractors` property. Please pass extractor object directly.


### PR DESCRIPTION
# Description

I believe it wasn't used, because it was even not documented. 

I removed this ability for simplicity and future ESM support. Related migration notice added.

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
