### PR TITLE
refactor: remove ramda

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "@types/jest": "^29.4.0",
     "@types/mock-fs": "^4.13.1",
     "@types/node": "20.14.8",
-    "@types/ramda": "^0.27.23",
     "babel-jest": "^29.7.0",
     "chalk": "^4.1.0",
     "cross-env": "^7.0.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -80,7 +80,6 @@
     "pkg-up": "^3.1.0",
     "pofile": "^1.1.4",
     "pseudolocale": "^2.0.0",
-    "ramda": "^0.27.1",
     "source-map": "^0.8.0-beta.0"
   },
   "devDependencies": {

--- a/packages/cli/src/api/catalog.test.ts
+++ b/packages/cli/src/api/catalog.test.ts
@@ -528,7 +528,7 @@ describe("order", () => {
       }),
     }
 
-    const orderedCatalogs = order("messageId")(catalog)
+    const orderedCatalogs = order("messageId", catalog)
 
     // Test that the message content is the same as before
     expect(orderedCatalogs).toMatchSnapshot()
@@ -560,7 +560,7 @@ describe("order", () => {
       }),
     }
 
-    const orderedCatalogs = order("origin")(catalog)
+    const orderedCatalogs = order("origin", catalog)
 
     // Test that the message content is the same as before
     expect(orderedCatalogs).toMatchSnapshot()
@@ -596,7 +596,7 @@ describe("order", () => {
       }),
     }
 
