### PR TITLE
fix(core): remove runtime whitespace trimming aligned with v5

### DIFF
--- a/packages/core/src/i18n.test.ts
+++ b/packages/core/src/i18n.test.ts
@@ -215,7 +215,7 @@ describe("I18n", () => {
         id: "My name is {name}",
         message: "Je m'appelle {name}",
       })
-    ).toEqual("Je m'appelle")
+    ).toEqual("Je m'appelle ")
 
     // Untranslated message
     expect(i18n._("Missing message")).toEqual("Missing message")
@@ -261,6 +261,23 @@ describe("I18n", () => {
         message: "Mi ''nombre'' es '{name}'",
       })
     ).toEqual("Mi 'nombre' es {name}")
+  })
+
+  it("._ should not trim whitespaces in translated messages", () => {
+    const messages = {}
+
+    const i18n = setupI18n({
+      locale: "es",
+      messages: { es: messages },
+    })
+
+    expect(
+      i18n._({
+        id: "msg",
+        /* note the space at the end */
+        message: " Hello ",
+      })
+    ).toEqual(" Hello ")
   })
 
   it("._ shouldn't compile uncompiled messages in production", () => {

--- a/packages/core/src/interpolate.test.ts
+++ b/packages/core/src/interpolate.test.ts
@@ -44,7 +44,7 @@ describe("interpolate", () => {
     expect(plural({ value: 1 })).toEqual("1 Book")
     expect(plural({ value: 2 })).toEqual("2 Books")
     expect(plural({ value: 4 })).toEqual("Four books")
-    expect(plural({ value: 99 })).toEqual("Books with problems")
+    expect(plural({ value: 99 })).toEqual(" Books with problems ")
 
     const offset = prepare(
       "{value, plural, offset:1 =0 {No Books} one {# Book} other {# Books}}"

--- a/packages/core/src/interpolate.ts
+++ b/packages/core/src/interpolate.ts
@@ -152,9 +152,9 @@ export function interpolate(
       // convert raw unicode sequences back to normal strings
       // note JSON.parse hack is not working as you might expect https://stackoverflow.com/a/57560631/2210610
       // that's why special library for that purpose is used
-      return unraw(result.trim())
+      return unraw(result)
     }
-    if (isString(result)) return result.trim()
+    if (isString(result)) return result
     return result ? String(result) : ""
   }
 }


### PR DESCRIPTION
# Description

Remove whitespace trimming in runtime, as was promised in v5 release notes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

Fixes https://github.com/lingui/js-lingui/issues/2167

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
