### PR TITLE
docs: fix mobile view of the main page

### DIFF
--- a/website/src/components/Features.module.scss
+++ b/website/src/components/Features.module.scss
@@ -21,6 +21,10 @@
     height: 0;
     z-index: -1;
 
+    @media (max-width: 768px) {
+      display: none;
+    }
+
     img {
       bottom: -30px;
       position: absolute;
@@ -36,6 +40,10 @@
     grid-column: 1 / -1;
     height: 0;
     z-index: 0;
+
+    @media (max-width: 768px) {
+      display: none;
+    }
 
     img {
       top: -70px;


### PR DESCRIPTION
# Description

This PR hides the background images for the Features section of the main page because they break the mobile layout.

![Screenshot 2025-01-31 at 10 30 56](https://github.com/user-attachments/assets/bd5c675e-ad21-41eb-8a5a-248f98eec247)


## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Examples update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
