### PR TITLE
feat: add meaningful error when locale is not set

### DIFF
--- a/packages/core/src/i18n.test.ts
+++ b/packages/core/src/i18n.test.ts
@@ -431,4 +431,17 @@ describe("I18n", () => {
     expect(i18n._("Software development")).toEqual("Software­entwicklung")
     expect(i18n._("Software development")).toEqual("Software­entwicklung")
   })
+
+  it("._ should throw a meaningful error when locale is not set", () => {
+    const i18n = setupI18n({})
+    expect(() =>
+      i18n._(
+        "Text {0, plural, offset:1 =0 {No books} =1 {1 book} other {# books}}"
+      )
+    ).toThrowErrorMatchingInlineSnapshot(`
+      "Lingui: Attempted to call a translation function without setting a locale.
+      Make sure to call \`i18n.activate(locale)\` before using Lingui functions.
+      This issue may also occur due to a race condition in your initialization logic."
+    `)
+  })
 })

--- a/packages/core/src/i18n.ts
+++ b/packages/core/src/i18n.ts
@@ -240,6 +240,14 @@ export class I18n extends EventEmitter<Events> {
     values?: Values,
     options?: MessageOptions
   ): string {
+    if (!this.locale) {
+      throw new Error(
+        "Lingui: Attempted to call a translation function without setting a locale.\n" +
+          "Make sure to call `i18n.activate(locale)` before using Lingui functions.\n" +
+          "This issue may also occur due to a race condition in your initialization logic."
+      )
+    }
+
     let message = options?.message
 
     if (!id) {

--- a/packages/vite-plugin/test/macro-usage/entrypoint.js
+++ b/packages/vite-plugin/test/macro-usage/entrypoint.js
@@ -1,5 +1,10 @@
 import { t } from "@lingui/core/macro"
+import { i18n } from "@lingui/core"
 
 export async function load() {
+  i18n.loadAndActivate({
+    locale: "en",
+    messages: {},
+  })
   return t`Ola`
 }


### PR DESCRIPTION
# Description

Related to https://github.com/lingui/js-lingui/issues/2095

There might be the cases where locale is not set. To avoid frustration and long debugging sessions it is better to fail earlier with a meaningful error message. 

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
