### PR TITLE
fix: Allow empty translations for pseudo locale in compile --strict

### DIFF
--- a/packages/cli/src/lingui-compile.ts
+++ b/packages/cli/src/lingui-compile.ts
@@ -45,7 +45,7 @@ export async function command(
         },
       })
 
-      if (!options.allowEmpty && missingMessages.length > 0) {
+      if (!options.allowEmpty && locale !== config.pseudoLocale && missingMessages.length > 0) {
         console.error(
           chalk.red(
             `Error: Failed to compile catalog for locale ${chalk.bold(locale)}!`

--- a/packages/cli/src/test/compile.test.ts
+++ b/packages/cli/src/test/compile.test.ts
@@ -8,10 +8,11 @@ describe("CLI Command: Compile", () => {
     // todo
   })
 
-  function getConfig(rootDir: string) {
+  function getConfig(rootDir: string, pseudoLocale?: string) {
     return makeConfig({
       locales: ["en", "pl"],
       sourceLocale: "en",
+      pseudoLocale,
       rootDir: rootDir,
       catalogs: [
         {
@@ -96,6 +97,42 @@ msgstr ""
           const log = getConsoleMockCalls(console.error)
           expect(log).toMatchSnapshot()
           expect(result).toBeFalsy()
+        })
+      }
+    )
+
+    it(
+      "Should allow empty translation for pseudo locale",
+      async () => {
+        expect.assertions(4)
+
+        const rootDir = await createFixtures({
+          "/test": {
+            "en.po": `
+msgid "Hello World"
+msgstr "Hello World"
+        `,
+            "pl.po": `
+msgid "Hello World"
+msgstr ""
+        `,
+          },
+        })
+
+        const config = getConfig(rootDir, 'pl')
+
+        await mockConsole(async (console) => {
+          const result = await command(config, {
+            allowEmpty: false,
+          })
+          const actualFiles = readFsToJson(config.rootDir)
+
+          expect(actualFiles["pl.js"]).toBeTruthy()
+          expect(actualFiles["en.js"]).toBeTruthy()
+
+          const log = getConsoleMockCalls(console.error)
+          expect(log).toBeUndefined()
+          expect(result).toBeTruthy()
         })
       }
     )

--- a/packages/cli/src/test/compile.test.ts
+++ b/packages/cli/src/test/compile.test.ts
@@ -12,7 +12,7 @@ describe("CLI Command: Compile", () => {
     return makeConfig({
       locales: ["en", "pl"],
       sourceLocale: "en",
-      pseudoLocale,
+      pseudoLocale: pseudoLocale,
       rootDir: rootDir,
       catalogs: [
         {


### PR DESCRIPTION
# Description

`lingui compile --strict` shouldn't fail with pseudo language missing translations.

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

Fixes #2128

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
