### PR TITLE
docs: add strip non essential fields option to SWC plugin doc

### DIFF
--- a/website/docs/ref/swc-plugin.md
+++ b/website/docs/ref/swc-plugin.md
@@ -46,6 +46,8 @@ or `overrides` for >npm@8.3
 
 ## Usage
 
+### Basic Usage
+
 Add the following configuration to your [`.swcrc`](https://swc.rs/docs/configuration/swcrc) file:
 
 ```json title=".swcrc"
@@ -87,9 +89,8 @@ const nextConfig = {
 module.exports = nextConfig;
 ```
 
-## Additional Configuration
-
 ### Runtime Modules Configuration
+
 You can configure the plugin by passing the `runtimeModules` option. This option is an object that maps runtime module names to their corresponding module paths and export names. It is essential for macros, which rely on referencing the global `i18n` object.
 
 ```json
@@ -103,9 +104,11 @@ You can configure the plugin by passing the `runtimeModules` option. This option
   }
 ]
 ```
+
 For more details, refer to the [Runtime Configuration](/ref/conf#runtimeconfigmodule) section of the documentation.
 
 ### Strip Non-Essential Fields
+
 Lingui strips non-essential fields from builds  if `NODE_ENV` is set to `production`. You can override this behavior by using the `stripNonEssentialFields` option. For example, if you want to keep all fields regardless of the environment, you can set:
 
 ```json
@@ -115,14 +118,12 @@ Lingui strips non-essential fields from builds  if `NODE_ENV` is set to `product
     "stripNonEssentialFields": false
   }
 ]
-
-
+```
 
 ## Examples
 
 - [React with Vite and SWC](https://github.com/lingui/js-lingui/tree/main/examples/vite-project-react-swc)
 - [Next.js with SWC](https://github.com/lingui/js-lingui/tree/main/examples/nextjs-swc)
-
 
 
 :::info

--- a/website/docs/ref/swc-plugin.md
+++ b/website/docs/ref/swc-plugin.md
@@ -125,7 +125,6 @@ Lingui strips non-essential fields from builds  if `NODE_ENV` is set to `product
 - [React with Vite and SWC](https://github.com/lingui/js-lingui/tree/main/examples/vite-project-react-swc)
 - [Next.js with SWC](https://github.com/lingui/js-lingui/tree/main/examples/nextjs-swc)
 
-
 :::info
 If you would like to suggest a new feature or report a bug, please [open an issue](https://github.com/lingui/swc-plugin/issues) on the GitHub repository.
 :::

--- a/website/docs/ref/swc-plugin.md
+++ b/website/docs/ref/swc-plugin.md
@@ -109,7 +109,7 @@ For more details, refer to the [Runtime Configuration](/ref/conf#runtimeconfigmo
 
 ### Strip Non-Essential Fields
 
-Lingui strips non-essential fields from builds  if `NODE_ENV` is set to `production`. You can override this behavior by using the `stripNonEssentialFields` option. For example, if you want to keep all fields regardless of the environment, you can set:
+Lingui strips non-essential fields from builds if `NODE_ENV` is set to `production`. You can override this behavior by using the `stripNonEssentialFields` option. For example, if you want to keep all fields regardless of the environment, you can set:
 
 ```json
 [

--- a/website/docs/ref/swc-plugin.md
+++ b/website/docs/ref/swc-plugin.md
@@ -87,8 +87,9 @@ const nextConfig = {
 module.exports = nextConfig;
 ```
 
-### Additional Configuration
+## Additional Configuration
 
+### Runtime Modules Configuration
 You can configure the plugin by passing the `runtimeModules` option. This option is an object that maps runtime module names to their corresponding module paths and export names. It is essential for macros, which rely on referencing the global `i18n` object.
 
 ```json
@@ -102,14 +103,28 @@ You can configure the plugin by passing the `runtimeModules` option. This option
   }
 ]
 ```
-
 For more details, refer to the [Runtime Configuration](/ref/conf#runtimeconfigmodule) section of the documentation.
 
-:::info
-If you would like to suggest a new feature or report a bug, please [open an issue](https://github.com/lingui/swc-plugin/issues) on the GitHub repository.
-:::
+### Strip Non-Essential Fields
+Lingui strips non-essential fields from builds  if `NODE_ENV` is set to `production`. You can override this behavior by using the `stripNonEssentialFields` option. For example, if you want to keep all fields regardless of the environment, you can set:
+
+```json
+[
+  "@lingui/swc-plugin",
+  {
+    "stripNonEssentialFields": false
+  }
+]
+
+
 
 ## Examples
 
 - [React with Vite and SWC](https://github.com/lingui/js-lingui/tree/main/examples/vite-project-react-swc)
 - [Next.js with SWC](https://github.com/lingui/js-lingui/tree/main/examples/nextjs-swc)
+
+
+
+:::info
+If you would like to suggest a new feature or report a bug, please [open an issue](https://github.com/lingui/swc-plugin/issues) on the GitHub repository.
+:::

--- a/website/docs/ref/swc-plugin.md
+++ b/website/docs/ref/swc-plugin.md
@@ -46,8 +46,6 @@ or `overrides` for >npm@8.3
 
 ## Usage
 
-### Basic Usage
-
 Add the following configuration to your [`.swcrc`](https://swc.rs/docs/configuration/swcrc) file:
 
 ```json title=".swcrc"
@@ -88,6 +86,8 @@ const nextConfig = {
 
 module.exports = nextConfig;
 ```
+
+## Additional Configuration
 
 ### Runtime Modules Configuration
 


### PR DESCRIPTION
# Description

As discussed in https://github.com/lingui/swc-plugin/pull/137, we added an option to override the default behavior that strips fields in production builds

## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Examples update


## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
