### PR TITLE
feat(core,message-utils): support date,time format with short/default/long/full and skeleton

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -9,7 +9,7 @@ const tsConfigPathMapping = pathsToModuleNameMapper(
 )
 
 const testMatch = ["**/?(*.)test.(js|ts|tsx)", "**/test/index.(js|ts|tsx)"]
-
+const transformIgnorePatterns = ["node_modules/(?!@messageformat)"]
 /**
  * @type {import('jest').Config}
  */
@@ -38,6 +38,7 @@ module.exports = {
       displayName: "web",
       testEnvironment: "jsdom",
       testMatch,
+      transformIgnorePatterns,
       moduleNameMapper: tsConfigPathMapping,
       roots: ["<rootDir>/packages/react"],
     },
@@ -45,6 +46,7 @@ module.exports = {
       displayName: "universal",
       testEnvironment: "jest-environment-node-single-context",
       testMatch,
+      transformIgnorePatterns,
       moduleNameMapper: tsConfigPathMapping,
       roots: ["<rootDir>/packages/core", "<rootDir>/packages/remote-loader"],
     },
@@ -57,6 +59,7 @@ module.exports = {
         require.resolve("./scripts/jest/stripAnsiSerializer.js"),
       ],
       setupFilesAfterEnv: [require.resolve("./scripts/jest/env.js")],
