### PR TITLE
feat(macro): deprecate custom i18n instance on `t` macro

### DIFF
--- a/packages/core/macro/index.d.ts
+++ b/packages/core/macro/index.d.ts
@@ -78,7 +78,7 @@ export function t(
  * import { I18n } from "@lingui/core";
  * const i18n = new I18n({
  *   locale: "nl",
- *   messages: { "Hello {0}": "Hallo {0}" },
+ *   messages: { "Hello {name}": "Hallo {name}" },
  * });
  * const message = t(i18n)`Hello ${name}`;
  * ```
@@ -89,10 +89,14 @@ export function t(
  * import { I18n } from "@lingui/core";
  * const i18n = new I18n({
  *   locale: "nl",
- *   messages: { "Hello {0}": "Hallo {0}" },
+ *   messages: { "Hello {name}": "Hallo {name}" },
  * });
  * const message = t(i18n)({ message: `Hello ${name}` });
  * ```
+ *
+ * @deprecated in v5, would be removed in v6.
+ * Please use `` i18n._(msg`Hello ${name}`) `` instead
+ *
  */
 export function t(i18n: I18n): {
   (literals: TemplateStringsArray, ...placeholders: any[]): string
@@ -209,6 +213,6 @@ export function defineMessage(
 
 /**
  * Define a message for later use
- * Alias for {@see defineMessage}
+ * Alias for {@link defineMessage}
  */
 export const msg: typeof defineMessage

--- a/website/docs/ref/macro.mdx
+++ b/website/docs/ref/macro.mdx
@@ -161,10 +161,6 @@ const message = i18n._(
 
 Optionally, a custom `i18n` instance can be passed that can be used instead of the global instance:
 
-:::note
-Deprecated in V5, would be removed in v6
-:::
-
 ```jsx
 import { t } from "@lingui/core/macro";
 import { i18nCustom } from "./lingui";

--- a/website/docs/ref/macro.mdx
+++ b/website/docs/ref/macro.mdx
@@ -161,6 +161,10 @@ const message = i18n._(
 
 Optionally, a custom `i18n` instance can be passed that can be used instead of the global instance:
 
+:::note
+Deprecated in V5, would be removed in v6
+:::
+
 ```jsx
 import { t } from "@lingui/core/macro";
 import { i18nCustom } from "./lingui";

--- a/website/docs/releases/migration-5.md
+++ b/website/docs/releases/migration-5.md
@@ -200,14 +200,18 @@ The structure of compiled messages has been changed to make them more predictabl
 
 You'll need to [re-compile](/docs/ref/cli.md#compile) your messages in the new format.
 
-## Deprecations and Removals
+## Deprecations
 
-- Removed the deprecated `isTranslated` prop from the React `Trans` component.
-- Removed support of the module path strings in `LinguiConfig.extractors` property. Please pass extractor object directly.
+In this release, we've removed some deprecated features and introduced new deprecations.
 
-### Using a Custom i18n Instance with the `t` Macro is Deprecated
+### Previous Deprecations Removed
 
-When you use the global `t` macro from `@lingui/macro`, it automatically relies on the global `i18n` instance. If you want to use a custom `i18n` instance, you could pass it directly to the `t` macro like this:
+- Removed the `isTranslated` prop from the React `Trans` component.
+- Removed support of the module path strings in `LinguiConfig.extractors` property. Pass the extractor object directly.
+
+### New Deprecations
+
+Using a custom `i18n` instance with the `t` macro is deprecated. When you use the global `t` macro from `@lingui/macro`, it automatically relies on the global `i18n` instance. If you want to use a custom `i18n` instance, you could pass it directly to the `t` macro like this:
 
 ```js
 import { t } from "@lingui/macro";
@@ -225,6 +229,6 @@ i18n._(msg(`Hello!`));
 
 This approach is neither better nor worse; it simply offers a different way to achieve the same result.
 
-From a technical perspective, supporting the custom i18n instance with the `t` macro required extra handling in Lingui's plugins for Babel, SWC, and ESLint, which introduced unnecessary complexity and maintenance overhead.
+From a technical perspective, supporting the custom `i18n` instance with the `t` macro required extra handling in Lingui's plugins for Babel, SWC, and ESLint, which introduced unnecessary complexity and maintenance overhead.
 
-As a result, using a custom i18n instance with the `t` macro has been deprecated. To assist with the transition, an automatic migration is available using [GritQL](https://gist.github.com/timofei-iatsenko/876706f265d725d0aac01018f1812b39).
+As a result, using a custom `i18n` instance with the `t` macro has been deprecated. To assist with the transition, an automatic migration is available using [GritQL](https://gist.github.com/timofei-iatsenko/876706f265d725d0aac01018f1812b39).

--- a/website/docs/releases/migration-5.md
+++ b/website/docs/releases/migration-5.md
@@ -204,3 +204,27 @@ You'll need to [re-compile](/docs/ref/cli.md#compile) your messages in the new f
 
 - Removed the deprecated `isTranslated` prop from the React `Trans` component.
 - Removed support of the module path strings in `LinguiConfig.extractors` property. Please pass extractor object directly.
+
+### Using a Custom i18n Instance with the `t` Macro is Deprecated
+
+When you use the global `t` macro from `@lingui/macro`, it automatically relies on the global `i18n` instance. If you want to use a custom `i18n` instance, you could pass it directly to the `t` macro like this:
+
+```js
+import { t } from "@lingui/macro";
+
+t(i18n)`Hello!`;
+```
+
+However, as Lingui evolved, an alternative approach was introduced using the `msg` macro:
+
+```js
+import { msg } from "@lingui/macro";
+
+i18n._(msg(`Hello!`));
+```
+
+This approach is neither better nor worse; it simply offers a different way to achieve the same result.
+
+From a technical perspective, supporting the custom i18n instance with the `t` macro required extra handling in Lingui's plugins for Babel, SWC, and ESLint, which introduced unnecessary complexity and maintenance overhead.
+
+As a result, using a custom i18n instance with the `t` macro has been deprecated. To assist with the transition, an automatic migration is available using [GritQL](https://gist.github.com/timofei-iatsenko/876706f265d725d0aac01018f1812b39).


### PR DESCRIPTION
# Description

As stated in the migration doc. There few ways to achieve the same result, it's better to stick with the one for consistency. As a benefit we can remove significant layer of complexity from SWC / babel / Eslint integrations. 
 
I've created a GritQL migration and test in the studio only. I don't know how to correctly run this migration in the users codebase, once i figure it out i will update gist or the doc. 

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Examples update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
