### PR TITLE
feat(macro): make message stripping configurable via Babel options

### DIFF
--- a/packages/babel-plugin-lingui-macro/src/index.ts
+++ b/packages/babel-plugin-lingui-macro/src/index.ts
@@ -48,16 +48,12 @@ function reportUnsupportedSyntax(path: NodePath, e: Error) {
 }
 
 function shouldStripMessageProp(opts: LinguiPluginOpts) {
-  if (opts.extract) {
-    // never strip message during extraction process
-    return false
-  }
   if (typeof opts.stripMessageField === "boolean") {
     // if explicitly set in options, use it
     return opts.stripMessageField
   }
-  // default to strip message in production if no explicit option is set
-  return process.env.NODE_ENV === "production"
+  // default to strip message in production if no explicit option is set and not during extract
+  return process.env.NODE_ENV === "production" && !opts.extract
 }
 
 type LinguiSymbol = "Trans" | "useLingui" | "i18n"

--- a/packages/babel-plugin-lingui-macro/src/macroJs.ts
+++ b/packages/babel-plugin-lingui-macro/src/macroJs.ts
@@ -27,6 +27,7 @@ export type MacroJsOpts = {
   useLinguiImportName: string
 
   stripNonEssentialProps: boolean
+  stripMessageProp: boolean
   isLinguiIdentifier: (node: Identifier, macro: JsMacroName) => boolean
 }
 
@@ -46,7 +47,8 @@ export class MacroJs {
 
     this._ctx = createMacroJsContext(
       opts.isLinguiIdentifier,
-      opts.stripNonEssentialProps
+      opts.stripNonEssentialProps,
+      opts.stripMessageProp
     )
   }
 
@@ -59,7 +61,8 @@ export class MacroJs {
       createMessageDescriptorFromTokens(
         tokens,
         path.node.loc,
-        this._ctx.stripNonEssentialProps
+        this._ctx.stripNonEssentialProps,
+        this._ctx.stripMessageProp
       ),
       linguiInstance
     )
@@ -89,7 +92,8 @@ export class MacroJs {
       return createMessageDescriptorFromTokens(
         tokens,
         path.node.loc,
-        ctx.stripNonEssentialProps
+        ctx.stripNonEssentialProps,
+        ctx.stripMessageProp
       )
     }
 