+      transformIgnorePatterns,
       roots: [
         "<rootDir>/packages/babel-plugin-extract-messages",
         "<rootDir>/packages/babel-plugin-lingui-macro",

--- a/packages/core/src/formats.test.ts
+++ b/packages/core/src/formats.test.ts
@@ -1,33 +1,6 @@
-import { date, number } from "./formats"
+import { number } from "./formats"
 
 describe("@lingui/core/formats", () => {
-  describe("date", () => {
-    it("should support Date as input", () => {
-      expect(date(["en"], new Date(2023, 2, 5))).toBe("3/5/2023")
-    })
-    it("should support iso string as input", () => {
-      expect(date(["en"], new Date(2023, 2, 5).toISOString())).toBe("3/5/2023")
-    })
-
-    it("should pass format options", () => {
-      expect(
-        date(["en"], new Date(2023, 2, 5).toISOString(), { dateStyle: "full" })
-      ).toBe("Sunday, March 5, 2023")
-
-      expect(
-        date(["en"], new Date(2023, 2, 5).toISOString(), {
-          dateStyle: "medium",
-        })
-      ).toBe("Mar 5, 2023")
-    })
-
-    it("should respect passed locale", () => {
-      expect(
-        date(["pl"], new Date(2023, 2, 5).toISOString(), { dateStyle: "full" })
-      ).toBe("niedziela, 5 marca 2023")
-    })
-  })
-
   describe("number", () => {
     it("should pass format options", () => {
       expect(number(["en"], 1000, { style: "currency", currency: "EUR" })).toBe(

--- a/packages/core/src/i18n.test.ts
+++ b/packages/core/src/i18n.test.ts
@@ -444,4 +444,191 @@ describe("I18n", () => {
       This issue may also occur due to a race condition in your initialization logic."
     `)
   })
+
+  describe("ICU date format", () => {
+    const i18n = setupI18n({
+      locale: "fr",
+      messages: { fr: {} },
+    })
+
+    const date = new Date("2014-12-06")
+
+    it("style short", () => {
+      expect(
+        i18n._("It starts on {someDate, date, short}", {
+          someDate: date,
+        })
+      ).toMatchInlineSnapshot(`"It starts on 06/12/2014"`)
+    })
+
+    it("style full", () => {
+      expect(
+        i18n._("It starts on {someDate, date, full}", {
+          someDate: date,
+        })
+      ).toMatchInlineSnapshot(`"It starts on samedi 6 décembre 2014"`)
+    })
+
+    it("style long", () => {
+      expect(
+        i18n._("It starts on {someDate, date, long}", {
+          someDate: date,
+        })
+      ).toMatchInlineSnapshot(`"It starts on 6 décembre 2014"`)
+    })
+
+    it("style default", () => {
+      expect(
+        i18n._("It starts on {someDate, date, default}", {
+          someDate: date,
+        })
+      ).toMatchInlineSnapshot(`"It starts on 6 déc. 2014"`)
+    })
+
+    it("no style", () => {
+      expect(
+        i18n._("It starts on {someDate, date}", {
+          someDate: date,
+        })
+      ).toMatchInlineSnapshot(`"It starts on 6 déc. 2014"`)
+    })
+
+    it("using custom style", () => {
+      expect(
+        i18n._(
+          "It starts on {someDate, date, myStyle}",
+          {
+            someDate: date,
+          },
+          {
+            formats: {
+              myStyle: {
+                day: "numeric",
+              },
+            },
+          }
+        )
+      ).toMatchInlineSnapshot(`"It starts on 6"`)
+    })
+
+    it("using date skeleton", () => {
+      expect(
+        i18n._("It starts on {someDate, date, ::GrMMMdd}", {
+          someDate: date,
+        })
+      ).toMatchInlineSnapshot(`"It starts on 06 déc. 2014 ap. J.-C."`)
+    })
+
+    it("should respect locale", () => {
+      const i18n = setupI18n({
+        locale: "fr",
+        messages: { fr: {}, pl: {} },
+      })
+
+      const msg = "It starts on {someDate, date, long}"
+
+      expect(
+        i18n._(msg, {
+          someDate: date,
+        })
+      ).toMatchInlineSnapshot(`"It starts on 6 décembre 2014"`)
+
+      i18n.activate("pl")
+
+      expect(
+        i18n._(msg, {
+          someDate: date,
+        })
+      ).toMatchInlineSnapshot(`"It starts on 6 grudnia 2014"`)
+    })
+  })
+  describe("ICU time format", () => {
+    const i18n = setupI18n({
+      locale: "fr",
+      messages: { fr: {} },
+    })
+
+    const date = new Date("2014-12-06::17:40 UTC")
+
+    it("style short", () => {
+      expect(
+        i18n._("It starts on {someDate, time, short}", {
+          someDate: date,
+        })
+      ).toMatchInlineSnapshot(`"It starts on 17:40"`)
+    })
+
+    it("style full", () => {
+      expect(
+        i18n._("It starts on {someDate, time, full}", {
+          someDate: date,
+        })
+      ).toMatchInlineSnapshot(`"It starts on 17:40:00 UTC"`)
+    })
+
+    it("style long", () => {
+      expect(
+        i18n._("It starts on {someDate, time, long}", {
+          someDate: date,
+        })
+      ).toMatchInlineSnapshot(`"It starts on 17:40:00 UTC"`)
+    })
+
+    it("style default", () => {
+      expect(
+        i18n._("It starts on {someDate, time, default}", {
+          someDate: date,
+        })
+      ).toMatchInlineSnapshot(`"It starts on 17:40:00"`)
+    })
+
+    it("no style", () => {
+      expect(
+        i18n._("It starts on {someDate, time}", {
+          someDate: date,
+        })
+      ).toMatchInlineSnapshot(`"It starts on 17:40:00"`)
+    })
+
+    it("using custom style", () => {
+      expect(
+        i18n._(
+          "It starts on {someDate, time, myStyle}",
+          {
+            someDate: date,
+          },
+          {
+            formats: {
+              myStyle: {
+                hour: "numeric",
+              },
+            },
+          }
+        )
+      ).toMatchInlineSnapshot(`"It starts on 17 h"`)
+    })
+
+    it("should respect locale", () => {
+      const i18n = setupI18n({
+        locale: "fr",
+        messages: { fr: {}, "en-US": {} },
+      })
+
+      const msg = "It starts on {someDate, time, long}"
+
+      expect(
+        i18n._(msg, {
+          someDate: date,
+        })
+      ).toMatchInlineSnapshot(`"It starts on 17:40:00 UTC"`)
+
+      i18n.activate("en-US")
+
+      expect(
+        i18n._(msg, {
+          someDate: date,
+        })
+      ).toMatchInlineSnapshot(`"It starts on 5:40:00 PM UTC"`)
+    })
+  })
 })

--- a/packages/core/src/interpolate.test.ts
+++ b/packages/core/src/interpolate.test.ts
@@ -144,18 +144,9 @@ describe("interpolate", () => {
 
   describe("Custom format", () => {
     const testVector = [
-      ["en", undefined, "0.1", "10%", "20%", "3/4/2017", "€0.10", "€1.00"],
-      [
-        "fr",
-        undefined,
-        "0,1",
-        "10 %",
-        "20 %",
-        "04/03/2017",
-        "0,10 €",
-        "1,00 €",
-      ],
-      ["fr", "fr-CH", "0,1", "10%", "20%", "04.03.2017", "0.10 €", "1.00 €"],
+      ["en", undefined, "0.1", "10%", "20%", "€0.10", "€1.00"],
+      ["fr", undefined, "0,1", "10 %", "20 %", "0,10 €", "1,00 €"],
+      ["fr", "fr-CH", "0,1", "10%", "20%", "0.10 €", "1.00 €"],
     ] as const
     testVector.forEach((tc) => {
       const [
@@ -164,7 +155,6 @@ describe("interpolate", () => {
         expectedNumber,
         expectedPercent1,
         expectedPercent2,
-        expectedDate,
         expectedCurrency1,
         expectedCurrency2,
       ] = tc
@@ -176,10 +166,6 @@ describe("interpolate", () => {
         const percent = prepare("{value, number, percent}", locale, locales)
         expect(percent({ value: 0.1 })).toEqual(expectedPercent1)
         expect(percent({ value: 0.2 })).toEqual(expectedPercent2)
-
-        const now = new Date("3/4/2017")
-        const date = prepare("{value, date}", locale, locales)
-        expect(date({ value: now })).toEqual(expectedDate)
 
         const formats = {
           currency: {

--- a/packages/core/src/interpolate.ts
+++ b/packages/core/src/interpolate.ts
@@ -1,5 +1,12 @@
 import { CompiledMessage, Formats, Locales, Values } from "./i18n"
-import { date, number, plural, type PluralOptions } from "./formats"
+import {
+  date,
+  DateTimeFormatSize,
+  number,
+  plural,
+  type PluralOptions,
+  time,
+} from "./formats"
 import { isString } from "./essentials"
 import { unraw } from "unraw"
 import { CompiledIcuChoices } from "@lingui/message-utils/compileMessage"
@@ -16,10 +23,10 @@ const getDefaultFormats = (
   const locales = passedLocales || locale
 
   const style = <T extends object>(format: string | T): T => {
-    return typeof format === "object"
-      ? (format as any)
-      : formats[format] || { style: format }
+    if (typeof format === "object") return format as T
+    return formats[format] as T
   }
+
   const replaceOctothorpe = (value: number, message: string): string => {
     const numberFormat = Object.keys(formats).length
       ? style("number")
@@ -48,12 +55,20 @@ const getDefaultFormats = (
     number: (
       value: number,
       format: string | Intl.NumberFormatOptions
-    ): string => number(locales, value, style(format)),
+    ): string =>
+      number(
+        locales,
+        value,
+        style(format) || ({ style: format } as Intl.NumberFormatOptions)
+      ),
 
     date: (
       value: string,
-      format: string | Intl.DateTimeFormatOptions
-    ): string => date(locales, value, style(format)),
+      format: Intl.DateTimeFormatOptions | string
+    ): string =>
+      date(locales, value, style(format) || (format as DateTimeFormatSize)),
+    time: (value: string, format: string): string =>
+      time(locales, value, style(format) || (format as DateTimeFormatSize)),
   } as const
 }
 

--- a/packages/message-utils/build.config.ts
+++ b/packages/message-utils/build.config.ts
@@ -1,0 +1,8 @@
+import { defineBuildConfig } from "unbuild"
+
+export default defineBuildConfig({
+  // we want to inline @messageformat/date-skeleton package, because it's
+  // esm only and will not work properly from ours cjs packages.
+  // need to delete this as well as inlining after switching to the ESM
+  failOnWarn: false,
+})

--- a/packages/message-utils/package.json
+++ b/packages/message-utils/package.json
@@ -52,6 +52,10 @@
   },
   "devDependencies": {
     "@lingui/jest-mocks": "workspace:^",
+    "@messageformat/date-skeleton": "^1.1.0",
     "unbuild": "2.0.0"
-  }
+  },
+  "bundledDependencies": [
+    "@messageformat/date-skeleton"
+  ]
 }

--- a/packages/message-utils/src/compileMessage.test.ts
+++ b/packages/message-utils/src/compileMessage.test.ts
@@ -197,16 +197,60 @@ describe("compileMessage", () => {
     `)
   })
 
-  it("should compile date", () => {
-    const tokens = compileMessage("{value, date}")
-    expect(tokens).toMatchInlineSnapshot(`
-      [
+  describe("compiling dates", () => {
+    it("with size", () => {
+      expect(compileMessage("{value, date, short}")).toMatchInlineSnapshot(`
+              [
+                [
+                  value,
+                  date,
+                  short,
+                ],
+              ]
+          `)
+    })
+
+    it("with no size", () => {
+      expect(compileMessage("{value, date}")).toMatchInlineSnapshot(`
         [
-          value,
-          date,
-        ],
-      ]
-    `)
+          [
+            value,
+            date,
+          ],
+        ]
+      `)
+    })
+
+    it("using date skeleton", () => {
+      expect(compileMessage("{value, date, ::GrMMMdd}")).toMatchInlineSnapshot(`
+        [
+          [
+            value,
+            date,
+            {
+              calendar: gregory,
+              day: 2-digit,
+              era: short,
+              month: short,
+              timeZone: undefined,
+              year: numeric,
+            },
+          ],
+        ]
+      `)
+    })
+
+    it("should report an error if wrong date skeleton", () => {
+      mockConsole((console) => {
+        expect(compileMessage("{value, date, ::bla}")).toEqual([
+          "{value, date, ::bla}",
+        ])
+
+        expect(console.error).toBeCalledWith(
+          expect.stringMatching("Unable to compile date expression")
+        )
+      })
+    })
   })
 
   it("should compile number", () => {

--- a/packages/message-utils/src/compileMessage.ts
+++ b/packages/message-utils/src/compileMessage.ts
@@ -1,4 +1,9 @@
 import { Content, parse, Token } from "@messageformat/parser"
+import {
+  DateFormatError,
+  getDateFormatOptions,
+} from "@messageformat/date-skeleton/lib/options"
+import { parseDateTokens } from "@messageformat/date-skeleton"
 
 export type CompiledIcuChoices = Record<string, CompiledMessage> & {
   offset: number | undefined
@@ -6,7 +11,11 @@ export type CompiledIcuChoices = Record<string, CompiledMessage> & {
 
 export type CompiledMessageToken =
   | string
-  | [name: string, type?: string, format?: null | string | CompiledIcuChoices]
+  | [
+      name: string,
+      type?: string,
+      format?: null | string | unknown | CompiledIcuChoices
+    ]
 
 export type CompiledMessage = CompiledMessageToken[]
 
@@ -33,6 +42,14 @@ function processTokens(tokens: Token[], mapText?: MapTextFn): CompiledMessage {
     } else if (token.type === "function") {
       const _param = token?.param?.[0] as Content
 
+      if (token.key === "date" && _param) {
+        const opts = compileDateExpression(_param.value.trim(), (e) => {
+          throw new Error(`Unable to compile date expression: ${e.message}`)
+        })
+
+        return [token.arg, token.key, opts]
+      }
+
       if (_param) {
         return [token.arg, token.key, _param.value.trim()]
       } else {
@@ -58,6 +75,18 @@ function processTokens(tokens: Token[], mapText?: MapTextFn): CompiledMessage {
       } as CompiledIcuChoices,
     ]
   })
+}
+
+function compileDateExpression(
+  format: string | undefined,
+  onError: (error: DateFormatError) => void
+) {
+  if (/^::/.test(format)) {
+    const tokens = parseDateTokens(format.substring(2))
+    return getDateFormatOptions(tokens, undefined, onError)
+  }
+
+  return format
 }
 
 export function compileMessage(

--- a/yarn.lock
+++ b/yarn.lock
@@ -2940,6 +2940,7 @@ __metadata:
   resolution: "@lingui/message-utils@workspace:packages/message-utils"
   dependencies:
     "@lingui/jest-mocks": "workspace:^"
+    "@messageformat/date-skeleton": ^1.1.0
     "@messageformat/parser": ^5.0.0
     js-sha256: ^0.10.1
     unbuild: 2.0.0
@@ -3035,6 +3036,13 @@ __metadata:
     vite: ^3 || ^4 || ^5.0.9 || ^6
   languageName: unknown
   linkType: soft
+
+"@messageformat/date-skeleton@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@messageformat/date-skeleton@npm:1.1.0"
+  checksum: 599adc2aba1639b9505420bce61035ce8cbf1a38bf77b39be5de7b9ecb4c4a2290ae3ebc2ee94ba5aabf52d22654b5febb961694dc52d9a4e6fb859d758aaea8
+  languageName: node
+  linkType: hard
 
 "@messageformat/parser@npm:^5.0.0":
   version: 5.0.0


### PR DESCRIPTION
# Description

Adding support for `short/default/long/full`full compatible with a reference implementation from here:

https://messageformat.github.io/messageformat/guide/#date-and-time

Only `date` and `time` are supported for now. 

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

Fixes https://github.com/lingui/js-lingui/issues/2116

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
