### PR TITLE
docs: introducing Lingui JS Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![Code Coverage][Badge-Coverage]][Coverage]
 [![PRs Welcome][Badge-PRWelcome]][PRWelcome]
 [![Join the community on Discord][Badge-Discord]][Discord]
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Lingui%20JS%20Guru-006BFF)](https://gurubase.io/g/lingui-js)
 
 [**Documentation**][Documentation] · [**Quickstart**](#quickstart) · [**Example**](#example) · [**Support**](#support) · [**Contribute**](#contribute) · [**License**](#license)
 </div>

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Code Coverage][Badge-Coverage]][Coverage]
 [![PRs Welcome][Badge-PRWelcome]][PRWelcome]
 [![Join the community on Discord][Badge-Discord]][Discord]
-[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Lingui%20JS%20Guru-006BFF)](https://gurubase.io/g/lingui-js)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Lingui%20JS%20Guru-006BFF?style=flat-square)](https://gurubase.io/g/lingui-js)
 
 [**Documentation**][Documentation] · [**Quickstart**](#quickstart) · [**Example**](#example) · [**Support**](#support) · [**Contribute**](#contribute) · [**License**](#license)
 </div>

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
 [![Code Coverage][Badge-Coverage]][Coverage]
 [![PRs Welcome][Badge-PRWelcome]][PRWelcome]
 [![Join the community on Discord][Badge-Discord]][Discord]
-[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Lingui%20JS%20Guru-006BFF?style=flat-square)](https://gurubase.io/g/lingui-js)
 
 [**Documentation**][Documentation] · [**Quickstart**](#quickstart) · [**Example**](#example) · [**Support**](#support) · [**Contribute**](#contribute) · [**License**](#license)
 </div>
@@ -105,6 +104,7 @@ If you are having issues, please let us know.
 - Join us on [Discord](https://discord.gg/gFWwAYnMtA) to chat with the community.
 - Ask questions on [StackOverflow](https://stackoverflow.com/questions/ask?tags=linguijs) and mark it with [Lingui](https://stackoverflow.com/questions/tagged/linguijs) tag.
 - If something doesn't work as documented, documentation is missing or if you just want to suggest a new feature, [create an issue][Issues].
+- You can also [Ask Lingui JS Guru](https://gurubase.io/g/lingui-js), it is a Lingui JS focused AI to answer your questions.
 
 ## Contribute
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Lingui JS Guru](https://gurubase.io/g/lingui-js) to Gurubase. Lingui JS Guru uses the data from this repo and data from the [docs](https://lingui.dev) to answer questions by leveraging the LLM.

In this PR, I showcased the "Lingui JS Guru", which highlights that Lingui JS now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Lingui JS Guru in Gurubase, just let me know that's totally fine.
