### PR TITLE
feat: add ph() and explicit labels for placeholders

### DIFF
--- a/packages/babel-plugin-lingui-macro/src/constants.ts
+++ b/packages/babel-plugin-lingui-macro/src/constants.ts
@@ -21,6 +21,7 @@ export enum JsMacroName {
   defineMessage = "defineMessage",
   arg = "arg",
   useLingui = "useLingui",
+  ph = "ph",
 }
 
 export enum JsxMacroName {

--- a/packages/babel-plugin-lingui-macro/src/index.ts
+++ b/packages/babel-plugin-lingui-macro/src/index.ts
@@ -196,6 +196,8 @@ export default function ({
                     stripMessageProp: shouldStripMessageProp(
                       state.opts as LinguiPluginOpts
                     ),
+                    isLinguiIdentifier: (node: Identifier, macro) =>
+                      isLinguiIdentifier(path, node, macro),
                   }
                 )
 

--- a/packages/babel-plugin-lingui-macro/src/macroJsAst.ts
+++ b/packages/babel-plugin-lingui-macro/src/macroJsAst.ts
@@ -301,10 +301,6 @@ export function expressionToArgument(
   if (t.isIdentifier(exp)) {
     return exp.name
   }
-
-  if (t.isStringLiteral(exp)) {
-    return exp.value
-  }
   return String(ctx.getExpressionIndex())
 }
 

--- a/packages/babel-plugin-lingui-macro/src/macroJsAst.ts
+++ b/packages/babel-plugin-lingui-macro/src/macroJsAst.ts
@@ -254,6 +254,9 @@ export function tokenizeExpression(
   node: Node | Expression,
   ctx: MacroJsContext
 ): ArgToken {
+  if (t.isTSAsExpression(node)) {
+    return tokenizeExpression(node.expression, ctx)
+  }
   if (t.isObjectExpression(node)) {
     return tokenizeLabeledExpression(node, ctx)
   } else if (

--- a/packages/babel-plugin-lingui-macro/src/macroJsAst.ts
+++ b/packages/babel-plugin-lingui-macro/src/macroJsAst.ts
@@ -1,16 +1,16 @@
 import * as t from "@babel/types"
 import {
-  ObjectExpression,
+  CallExpression,
   Expression,
-  TemplateLiteral,
   Identifier,
   Node,
-  CallExpression,
-  StringLiteral,
+  ObjectExpression,
   ObjectProperty,
+  StringLiteral,
+  TemplateLiteral,
 } from "@babel/types"
-import { MsgDescriptorPropKey, JsMacroName } from "./constants"
-import { Token, TextToken, ArgToken } from "./icu"
+import { JsMacroName, MsgDescriptorPropKey } from "./constants"
+import { ArgToken, TextToken, Token } from "./icu"
 import { createMessageDescriptorFromTokens } from "./messageDescriptorUtils"
 import { makeCounter } from "./utils"
 
@@ -224,10 +224,52 @@ export function tokenizeChoiceComponent(
   return token
 }
 
+function tokenizeLabeledExpression(
+  node: ObjectExpression,
+  ctx: MacroJsContext
+): ArgToken {
+  if (node.properties.length > 1) {
+    throw new Error(
+      "Incorrect usage, expected exactly one property as `{variableName: variableValue}`"
+    )
+  }
+
+  // assume this is labeled expression, {label: value}
+  const property = node.properties[0]
+
+  if (t.isProperty(property) && t.isIdentifier(property.key)) {
+    return {
+      type: "arg",
+      name: expressionToArgument(property.key, ctx),
+      value: property.value as Expression,
+    }
+  } else {
+    throw new Error(
+      "Incorrect usage of a labeled expression. Expected to have one object property with property key as identifier"
+    )
+  }
+}
+
 export function tokenizeExpression(
   node: Node | Expression,
   ctx: MacroJsContext
 ): ArgToken {
+  if (t.isObjectExpression(node)) {
+    return tokenizeLabeledExpression(node, ctx)
+  } else if (
+    t.isCallExpression(node) &&
+    isLinguiIdentifier(node.callee, JsMacroName.ph, ctx) &&
+    node.arguments.length > 0
+  ) {
+    if (!t.isObjectExpression(node.arguments[0])) {
+      throw new Error(
+        "Incorrect usage of `ph` macro. First argument should be an ObjectExpression"
+      )
+    }
+
+    return tokenizeLabeledExpression(node.arguments[0], ctx)
+  }
+
   return {
     type: "arg",
     name: expressionToArgument(node as Expression, ctx),
@@ -255,11 +297,12 @@ export function expressionToArgument(
 ): string {
   if (t.isIdentifier(exp)) {
     return exp.name
-  } else if (t.isStringLiteral(exp)) {
-    return exp.value
-  } else {
-    return String(ctx.getExpressionIndex())
   }
+
+  if (t.isStringLiteral(exp)) {
+    return exp.value
+  }
+  return String(ctx.getExpressionIndex())
 }
 
 export function isArgDecorator(node: Node, ctx: MacroJsContext): boolean {

--- a/packages/babel-plugin-lingui-macro/src/macroJsx.test.ts
+++ b/packages/babel-plugin-lingui-macro/src/macroJsx.test.ts
@@ -37,6 +37,7 @@ function createMacro() {
       stripNonEssentialProps: false,
       stripMessageProp: false,
       transImportName: "Trans",
+      isLinguiIdentifier: () => true,
     }
   )
 }

--- a/packages/babel-plugin-lingui-macro/src/macroJsx.ts
+++ b/packages/babel-plugin-lingui-macro/src/macroJsx.ts
@@ -294,7 +294,7 @@ export class MacroJSX {
       )(attr.node)
     })
 
-    const token: Token = {
+    let token: Token = {
       type: "arg",
       format,
       name: null,
@@ -321,10 +321,12 @@ export class MacroJSX {
         | NodePath<JSXExpressionContainer>
 
       if (name === "value") {
-        const exp = value.isLiteral() ? value : value.get("expression")
-
-        token.name = this.expressionToArgument(exp)
-        token.value = exp.node as Expression
+        token = {
+          ...token,
+          ...this.tokenizeExpression(
+            value.isLiteral() ? value : value.get("expression")
+          ),
+        }
       } else if (format !== "select" && name === "offset") {
         // offset is static parameter, so it must be either string or number
         token.options.offset =
@@ -394,11 +396,7 @@ export class MacroJSX {
       },
     })
 
-    return {
-      type: "arg",
-      name: this.expressionToArgument(exp),
-      value: exp.node,
-    }
+    return this.tokenizeExpression(exp)
   }
 
   tokenizeText = (value: string): TextToken => {
@@ -406,12 +404,6 @@ export class MacroJSX {
       type: "text",
       value,
     }
-  }
-
-  expressionToArgument(path: NodePath<Expression | Node>): string {
-    return path.isIdentifier()
-      ? path.node.name
-      : String(this.ctx.getExpressionIndex())
   }
 
   isLinguiComponent = (

--- a/packages/babel-plugin-lingui-macro/test/__snapshots__/js-plural.test.ts.snap
+++ b/packages/babel-plugin-lingui-macro/test/__snapshots__/js-plural.test.ts.snap
@@ -50,6 +50,78 @@ _i18n._(
 
 `;
 
+exports[`Macro with labeled expression as value 1`] = `
+import { plural } from "@lingui/core/macro";
+const a = plural(
+  { count: getCount() },
+  {
+    one: \`# book\`,
+    other: "# books",
+  }
+);
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { i18n as _i18n } from "@lingui/core";
+const a = _i18n._(
+  /*i18n*/
+  {
+    id: "esnaQO",
+    message: "{count, plural, one {# book} other {# books}}",
+    values: {
+      count: getCount(),
+    },
+  }
+);
+
+`;
+
+exports[`Macro with labeled expression as value 2`] = `
+import { plural, ph } from "@lingui/core/macro";
+const a = plural(ph({ count: getCount() }), {
+  one: \`# book\`,
+  other: "# books",
+});
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { i18n as _i18n } from "@lingui/core";
+const a = _i18n._(
+  /*i18n*/
+  {
+    id: "esnaQO",
+    message: "{count, plural, one {# book} other {# books}}",
+    values: {
+      count: getCount(),
+    },
+  }
+);
+
+`;
+
+exports[`Macro with labeled expression with \`as\` expression 1`] = `
+import { plural } from "@lingui/core/macro";
+const a = plural({ count: getCount() } as any, {
+  one: \`# book\`,
+  other: "# books",
+});
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { i18n as _i18n } from "@lingui/core";
+const a = _i18n._(
+  /*i18n*/
+  {
+    id: "esnaQO",
+    message: "{count, plural, one {# book} other {# books}}",
+    values: {
+      count: getCount(),
+    },
+  }
+);
+
+`;
+
 exports[`Macro with offset and exact matches 1`] = `
 import { plural } from "@lingui/core/macro";
 plural(users.length, {

--- a/packages/babel-plugin-lingui-macro/test/__snapshots__/js-t.test.ts.snap
+++ b/packages/babel-plugin-lingui-macro/test/__snapshots__/js-t.test.ts.snap
@@ -494,6 +494,26 @@ _i18n._(
 
 `;
 
+exports[`Variables with \`as\` type casting 1`] = `
+import { t } from "@lingui/core/macro";
+t\`Variable \${{ name } as any}\`;
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { i18n as _i18n } from "@lingui/core";
+_i18n._(
+  /*i18n*/
+  {
+    id: "xRRkAE",
+    message: "Variable {name}",
+    values: {
+      name: name,
+    },
+  }
+);
+
+`;
+
 exports[`Variables with escaped double quotes are correctly formatted 1`] = `
 import { t } from "@lingui/core/macro";
 t\`Variable "name"\`;

--- a/packages/babel-plugin-lingui-macro/test/__snapshots__/js-t.test.ts.snap
+++ b/packages/babel-plugin-lingui-macro/test/__snapshots__/js-t.test.ts.snap
@@ -531,6 +531,66 @@ _i18n._(
 
 `;
 
+exports[`Variables with explicit label 1`] = `
+import { t } from "@lingui/core/macro";
+t\`Variable \${{ name: random() }}\`;
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { i18n as _i18n } from "@lingui/core";
+_i18n._(
+  /*i18n*/
+  {
+    id: "xRRkAE",
+    message: "Variable {name}",
+    values: {
+      name: random(),
+    },
+  }
+);
+
+`;
+
+exports[`Variables with explicit label, shortcut syntax 1`] = `
+import { t } from "@lingui/core/macro";
+t\`Variable \${{ name }}\`;
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { i18n as _i18n } from "@lingui/core";
+_i18n._(
+  /*i18n*/
+  {
+    id: "xRRkAE",
+    message: "Variable {name}",
+    values: {
+      name: name,
+    },
+  }
+);
+
+`;
+
+exports[`Variables with explicit ph helper 1`] = `
+import { t, ph } from "@lingui/core/macro";
+t\`Variable \${ph({ name: random() })}\`;
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { i18n as _i18n } from "@lingui/core";
+_i18n._(
+  /*i18n*/
+  {
+    id: "xRRkAE",
+    message: "Variable {name}",
+    values: {
+      name: random(),
+    },
+  }
+);
+
+`;
+
 exports[`should correctly process nested macro when referenced from different imports 1`] = `
 import { t } from "@lingui/core/macro";
 import { plural } from "@lingui/core/macro";

--- a/packages/babel-plugin-lingui-macro/test/__snapshots__/jsx-plural.test.ts.snap
+++ b/packages/babel-plugin-lingui-macro/test/__snapshots__/jsx-plural.test.ts.snap
@@ -261,3 +261,62 @@ import { Trans as _Trans } from "@lingui/react";
 />;
 
 `;
+
+exports[`With labeled expression as value 1`] = `
+import { Plural } from "@lingui/react/macro";
+<Plural
+  value={{ count: getCount() }}
+  one={"oneText"}
+  other={<a href="/more">A lot of them</a>}
+/>;
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { Trans as _Trans } from "@lingui/react";
+<_Trans
+  {
+    /*i18n*/
+    ...{
+      id: "blU5AK",
+      message: "{count, plural, one {oneText} other {<0>A lot of them</0>}}",
+      values: {
+        count: getCount(),
+      },
+      components: {
+        0: <a href="/more" />,
+      },
+    }
+  }
+/>;
+
+`;
+
+exports[`With labeled expression as value with ph 1`] = `
+import { Plural } from "@lingui/react/macro";
+import { ph } from "@lingui/core/macro";
+<Plural
+  value={ph({ count: getCount() })}
+  one={"oneText"}
+  other={<a href="/more">A lot of them</a>}
+/>;
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { Trans as _Trans } from "@lingui/react";
+<_Trans
+  {
+    /*i18n*/
+    ...{
+      id: "blU5AK",
+      message: "{count, plural, one {oneText} other {<0>A lot of them</0>}}",
+      values: {
+        count: getCount(),
+      },
+      components: {
+        0: <a href="/more" />,
+      },
+    }
+  }
+/>;
+
+`;

--- a/packages/babel-plugin-lingui-macro/test/__snapshots__/jsx-trans.test.ts.snap
+++ b/packages/babel-plugin-lingui-macro/test/__snapshots__/jsx-trans.test.ts.snap
@@ -336,6 +336,33 @@ import { Trans as _Trans } from "@lingui/react";
 
 `;
 
+exports[`Labeled expressions with \`as\` expression 1`] = `
+import { Trans } from "@lingui/react/macro";
+import { ph } from "@lingui/core/macro";
+<Trans>
+  Hi {{ name: getUserName() } as any}, my name is{" "}
+  {{ myName: getMyName() } as any}
+</Trans>;
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { Trans as _Trans } from "@lingui/react";
+<_Trans
+  {
+    /*i18n*/
+    ...{
+      id: "eqk/cH",
+      message: "Hi {name}, my name is {myName}",
+      values: {
+        name: getUserName(),
+        myName: getMyName(),
+      },
+    }
+  }
+/>;
+
+`;
+
 exports[`Labeled expressions with ph helper 1`] = `
 import { Trans } from "@lingui/react/macro";
 import { ph } from "@lingui/core/macro";

--- a/packages/babel-plugin-lingui-macro/test/__snapshots__/jsx-trans.test.ts.snap
+++ b/packages/babel-plugin-lingui-macro/test/__snapshots__/jsx-trans.test.ts.snap
@@ -311,6 +311,57 @@ import { Trans as _Trans } from "@lingui/react";
 
 `;
 
+exports[`Labeled expressions are supported 1`] = `
+import { Trans } from "@lingui/react/macro";
+<Trans>
+  Hi {{ name: getUserName() }}, my name is {{ myName: getMyName() }}
+</Trans>;
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { Trans as _Trans } from "@lingui/react";
+<_Trans
+  {
+    /*i18n*/
+    ...{
+      id: "eqk/cH",
+      message: "Hi {name}, my name is {myName}",
+      values: {
+        name: getUserName(),
+        myName: getMyName(),
+      },
+    }
+  }
+/>;
+
+`;
+
+exports[`Labeled expressions with ph helper 1`] = `
+import { Trans } from "@lingui/react/macro";
+import { ph } from "@lingui/core/macro";
+<Trans>
+  Hi {ph({ name: getUserName() })}, my name is {ph({ myName: getMyName() })}
+</Trans>;
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { Trans as _Trans } from "@lingui/react";
+<_Trans
+  {
+    /*i18n*/
+    ...{
+      id: "eqk/cH",
+      message: "Hi {name}, my name is {myName}",
+      values: {
+        name: getUserName(),
+        myName: getMyName(),
+      },
+    }
+  }
+/>;
+
+`;
+
 exports[`Preserve custom ID (literal expression) 1`] = `
 import { Trans } from "@lingui/react/macro";
 <Trans id={"msg.hello"}>Hello World</Trans>;

--- a/packages/babel-plugin-lingui-macro/test/js-defineMessage.test.ts
+++ b/packages/babel-plugin-lingui-macro/test/js-defineMessage.test.ts
@@ -1,4 +1,5 @@
 import { macroTester } from "./macroTester"
+describe.skip("", () => {})
 
 macroTester({
   cases: [

--- a/packages/babel-plugin-lingui-macro/test/js-plural.test.ts
+++ b/packages/babel-plugin-lingui-macro/test/js-plural.test.ts
@@ -1,4 +1,5 @@
 import { macroTester } from "./macroTester"
+describe.skip("", () => {})
 
 macroTester({
   cases: [
@@ -43,6 +44,39 @@ macroTester({
           0: "No books",
           1: "1 book",
           other: someOtherExp
+        });
+      `,
+    },
+    {
+      name: "Macro with labeled expression as value",
+      code: `
+        import { plural } from '@lingui/core/macro'
+        const a = plural({ count: getCount() }, {
+          "one": \`# book\`,
+          other: "# books"
+        });
+      `,
+    },
+
+    {
+      name: "Macro with labeled expression as value",
+      code: `
+        import { plural, ph } from '@lingui/core/macro'
+        const a = plural(ph({ count: getCount() }), {
+          "one": \`# book\`,
+          other: "# books"
+        });
+      `,
+    },
+
+    {
+      useTypescriptPreset: true,
+      name: "Macro with labeled expression with `as` expression",
+      code: `
+        import { plural } from '@lingui/core/macro'
+        const a = plural({ count: getCount() } as any, {
+          "one": \`# book\`,
+          other: "# books"
         });
       `,
     },

--- a/packages/babel-plugin-lingui-macro/test/js-select.test.ts
+++ b/packages/babel-plugin-lingui-macro/test/js-select.test.ts
@@ -1,4 +1,5 @@
 import { macroTester } from "./macroTester"
+describe.skip("", () => {})
 
 macroTester({
   cases: [

--- a/packages/babel-plugin-lingui-macro/test/js-selectOrdinal.test.ts
+++ b/packages/babel-plugin-lingui-macro/test/js-selectOrdinal.test.ts
@@ -1,4 +1,5 @@
 import { macroTester } from "./macroTester"
+describe.skip("", () => {})
 
 macroTester({
   cases: [

--- a/packages/babel-plugin-lingui-macro/test/js-t.test.ts
+++ b/packages/babel-plugin-lingui-macro/test/js-t.test.ts
@@ -100,6 +100,15 @@ macroTester({
     `,
     },
     {
+      useTypescriptPreset: true,
+      name: "Variables with `as` type casting",
+      code: `
+        import { t } from '@lingui/core/macro';
+     
+        t\`Variable \${{name} as any}\`;
+    `,
+    },
+    {
       name: "Newlines are preserved",
       code: `
         import { t } from '@lingui/core/macro';

--- a/packages/babel-plugin-lingui-macro/test/js-t.test.ts
+++ b/packages/babel-plugin-lingui-macro/test/js-t.test.ts
@@ -76,6 +76,30 @@ macroTester({
 `,
     },
     {
+      name: "Variables with explicit label",
+      code: `
+        import { t } from '@lingui/core/macro';
+      
+        t\`Variable \${{name: random()}}\`;
+    `,
+    },
+    {
+      name: "Variables with explicit label, shortcut syntax",
+      code: `
+        import { t } from '@lingui/core/macro';
+      
+        t\`Variable \${{name}}\`;
+    `,
+    },
+    {
+      name: "Variables with explicit ph helper",
+      code: `
+        import { t, ph } from '@lingui/core/macro';
+     
+        t\`Variable \${ph({name: random()})}\`;
+    `,
+    },
+    {
       name: "Newlines are preserved",
       code: `
         import { t } from '@lingui/core/macro';

--- a/packages/babel-plugin-lingui-macro/test/jsx-plural.test.ts
+++ b/packages/babel-plugin-lingui-macro/test/jsx-plural.test.ts
@@ -122,6 +122,30 @@ macroTester({
       `,
     },
     {
+      name: "With labeled expression as value",
+      code: `
+        import { Plural } from '@lingui/react/macro';
+        <Plural
+          value={{count: getCount()}}
+          one={"oneText"}
+          other={<a href="/more">A lot of them</a>}
+        />;
+      `,
+    },
+    {
+      name: "With labeled expression as value with ph",
+      code: `
+        import { Plural } from '@lingui/react/macro';
+        import { ph } from '@lingui/core/macro';
+        <Plural
+          value={ph({count: getCount()})}
+          one={"oneText"}
+          other={<a href="/more">A lot of them</a>}
+        />;
+      `,
+    },
+
+    {
       filename: `jsx-plural-select-nested.js`,
     },
   ],

--- a/packages/babel-plugin-lingui-macro/test/jsx-select.test.ts
+++ b/packages/babel-plugin-lingui-macro/test/jsx-select.test.ts
@@ -1,4 +1,5 @@
 import { macroTester } from "./macroTester"
+describe.skip("", () => {})
 
 macroTester({
   cases: [
@@ -27,6 +28,7 @@ macroTester({
       `,
     },
     {
+      only: true,
       name: "Select should support JSX elements in cases",
       code: `
         import { Select, Trans } from '@lingui/react/macro';

--- a/packages/babel-plugin-lingui-macro/test/jsx-selectOrdinal.test.ts
+++ b/packages/babel-plugin-lingui-macro/test/jsx-selectOrdinal.test.ts
@@ -1,4 +1,5 @@
 import { macroTester } from "./macroTester"
+describe.skip("", () => {})
 
 macroTester({
   cases: [

--- a/packages/babel-plugin-lingui-macro/test/jsx-trans.test.ts
+++ b/packages/babel-plugin-lingui-macro/test/jsx-trans.test.ts
@@ -81,6 +81,15 @@ macroTester({
       `,
     },
     {
+      useTypescriptPreset: true,
+      name: "Labeled expressions with `as` expression",
+      code: `
+        import { Trans } from '@lingui/react/macro';
+        import { ph } from '@lingui/core/macro';
+        <Trans>Hi {{name: getUserName()} as any}, my name is {{myName: getMyName()} as any}</Trans>;
+      `,
+    },
+    {
       name: "Variables are deduplicated",
       code: `
         import { Trans } from '@lingui/react/macro';

--- a/packages/babel-plugin-lingui-macro/test/jsx-trans.test.ts
+++ b/packages/babel-plugin-lingui-macro/test/jsx-trans.test.ts
@@ -66,6 +66,21 @@ macroTester({
       `,
     },
     {
+      name: "Labeled expressions are supported",
+      code: `
+        import { Trans } from '@lingui/react/macro';
+        <Trans>Hi {{name: getUserName()}}, my name is {{myName: getMyName()}}</Trans>;
+      `,
+    },
+    {
+      name: "Labeled expressions with ph helper",
+      code: `
+        import { Trans } from '@lingui/react/macro';
+        import { ph } from '@lingui/core/macro';
+        <Trans>Hi {ph({name: getUserName()})}, my name is {ph({myName: getMyName()})}</Trans>;
+      `,
+    },
+    {
       name: "Variables are deduplicated",
       code: `
         import { Trans } from '@lingui/react/macro';

--- a/packages/core/macro/__typetests__/index.test-d.tsx
+++ b/packages/core/macro/__typetests__/index.test-d.tsx
@@ -160,6 +160,25 @@ expectType<string>(
   })
 )
 
+// with labeled value
+expectType<string>(
+  plural(
+    { count: 5 },
+    {
+      one: "...",
+      other: "...",
+    }
+  )
+)
+
+// with labeled value with ph helper
+expectType<string>(
+  plural(ph({ count: 5 }), {
+    one: "...",
+    other: "...",
+  })
+)
+
 expectType<string>(
   plural(5, {
     // @ts-expect-error: should accept only strings
@@ -224,6 +243,25 @@ expectType<string>(
   })
 )
 
+// with labeled value
+expectType<string>(
+  selectOrdinal(
+    { count: 5 },
+    {
+      one: "...",
+      other: "...",
+    }
+  )
+)
+
+// with labeled value with ph helper
+expectType<string>(
+  selectOrdinal(ph({ count: 5 }), {
+    one: "...",
+    other: "...",
+  })
+)
+
 ///////////////////
 //// Select
 ///////////////////
@@ -248,6 +286,26 @@ expectType<string>(
     male: "he",
     female: "she",
     other: "they",
+  })
+)
+
+// with labeled value
+expectType<string>(
+  select(
+    // @ts-expect-error value could be strings only
+    { count: 5 },
+    {
+      male: "...",
+      other: "...",
+    }
+  )
+)
+
+// with labeled value with ph helper
+expectType<string>(
+  select(ph({ value: "one" }), {
+    male: "...",
+    other: "...",
   })
 )
 

--- a/packages/core/macro/__typetests__/index.test-d.tsx
+++ b/packages/core/macro/__typetests__/index.test-d.tsx
@@ -8,14 +8,26 @@ import {
   plural,
   selectOrdinal,
   select,
+  ph,
 } from "@lingui/core/macro"
 
 const name = "Jack"
+const user = { name: "Jack" }
 const i18n: I18n = null
+const numberValue = 2
 
 // simple
 expectType<string>(t`Hello world`)
 expectType<string>(t`Hello ${name}`)
+
+// with labeled expression
+expectType<string>(t`Hello ${{ name: user.name }}`)
+
+// with ph labeled expression
+expectType<string>(t`Hello ${ph({ name: user.name })}`)
+
+// allow numbers
+expectType<string>(t`Hello ${numberValue}`)
 
 // with custom i18n
 expectType<string>(t(i18n)`With custom i18n instance`)
@@ -62,6 +74,26 @@ expectType<string>(
     message: "Hello world",
   })
 )
+
+///
+// defineMessage
+///
+
+// simple
+expectType<MessageDescriptor>(msg`Hello ${name}`)
+expectType<MessageDescriptor>(defineMessage`Hello ${name}`)
+
+// with labeled expression
+expectType<MessageDescriptor>(msg`Hello ${{ name: user.name }}`)
+expectType<MessageDescriptor>(defineMessage`Hello ${{ name: user.name }}`)
+
+// with ph labeled expression
+expectType<MessageDescriptor>(msg`Hello ${ph({ name: user.name })}`)
+expectType<MessageDescriptor>(defineMessage`Hello ${ph({ name: user.name })}`)
+
+// allow numbers
+expectType<MessageDescriptor>(msg`Hello ${numberValue}`)
+expectType<MessageDescriptor>(defineMessage`Hello ${numberValue}`)
 
 expectType<MessageDescriptor>(
   defineMessage({

--- a/packages/core/macro/index.d.ts
+++ b/packages/core/macro/index.d.ts
@@ -38,7 +38,7 @@ type MacroMessageDescriptor = (
  * const message = t({
  *   id: "msg.hello",
  *   comment: "Greetings at the homepage",
- *   message: `Hello ${name}`,
+ *   message: `Hello ${{name}}`,
  * });
  * ```
  *
@@ -55,8 +55,11 @@ type MacroMessageDescriptor = (
  */
 export function t(descriptor: MacroMessageDescriptor): string
 
-export type LabeledExpression = Record<string, string | number>
-export type MessagePlaceholder = string | number | LabeledExpression
+export type LabeledExpression<T> = Record<string, T>
+export type MessagePlaceholder =
+  | string
+  | number
+  | LabeledExpression<string | number>
 
 /**
  * Translates a template string using the global I18n instance
@@ -64,7 +67,7 @@ export type MessagePlaceholder = string | number | LabeledExpression
  * @example
  * ```
  * import { t } from "@lingui/core/macro";
- * const message = t`Hello ${name}`;
+ * const message = t`Hello ${{name}}`;
  * ```
  */
 export function t(
@@ -81,9 +84,9 @@ export function t(
  * import { I18n } from "@lingui/core";
  * const i18n = new I18n({
  *   locale: "nl",
- *   messages: { "Hello {name}": "Hallo {name}" },
+ *   messages: { "Hello {{name}}": "Hallo {{name}}" },
  * });
- * const message = t(i18n)`Hello ${name}`;
+ * const message = t(i18n)`Hello ${{name}}`;
  * ```
  *
  * @example
@@ -92,13 +95,13 @@ export function t(
  * import { I18n } from "@lingui/core";
  * const i18n = new I18n({
  *   locale: "nl",
- *   messages: { "Hello {name}": "Hallo {name}" },
+ *   messages: { "Hello {{name}}": "Hallo {{name}}" },
  * });
- * const message = t(i18n)({ message: `Hello ${name}` });
+ * const message = t(i18n)({ message: `Hello ${{name}}` });
  * ```
  *
  * @deprecated in v5, would be removed in v6.
- * Please use `` i18n._(msg`Hello ${name}`) `` instead
+ * Please use `` i18n._(msg`Hello ${{name}}`) `` instead
  *
  */
 export function t(i18n: I18n): {
@@ -112,7 +115,7 @@ export function t(i18n: I18n): {
  * @example
  * ```
  * import { plural } from "@lingui/core/macro";
- * const message = plural(count, {
+ * const message = plural({count}, {
  *   one: "# Book",
  *   other: "# Books",
  * });
@@ -121,7 +124,10 @@ export function t(i18n: I18n): {
  * @param value Determines the plural form
  * @param options Object with available plural forms
  */
-export function plural(value: number | string, options: ChoiceOptions): string
+export function plural(
+  value: number | string | LabeledExpression<number | string>,
+  options: ChoiceOptions
+): string
 
 /**
  * Pluralize a message using ordinal forms
@@ -132,7 +138,7 @@ export function plural(value: number | string, options: ChoiceOptions): string
  * @example
  * ```
  * import { selectOrdinal } from "@lingui/core/macro";
- * const message = selectOrdinal(count, {
+ * const message = selectOrdinal({count}, {
  *    one: "#st",
  *    two: "#nd",
  *    few: "#rd",
@@ -144,7 +150,7 @@ export function plural(value: number | string, options: ChoiceOptions): string
  * @param options Object with available plural forms
  */
 export function selectOrdinal(
-  value: number | string,
+  value: number | string | LabeledExpression<number | string>,
   options: ChoiceOptions
 ): string
 
@@ -164,7 +170,7 @@ type SelectOptions = {
  * @example
  * ```
  * import { select } from "@lingui/core/macro";
- * const message = select(gender, {
+ * const message = select({gender}, {
  *    male: "he",
  *    female: "she",
  *    other: "they",
@@ -174,7 +180,10 @@ type SelectOptions = {
  * @param value The key of choices to use
  * @param choices
  */
-export function select(value: string, choices: SelectOptions): string
+export function select(
+  value: string | LabeledExpression<string>,
+  choices: SelectOptions
+): string
 
 /**
  * Define a message for later use
@@ -187,7 +196,7 @@ export function select(value: string, choices: SelectOptions): string
  * import { defineMessage } from "@lingui/core/macro";
  * const message = defineMessage({
  *    comment: "Greetings on the welcome page",
- *    message: `Welcome, ${name}!`,
+ *    message: `Welcome, ${{name}}!`,
  * });
  * ```
  *
@@ -203,10 +212,10 @@ export function defineMessage(
  * @example
  * ```
  * import { defineMessage, msg } from "@lingui/core/macro";
- * const message = defineMessage`Hello ${name}`;
+ * const message = defineMessage`Hello ${{name}}`;
  *
  * // or using shorter version
- * const message = msg`Hello ${name}`;
+ * const message = msg`Hello ${{name}}`;
  * ```
  */
 export function defineMessage(

--- a/packages/core/macro/index.d.ts
+++ b/packages/core/macro/index.d.ts
@@ -55,6 +55,9 @@ type MacroMessageDescriptor = (
  */
 export function t(descriptor: MacroMessageDescriptor): string
 
+export type LabeledExpression = Record<string, string | number>
+export type MessagePlaceholder = string | number | LabeledExpression
+
 /**
  * Translates a template string using the global I18n instance
  *
@@ -66,7 +69,7 @@ export function t(descriptor: MacroMessageDescriptor): string
  */
 export function t(
   literals: TemplateStringsArray,
-  ...placeholders: any[]
+  ...placeholders: MessagePlaceholder[]
 ): string
 
 /**
@@ -208,7 +211,7 @@ export function defineMessage(
  */
 export function defineMessage(
   literals: TemplateStringsArray,
-  ...placeholders: any[]
+  ...placeholders: MessagePlaceholder[]
 ): MessageDescriptor
 
 /**
@@ -216,3 +219,8 @@ export function defineMessage(
  * Alias for {@link defineMessage}
  */
 export const msg: typeof defineMessage
+
+/**
+ * Helps to define a name for a variable in the message
+ */
+export function ph(def: LabeledExpression): string

--- a/packages/react/macro/__typetests__/index.test-d.tsx
+++ b/packages/react/macro/__typetests__/index.test-d.tsx
@@ -81,6 +81,9 @@ m = <Plural value={5} one={<Trans>...</Trans>} other={<Trans>...</Trans>} />
 // value as string
 m = <Plural value={"5"} one={"..."} other={"..."} />
 
+// with labeled value
+m = <Plural value={{ count: 5 }} one={"..."} other={"..."} />
+
 // @ts-expect-error: `other` should always be present
 m = <Plural value={"5"} one={"..."} />
 
@@ -133,6 +136,8 @@ m = <Select value={gender} _male="..." _female="..." other={"..."} />
 
 // @ts-expect-error: exact cases should be prefixed with underscore
 m = <Select value={gender} male="..." female=".." other={"..."} />
+
+m = <Select value={{ gender }} _male="..." _female=".." other={"..."} />
 
 // should support JSX in props
 m = (

--- a/packages/react/macro/__typetests__/index.test-d.tsx
+++ b/packages/react/macro/__typetests__/index.test-d.tsx
@@ -9,8 +9,12 @@ import {
   useLingui,
 } from "@lingui/react/macro"
 import React from "react"
+import { ph } from "@lingui/core/macro"
 
 const gender = "male"
+const user = {
+  name: "John",
+}
 let m: any
 
 ///////////////////
@@ -27,6 +31,29 @@ m = (
 // @ts-expect-error: children are required here
 m = <Trans id="custom.id" comment="comment" context="context" />
 
+m = <Trans>Hello {{ username: user.name }}</Trans>
+
+m = (
+  <Trans>
+    Hello <strong>{ph({ name: user.name })}</strong>
+  </Trans>
+)
+m = (
+  <Trans>
+    Hello <strong>{ph({ name: user.name })}</strong>
+  </Trans>
+)
+m = (
+  <Trans>
+    Hello <strong>{user.name}</strong>
+  </Trans>
+)
+m = (
+  <Trans>
+    {/* @ts-expect-error: use of {} without ph() helper is not possible in the children components */}
+    Hello <strong>{{ name: user.name }}</strong>
+  </Trans>
+)
 ///////////////////
 //// JSX Plural
 ///////////////////

--- a/packages/react/macro/index.d.ts
+++ b/packages/react/macro/index.d.ts
@@ -1,6 +1,9 @@
 import type { ReactNode, VFC, FC } from "react"
 import type { TransRenderCallbackOrComponent, I18nContext } from "@lingui/react"
-import type { MacroMessageDescriptor } from "@lingui/core/macro"
+import type {
+  MacroMessageDescriptor,
+  LabeledExpression,
+} from "@lingui/core/macro"
 
 type CommonProps = TransRenderCallbackOrComponent & {
   id?: string
@@ -8,8 +11,9 @@ type CommonProps = TransRenderCallbackOrComponent & {
   context?: string
 }
 
+type TransChildren = ReactNode | LabeledExpression
 type TransProps = {
-  children: ReactNode
+  children: TransChildren | TransChildren[]
 } & CommonProps
 
 type PluralChoiceProps = {

--- a/packages/react/macro/index.d.ts
+++ b/packages/react/macro/index.d.ts
@@ -11,13 +11,13 @@ type CommonProps = TransRenderCallbackOrComponent & {
   context?: string
 }
 
-type TransChildren = ReactNode | LabeledExpression
+type TransChildren = ReactNode | LabeledExpression<string | number>
 type TransProps = {
   children: TransChildren | TransChildren[]
 } & CommonProps
 
 type PluralChoiceProps = {
-  value: string | number
+  value: string | number | LabeledExpression<string | number>
   /** Offset of value when calculating plural forms */
   offset?: number
   zero?: ReactNode
@@ -33,7 +33,7 @@ type PluralChoiceProps = {
 } & CommonProps
 
 type SelectChoiceProps = {
-  value: string
+  value: string | LabeledExpression<string | number>
   /** Catch-all option */
   other: ReactNode
   [option: `_${string}`]: ReactNode


### PR DESCRIPTION
# Description

Adds a way to give an explicit name for placeholders in the messages. There are two syntaxes supported: 

```js
import {t} from "@lingui/core/macro";
t`Hello ${{name: getUsername()}}`
```

And with explicit `ph` helper:

```js
import {ph, t} from "@lingui/core/macro";
t`Hello ${ph({name: getUsername()})}`
```

Shortcut syntax is also supported: 

```js
import {t} from "@lingui/core/macro";
const name = "World"
t`Hello ${{name}}`
```

plural / select / selectOrdinal:

```js
import {t, plural} from "@lingui/core/macro";
t`We have ${plural({count: getDevelopersCount()}, {one: "# developer", "# developers"})}`
```

In the JSX

```js
import {Trans} from "@lingui/react/macro";

<Trans>Hello {{name: getUsername()}}</Trans>;
```

```jsx
import { Plural } from "@lingui/react/macro";

<Plural
  value={{ count: getCount() }}
/>
```

Note, that Children type for the Trans component was amended to allow passing an object. However, inner elements in the Trans will not allow that, and the only one way to use is a `ph()` helper macro, which basically a type helper to mitigate this issue. 

```js
import {ph} from "@lingui/core/macro";
import {Trans} from "@lingui/react/macro";

// ❌ this will not work, children of `strong` element does not accept an arbitrary object
<Trans>Hello <strong>{{name: getUsername()}}</strong></Trans>; 

// ✅ with a help of `ph()` macro it will work
<Trans>Hello <strong>{ph({name: getUsername()})}</strong></Trans>; 
```

PS

Actually everything could be covered with `ph()` helper, but i've found syntax without it much easier to write in day to day routine. So i decided to left both of them. For most of cases just `{name: getName()}` and for cases where it doesn't work the `ph`. 

The implementation is almost the same, to support both of the methods it's additional 10 lines of code. 


Let me know what you think about it. 

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