-    const orderedCatalogs = order("message")(catalog)
+    const orderedCatalogs = order("message", catalog)
 
     // Jest snapshot order the keys automatically, so test that the key order explicitly
     expect(Object.keys(orderedCatalogs)).toMatchInlineSnapshot(`

--- a/packages/cli/src/api/pseudoLocalize.ts
+++ b/packages/cli/src/api/pseudoLocalize.ts
@@ -1,4 +1,3 @@
-import R from "ramda"
 import pseudolocale from "pseudolocale"
 
 const delimiter = "%&&&%"
@@ -45,18 +44,14 @@ function addDelimitersVariables(message: string) {
   })
 }
 
-const addDelimiters = R.compose(
-  addDelimitersVariables,
-  addDelimitersMacro,
-  addDelimitersHTMLTags
-)
-
 function removeDelimiters(message: string) {
   return message.replace(new RegExp(delimiter, "g"), "")
 }
 
 export default function (message: string) {
-  message = addDelimiters(message)
+  message = addDelimitersHTMLTags(message)
+  message = addDelimitersMacro(message)
+  message = addDelimitersVariables(message)
   message = pseudolocale(message, {
     delimiter,
     prepend: "",

--- a/packages/cli/src/extract-experimental/writeCatalogs.ts
+++ b/packages/cli/src/extract-experimental/writeCatalogs.ts
@@ -30,7 +30,7 @@ function cleanAndSort(catalog: CatalogType, clean: boolean, orderBy: OrderBy) {
     catalog = cleanObsolete(catalog)
   }
 
-  return order(orderBy)(catalog) as CatalogType
+  return order(orderBy, catalog) as CatalogType
 }
 
 export async function writeCatalogs(

--- a/packages/format-json/package.json
+++ b/packages/format-json/package.json
@@ -39,8 +39,7 @@
     "dist/"
   ],
   "dependencies": {
-    "@lingui/conf": "5.1.2",
-    "ramda": "^0.28.0"
+    "@lingui/conf": "5.1.2"
   },
   "devDependencies": {
     "tsd": "^0.28.0",

--- a/packages/format-json/src/json.ts
+++ b/packages/format-json/src/json.ts
@@ -1,10 +1,7 @@
-import * as R from "ramda"
-
 import {
   CatalogFormatter,
   CatalogType,
   ExtractedMessageType,
-  MessageType,
 } from "@lingui/conf"
 
 export type JsonFormatterOptions = {
@@ -43,27 +40,50 @@ type NoOriginsCatalogType = {
 
 type MinimalCatalogType = Record<string, string>
 
-const serializeMinimal = R.map(
-  (message: MessageType) => message.translation || ""
-) as unknown as (catalog: CatalogType) => MinimalCatalogType
-
-const deserializeMinimal = R.map((translation: string) => ({
-  translation,
-  obsolete: false,
-  message: null,
-  origin: [],
-})) as unknown as (minimalCatalog: MinimalCatalogType) => CatalogType
-
-const removeOrigins = R.map(({ origin, ...message }) => message) as unknown as (
-  catalog: CatalogType
-) => NoOriginsCatalogType
-
-const removeLineNumbers = R.map((message: ExtractedMessageType) => {
-  if (message.origin) {
-    message.origin = message.origin.map(([file]) => [file])
+const serializeMinimal = (catalog: CatalogType): MinimalCatalogType => {
+  const result: MinimalCatalogType = {}
+  for (const key in catalog) {
+    result[key] = catalog[key].translation || ""
   }
-  return message
-}) as unknown as (catalog: ExtractedMessageType) => NoOriginsCatalogType
+  return result
+}
+
+const deserializeMinimal = (
+  minimalCatalog: MinimalCatalogType
+): CatalogType => {
+  const result: CatalogType = {}
+  for (const key in minimalCatalog) {
+    result[key] = {
+      translation: minimalCatalog[key],
+      obsolete: false,
+      message: null,
+      origin: [],
+    }
+  }
+  return result
+}
+
+const removeOrigins = (catalog: CatalogType): NoOriginsCatalogType => {
+  const result: NoOriginsCatalogType = {}
+  for (const key in catalog) {
+    const { origin, ...message } = catalog[key]
+    result[key] = message
+  }
+  return result
+}
+
+const removeLineNumbers = (
+  catalog: ExtractedMessageType
+): NoOriginsCatalogType => {
+  const result: NoOriginsCatalogType = {}
+  for (const key in catalog) {
+    result[key] = {
+      ...catalog[key],
+      origin: catalog[key].origin?.map(([file]) => [file]),
+    }
+  }
+  return result
+}
 
 export function formatter(
   options: JsonFormatterOptions = {}

--- a/packages/remote-loader/package.json
+++ b/packages/remote-loader/package.json
@@ -50,8 +50,7 @@
   ],
   "dependencies": {
     "@lingui/core": "4.0.0",
-    "@lingui/message-utils": "4.0.0",
-    "ramda": "^0.27.1"
+    "@lingui/message-utils": "4.0.0"
   },
   "devDependencies": {
     "unbuild": "2.0.0"

--- a/packages/remote-loader/src/index.ts
+++ b/packages/remote-loader/src/index.ts
@@ -1,4 +1,3 @@
-import * as R from "ramda"
 import { createBrowserCompiledCatalog } from "./browserCompiler"
 import PARSERS from "./minimalParser"
 
@@ -8,7 +7,7 @@ type RemoteLoaderOpts<T> = {
   messages: string | Record<string, any> | T
 }
 
-function remoteLoader<T>({
+export function remoteLoader<T>({
   format = "minimal",
   fallbackMessages,
   messages,
@@ -35,19 +34,16 @@ function remoteLoader<T>({
       `)
   }
 
-  const mapTranslationsToInterporlatedString = R.mapObjIndexed((_, key) => {
+  const mapTranslationsToInterpolatedString = Object.fromEntries(
     // if there's fallback and translation is empty, return the fallback
-    if (
+    Object.keys(parsedMessages).map((key) => [
+      key,
       parsedMessages[key].translation === "" &&
       parsedFallbackMessages?.[key]?.translation
-    ) {
-      return parsedFallbackMessages[key].translation
-    }
+        ? parsedFallbackMessages[key].translation
+        : parsedMessages[key].translation,
+    ])
+  )
 
-    return parsedMessages[key].translation
-  }, parsedMessages)
-
-  return createBrowserCompiledCatalog(mapTranslationsToInterporlatedString)
+  return createBrowserCompiledCatalog(mapTranslationsToInterpolatedString)
 }
-
-export { remoteLoader }