@@ -260,7 +264,8 @@ export class MacroJs {
           const descriptor = createMessageDescriptorFromTokens(
             tokens,
             currentPath.node.loc,
-            ctx.stripNonEssentialProps
+            ctx.stripNonEssentialProps,
+            ctx.stripMessageProp
           )
 
           const callExpr = t.callExpression(

--- a/packages/babel-plugin-lingui-macro/src/macroJsAst.test.ts
+++ b/packages/babel-plugin-lingui-macro/src/macroJsAst.test.ts
@@ -35,9 +35,13 @@ const parseExpression = (expression: string) => {
 }
 
 function createMacroCtx() {
-  return createMacroJsContext((identifier, macro) => {
-    return identifier.name === macro
-  }, false)
+  return createMacroJsContext(
+    (identifier, macro) => {
+      return identifier.name === macro
+    },
+    false, // stripNonEssentialProps
+    false // stripMessageProp
+  )
 }
 
 describe("js macro", () => {

--- a/packages/babel-plugin-lingui-macro/src/macroJsAst.ts
+++ b/packages/babel-plugin-lingui-macro/src/macroJsAst.ts
@@ -18,17 +18,20 @@ export type MacroJsContext = {
   // Positional expressions counter (e.g. for placeholders `Hello {0}, today is {1}`)
   getExpressionIndex: () => number
   stripNonEssentialProps: boolean
+  stripMessageProp: boolean
   isLinguiIdentifier: (node: Identifier, macro: JsMacroName) => boolean
 }
 
 export function createMacroJsContext(
   isLinguiIdentifier: MacroJsContext["isLinguiIdentifier"],
-  stripNonEssentialProps: boolean
+  stripNonEssentialProps: boolean,
+  stripMessageProp: boolean
 ): MacroJsContext {
   return {
     getExpressionIndex: makeCounter(),
     isLinguiIdentifier,
     stripNonEssentialProps,
+    stripMessageProp,
   }
 }
 
@@ -85,6 +88,7 @@ export function processDescriptor(
     tokens,
     descriptor.loc,
     ctx.stripNonEssentialProps,
+    ctx.stripMessageProp,
     {
       id: idProperty,
       context: contextProperty,

--- a/packages/babel-plugin-lingui-macro/src/macroJsx.test.ts
+++ b/packages/babel-plugin-lingui-macro/src/macroJsx.test.ts
@@ -33,7 +33,11 @@ const parseExpression = (expression: string) => {
 function createMacro() {
   return new MacroJSX(
     { types },
-    { stripNonEssentialProps: false, transImportName: "Trans" }
+    {
+      stripNonEssentialProps: false,
+      stripMessageProp: false,
+      transImportName: "Trans",
+    }
   )
 }
 

--- a/packages/babel-plugin-lingui-macro/src/macroJsx.ts
+++ b/packages/babel-plugin-lingui-macro/src/macroJsx.ts
@@ -45,6 +45,7 @@ function maybeNodeValue(node: Node): { text: string; loc: SourceLocation } {
 
 export type MacroJsxOpts = {
   stripNonEssentialProps: boolean
+  stripMessageProp: boolean
   transImportName: string
 }
 
@@ -53,11 +54,13 @@ export class MacroJSX {
   expressionIndex = makeCounter()
   elementIndex = makeCounter()
   stripNonEssentialProps: boolean
+  stripMessageProp: boolean
   transImportName: string
 
   constructor({ types }: { types: typeof babelTypes }, opts: MacroJsxOpts) {
     this.types = types
     this.stripNonEssentialProps = opts.stripNonEssentialProps
+    this.stripMessageProp = opts.stripMessageProp
     this.transImportName = opts.transImportName
   }
 
@@ -84,6 +87,7 @@ export class MacroJSX {
       tokens,
       path.node.loc,
       this.stripNonEssentialProps,
+      this.stripMessageProp,
       {
         id,
         context,

--- a/packages/babel-plugin-lingui-macro/src/messageDescriptorUtils.ts
+++ b/packages/babel-plugin-lingui-macro/src/messageDescriptorUtils.ts
@@ -29,6 +29,7 @@ export function createMessageDescriptorFromTokens(
   tokens: Tokens,
   oldLoc: SourceLocation,
   stripNonEssentialProps: boolean,
+  stripMessageProp: boolean,
   defaults: {
     id?: TextWithLoc | ObjectProperty
     context?: TextWithLoc | ObjectProperty
@@ -39,6 +40,7 @@ export function createMessageDescriptorFromTokens(
     buildICUFromTokens(tokens),
     oldLoc,
     stripNonEssentialProps,
+    stripMessageProp,
     defaults
   )
 }
@@ -47,6 +49,7 @@ export function createMessageDescriptor(
   result: Partial<ParsedResult>,
   oldLoc: SourceLocation,
   stripNonEssentialProps: boolean,
+  stripMessageProp: boolean,
   defaults: {
     id?: TextWithLoc | ObjectProperty
     context?: TextWithLoc | ObjectProperty
@@ -76,13 +79,15 @@ export function createMessageDescriptor(
         )
   )
 
-  if (!stripNonEssentialProps) {
+  if (!stripMessageProp) {
     if (message) {
       properties.push(
         createStringObjectProperty(MsgDescriptorPropKey.message, message)
       )
     }
+  }
 
+  if (!stripNonEssentialProps) {
     if (defaults.comment) {
       properties.push(
         isObjectProperty(defaults.comment)

--- a/packages/babel-plugin-lingui-macro/test/__snapshots__/js-t.test.ts.snap
+++ b/packages/babel-plugin-lingui-macro/test/__snapshots__/js-t.test.ts.snap
@@ -156,6 +156,31 @@ const msg = _i18n._(
 
 `;
 
+exports[`Production - message prop is kept if stripMessageField: false 1`] = `
+import { t } from "@lingui/macro";
+const msg = t({
+  message: \`Hello \${name}\`,
+  id: "msgId",
+  comment: "description for translators",
+  context: "My Context",
+});
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { i18n as _i18n } from "@lingui/core";
+const msg = _i18n._(
+  /*i18n*/
+  {
+    id: "msgId",
+    message: "Hello {name}",
+    values: {
+      name: name,
+    },
+  }
+);
+
+`;
+
 exports[`Production - only essential props are kept 1`] = `
 import { t } from "@lingui/core/macro";
 const msg = t\`Message\`;
@@ -567,6 +592,39 @@ const msg = t();
 
 import { i18n as _i18n } from "@lingui/core";
 const msg = _i18n._();
+
+`;
+
+exports[`stripMessageField option - Message prop is kept during extraction process if extract: true and stripMessageField: true 1`] = `
+import { t } from "@lingui/macro";
+const msg = t\`Message\`;
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { i18n as _i18n } from "@lingui/core";
+const msg = _i18n._(
+  /*i18n*/
+  {
+    id: "xDAtGP",
+    message: "Message",
+  }
+);
+
+`;
+
+exports[`stripMessageField option - message prop is removed if stripMessageField: true 1`] = `
+import { t } from "@lingui/macro";
+const msg = t\`Message\`;
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { i18n as _i18n } from "@lingui/core";
+const msg = _i18n._(
+  /*i18n*/
+  {
+    id: "xDAtGP",
+  }
+);
 
 `;
 

--- a/packages/babel-plugin-lingui-macro/test/__snapshots__/js-t.test.ts.snap
+++ b/packages/babel-plugin-lingui-macro/test/__snapshots__/js-t.test.ts.snap
@@ -595,23 +595,6 @@ const msg = _i18n._();
 
 `;
 
-exports[`stripMessageField option - Message prop is kept during extraction process if extract: true and stripMessageField: true 1`] = `
-import { t } from "@lingui/macro";
-const msg = t\`Message\`;
-
-↓ ↓ ↓ ↓ ↓ ↓
-
-import { i18n as _i18n } from "@lingui/core";
-const msg = _i18n._(
-  /*i18n*/
-  {
-    id: "xDAtGP",
-    message: "Message",
-  }
-);
-
-`;
-
 exports[`stripMessageField option - message prop is removed if stripMessageField: true 1`] = `
 import { t } from "@lingui/macro";
 const msg = t\`Message\`;

--- a/packages/babel-plugin-lingui-macro/test/__snapshots__/jsx-trans.test.ts.snap
+++ b/packages/babel-plugin-lingui-macro/test/__snapshots__/jsx-trans.test.ts.snap
@@ -813,25 +813,6 @@ import { Trans as _Trans } from "@lingui/react";
 
 `;
 
-exports[`stripMessageField option - Message prop is kept during extraction process if extract: true and stripMessageField: true 1`] = `
-import { Trans } from "@lingui/macro";
-<Trans id="msg.hello">Hello World</Trans>;
-
-↓ ↓ ↓ ↓ ↓ ↓
-
-import { Trans as _Trans } from "@lingui/react";
-<_Trans
-  {
-    /*i18n*/
-    ...{
-      id: "msg.hello",
-      message: "Hello World",
-    }
-  }
-/>;
-
-`;
-
 exports[`stripMessageField option - message prop is removed if stripMessageField: true 1`] = `
 import { Trans } from "@lingui/macro";
 <Trans id="msg.hello">Hello World</Trans>;

--- a/packages/babel-plugin-lingui-macro/test/__snapshots__/jsx-trans.test.ts.snap
+++ b/packages/babel-plugin-lingui-macro/test/__snapshots__/jsx-trans.test.ts.snap
@@ -411,6 +411,27 @@ import { Trans as _Trans } from "@lingui/react";
 
 `;
 
+exports[`Production - message prop is kept if stripMessageField: false 1`] = `
+import { Trans } from "@lingui/macro";
+<Trans id="msg.hello" comment="Hello World">
+  Hello World
+</Trans>;
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { Trans as _Trans } from "@lingui/react";
+<_Trans
+  {
+    /*i18n*/
+    ...{
+      id: "msg.hello",
+      message: "Hello World",
+    }
+  }
+/>;
+
+`;
+
 exports[`Production - only essential props are kept 1`] = `
 import { Trans } from "@lingui/react/macro";
 <Trans id="msg.hello" context="my context" comment="Hello World">
@@ -786,6 +807,43 @@ import { Trans as _Trans } from "@lingui/react";
       values: {
         duplicate: duplicate,
       },
+    }
+  }
+/>;
+
+`;
+
+exports[`stripMessageField option - Message prop is kept during extraction process if extract: true and stripMessageField: true 1`] = `
+import { Trans } from "@lingui/macro";
+<Trans id="msg.hello">Hello World</Trans>;
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { Trans as _Trans } from "@lingui/react";
+<_Trans
+  {
+    /*i18n*/
+    ...{
+      id: "msg.hello",
+      message: "Hello World",
+    }
+  }
+/>;
+
+`;
+
+exports[`stripMessageField option - message prop is removed if stripMessageField: true 1`] = `
+import { Trans } from "@lingui/macro";
+<Trans id="msg.hello">Hello World</Trans>;
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { Trans as _Trans } from "@lingui/react";
+<_Trans
+  {
+    /*i18n*/
+    ...{
+      id: "msg.hello",
     }
   }
 />;

--- a/packages/babel-plugin-lingui-macro/test/js-t.test.ts
+++ b/packages/babel-plugin-lingui-macro/test/js-t.test.ts
@@ -167,17 +167,6 @@ macroTester({
         `,
     },
     {
-      name: "stripMessageField option - Message prop is kept during extraction process if extract: true and stripMessageField: true",
-      macroOpts: {
-        extract: true,
-        stripMessageField: true,
-      },
-      code: `
-          import { t } from '@lingui/macro'
-          const msg = t\`Message\`
-        `,
-    },
-    {
       name: "Production - only essential props are kept",
       production: true,
       code: `

--- a/packages/babel-plugin-lingui-macro/test/js-t.test.ts
+++ b/packages/babel-plugin-lingui-macro/test/js-t.test.ts
@@ -157,6 +157,27 @@ macroTester({
       `,
     },
     {
+      name: "stripMessageField option - message prop is removed if stripMessageField: true",
+      macroOpts: {
+        stripMessageField: true,
+      },
+      code: `
+          import { t } from '@lingui/macro'
+          const msg = t\`Message\`
+        `,
+    },
+    {
+      name: "stripMessageField option - Message prop is kept during extraction process if extract: true and stripMessageField: true",
+      macroOpts: {
+        extract: true,
+        stripMessageField: true,
+      },
+      code: `
+          import { t } from '@lingui/macro'
+          const msg = t\`Message\`
+        `,
+    },
+    {
       name: "Production - only essential props are kept",
       production: true,
       code: `
@@ -203,6 +224,22 @@ macroTester({
             context: 'My Context',
         })
     `,
+    },
+    {
+      name: "Production - message prop is kept if stripMessageField: false",
+      production: true,
+      macroOpts: {
+        stripMessageField: false,
+      },
+      code: `
+          import { t } from '@lingui/macro';
+          const msg = t({
+              message: \`Hello $\{name\}\`,
+              id: 'msgId',
+              comment: 'description for translators',
+              context: 'My Context',
+          })
+      `,
     },
     {
       name: "Production - all props kept if extract: true",

--- a/packages/babel-plugin-lingui-macro/test/jsx-trans.test.ts
+++ b/packages/babel-plugin-lingui-macro/test/jsx-trans.test.ts
@@ -174,17 +174,6 @@ macroTester({
     `,
     },
     {
-      name: "stripMessageField option - Message prop is kept during extraction process if extract: true and stripMessageField: true",
-      macroOpts: {
-        extract: true,
-        stripMessageField: true,
-      },
-      code: `
-      import { Trans } from '@lingui/macro';
-      <Trans id="msg.hello">Hello World</Trans>
-    `,
-    },
-    {
       name: "Production - only essential props are kept",
       production: true,
       code: `

--- a/packages/babel-plugin-lingui-macro/test/jsx-trans.test.ts
+++ b/packages/babel-plugin-lingui-macro/test/jsx-trans.test.ts
@@ -164,12 +164,44 @@ macroTester({
       `,
     },
     {
+      name: "stripMessageField option - message prop is removed if stripMessageField: true",
+      macroOpts: {
+        stripMessageField: true,
+      },
+      code: `
+      import { Trans } from '@lingui/macro';
+      <Trans id="msg.hello">Hello World</Trans>
+    `,
+    },
+    {
+      name: "stripMessageField option - Message prop is kept during extraction process if extract: true and stripMessageField: true",
+      macroOpts: {
+        extract: true,
+        stripMessageField: true,
+      },
+      code: `
+      import { Trans } from '@lingui/macro';
+      <Trans id="msg.hello">Hello World</Trans>
+    `,
+    },
+    {
       name: "Production - only essential props are kept",
       production: true,
       code: `
         import { Trans } from '@lingui/react/macro';
         <Trans id="msg.hello" context="my context" comment="Hello World">Hello World</Trans>
       `,
+    },
+    {
+      name: "Production - message prop is kept if stripMessageField: false",
+      production: true,
+      macroOpts: {
+        stripMessageField: false,
+      },
+      code: `
+      import { Trans } from '@lingui/macro';
+      <Trans id="msg.hello" comment="Hello World">Hello World</Trans>
+    `,
     },
     {
       name: "Production - all props kept if extract: true",


### PR DESCRIPTION
# Description

Make it possible to configure whether the `message` prop should be stripped or not from the transpiled output. I have added a new option called `stripMessageField` that can be set from the Babel config to control the behaviour.

This does not change any of the default behaviour in the macro. Message (and other props like comment / context) will be kept in development mode, but removed in production mode (`NODE_ENV ===" production"`) by default. But it is now possible to override this behaviour by setting `stripMessageField` option in Babel config:

<details>
<summary>Example babel.config.js</summary>

```javascript
// babel.config.js
module.exports = {
    plugins: [
        "macros",
        {
            // ...
            // Other macros config
            lingui: {
                // message field will be removed in both dev and prod mode
                stripMessageField: true,
            },
        }
    ]
}
```
</details>

The section below outlines the different behaviours based on the `stripMessageField` option:
- Default (not set): `message` prop will be kept in development mode, but removed in production (when `process.env.NODE_ENV === "production"`)
- `stripMessageField: true`: always removes the `message` prop **except** during the extraction process
- `stripMessageField: false`: never removes the `message` prop

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Motivation for the change

We have recently added Lingui to our project and are so far very happy with it. One issue that we have encountered though is discrepancy between development mode and production mode due to how message fallbacks work. In development mode, the macro will fallback to the source message if there is no translated message available in the .po file (e.g. if the message hasn't been extracted) or if there is an issue with how the macro is used (e.g. using `t` macro directly on module level). However, in production mode the message prop is removed by default and therefore fallbacks to showing the ID in these cases.

For our workflow, we would like development mode to behave more like production and NOT fallback to the source message in the cases above to give developers an earlier indication that something is not working as it should during the development phase. On the contrary, one could also use `stripMessageField: false` to allow fallback to source message in production if a translated message is not available (possibly related to #https://github.com/lingui/js-lingui/issues/2043).

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
