### PR TITLE
feat(react): preserve newlines during string formatting

### DIFF
--- a/packages/react/src/format.test.tsx
+++ b/packages/react/src/format.test.tsx
@@ -32,6 +32,20 @@ describe("formatElements", function () {
     ).toEqual('<a href="/about">About</a>')
   })
 
+  it("should preserve newlines", function () {
+    expect(html(formatElements("<0>Inn\ner</0>", { 0: <strong /> }))).toEqual(
+      "<strong>Inn\ner</strong>"
+    )
+
+    expect(
+      html(formatElements("Before <0>Inn\r\ner</0> After", { 0: <strong /> }))
+    ).toEqual("Before <strong>Inn\r\ner</strong> After")
+
+    expect(
+      html(formatElements("<0>Ab\rout</0>", { 0: <a href="/about" /> }))
+    ).toEqual('<a href="/about">Ab\rout</a>')
+  })
+
   it("should preserve named element props", function () {
     expect(
       html(
@@ -69,7 +83,7 @@ describe("formatElements", function () {
         )
       )
     ).toEqual(
-      'Before <a href="/about">Inside <strong>Nested</strong> Between <br> After</a>'
+      'Before \n<a href="/about">Inside <strong>\nNested</strong>\n Between <br> After</a>'
     )
   })
 

--- a/packages/react/src/format.ts
+++ b/packages/react/src/format.ts
@@ -1,8 +1,7 @@
 import React from "react"
 
 // match <tag>paired</tag> and <tag/> unpaired tags
-const tagRe = /<([a-zA-Z0-9]+)>(.*?)<\/\1>|<([a-zA-Z0-9]+)\/>/
-const nlRe = /(?:\r\n|\r|\n)/g
+const tagRe = /<([a-zA-Z0-9]+)>([\s\S]*?)<\/\1>|<([a-zA-Z0-9]+)\/>/
 
 // For HTML, certain tags should omit their close tag. We keep a whitelist for
 // those special-case tags.
@@ -37,7 +36,7 @@ function formatElements(
   elements: { [key: string]: React.ReactElement } = {}
 ): string | React.ReactElement | Array<React.ReactElement | string> {
   const uniqueId = makeCounter(0, "$lingui$")
-  const parts = value.replace(nlRe, "").split(tagRe)
+  const parts = value.split(tagRe)
 
   // no inline elements, return
   if (parts.length === 1) return value


### PR DESCRIPTION
# Description

In @lingui/react, newlines in translations are not preserved during formatting (rendering), when `<tags>` are present.
Please see this demo: https://codesandbox.io/p/devbox/infallible-cdn-y863cd 
This PR ensures that formatting is done the same way for both variants: with and without `<tags>`.

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

Fixes #2157 

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