--- a/packages/remote-loader/src/minimalParser.ts
+++ b/packages/remote-loader/src/minimalParser.ts
@@ -1,15 +1,19 @@
-import * as R from "ramda"
-
-const deserialize = R.map((translation: string) => ({
-  translation,
-  obsolete: false,
-  message: null,
-  origin: [],
-})) as unknown as (minimalCatalog: any) => any
+const deserialize = (minimalCatalog: Record<string, any>) => {
+  const result: Record<string, any> = {}
+  for (const key in minimalCatalog) {
+    result[key] = {
+      translation: minimalCatalog[key],
+      obsolete: false,
+      message: null,
+      origin: [],
+    }
+  }
+  return result
+}
 
 const PARSERS = {
   minimal: <T>(content: Record<string, any> | T) => {
-    return deserialize(content)
+    return deserialize(content as Record<string, any>)
   },
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2684,7 +2684,6 @@ __metadata:
     pkg-up: ^3.1.0
     pofile: ^1.1.4
     pseudolocale: ^2.0.0
-    ramda: ^0.27.1
     source-map: ^0.8.0-beta.0
   bin:
     lingui: ./dist/lingui.js
@@ -2775,7 +2774,6 @@ __metadata:
   resolution: "@lingui/format-json@workspace:packages/format-json"
   dependencies:
     "@lingui/conf": 5.1.2
-    ramda: ^0.28.0
     tsd: ^0.28.0
     unbuild: ^2.0.0
   languageName: unknown
@@ -2934,7 +2932,6 @@ __metadata:
   dependencies:
     "@lingui/core": 4.0.0
     "@lingui/message-utils": 4.0.0
-    ramda: ^0.27.1
     unbuild: 2.0.0
   languageName: unknown
   linkType: soft
@@ -4315,15 +4312,6 @@ __metadata:
   version: 15.7.5
   resolution: "@types/prop-types@npm:15.7.5"
   checksum: 5b43b8b15415e1f298243165f1d44390403bb2bd42e662bca3b5b5633fdd39c938e91b7fce3a9483699db0f7a715d08cef220c121f723a634972fdf596aec980
-  languageName: node
-  linkType: hard
-
-"@types/ramda@npm:^0.27.23":
-  version: 0.27.23
-  resolution: "@types/ramda@npm:0.27.23"
-  dependencies:
-    ts-toolbelt: ^6.3.3
-  checksum: cb551b6b44adbb40426ed5fde35104cd05850077e0c78c33bccd555156c3a9768f02186c57576d1806d238b517fcb2b6ef5fb472d43261865562ac9647e997b8
   languageName: node
   linkType: hard
 
@@ -10624,7 +10612,6 @@ __metadata:
     "@types/jest": ^29.4.0
     "@types/mock-fs": ^4.13.1
     "@types/node": 20.14.8
-    "@types/ramda": ^0.27.23
     babel-jest: ^29.7.0
     chalk: ^4.1.0
     cross-env: ^7.0.2
@@ -13453,20 +13440,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ramda@npm:^0.27.1":
-  version: 0.27.2
-  resolution: "ramda@npm:0.27.2"
-  checksum: 28d6735dd1eea1a796c56cf6111f3673c6105bbd736e521cdd7826c46a18eeff337c2dba4668f6eed990d539b9961fd6db19aa46ccc1530ba67a396c0a9f580d
-  languageName: node
-  linkType: hard
-
-"ramda@npm:^0.28.0":
-  version: 0.28.0
-  resolution: "ramda@npm:0.28.0"
-  checksum: 44ea6e5010bba70151b6a92d8114a91915e8b5a16105cce65fae58c9d7386b812c429645e35f21141d7087568550ce383bc10ee1a65cdec951f4b69ea457e6a4
-  languageName: node
-  linkType: hard
-
 "randombytes@npm:^2.1.0":
   version: 2.1.0
   resolution: "randombytes@npm:2.1.0"
@@ -15319,13 +15292,6 @@ __metadata:
   bin:
     ts-jest: cli.js
   checksum: d60d1e1d80936f6002b1bb27f7e062408bc733141b9d666565503f023c340a3196d506c836a4316c5793af81a5f910ab49bb9c13f66e2dc66de4e0f03851dbca
-  languageName: node
-  linkType: hard
-
-"ts-toolbelt@npm:^6.3.3":
-  version: 6.15.5
-  resolution: "ts-toolbelt@npm:6.15.5"
-  checksum: 24ad00cfd9ce735c76c873a9b1347eac475b94e39ebbdf100c9019dce88dd5f4babed52884cf82bb456a38c28edd0099ab6f704b84b2e5e034852b618472c1f3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

Remove ramda leftovers from the code. The new EcmaScript features perfectly replaces everything from it without much boilerplate. As an additional benefit, it's more friendly for typescript. 

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
