### PR TITLE
fix: incorrect index for placeholders in useLingui macro

### DIFF
--- a/packages/babel-plugin-lingui-macro/src/macroJs.ts
+++ b/packages/babel-plugin-lingui-macro/src/macroJs.ts
@@ -256,16 +256,22 @@ export class MacroJs {
         // parent would be an Expression with this identifier which we are interesting in
         const currentPath = refPath.parentPath
 
+        const _ctx = createMacroJsContext(
+          ctx.isLinguiIdentifier,
+          ctx.stripNonEssentialProps,
+          ctx.stripMessageProp
+        )
+
         // { t } = useLingui()
         // t`Hello!`
         if (currentPath.isTaggedTemplateExpression()) {
-          const tokens = tokenizeTemplateLiteral(currentPath.node, ctx)
+          const tokens = tokenizeTemplateLiteral(currentPath.node, _ctx)
 
           const descriptor = createMessageDescriptorFromTokens(
             tokens,
             currentPath.node.loc,
-            ctx.stripNonEssentialProps,
-            ctx.stripMessageProp
+            _ctx.stripNonEssentialProps,
+            _ctx.stripMessageProp
           )
 
           const callExpr = t.callExpression(
@@ -285,7 +291,7 @@ export class MacroJs {
           const descriptor = processDescriptor(
             (currentPath.get("arguments")[0] as NodePath<ObjectExpression>)
               .node,
-            ctx
+            _ctx
           )
           const callExpr = t.callExpression(
             t.identifier(uniqTIdentifier.name),

--- a/packages/babel-plugin-lingui-macro/test/__snapshots__/js-useLingui.test.ts.snap
+++ b/packages/babel-plugin-lingui-macro/test/__snapshots__/js-useLingui.test.ts.snap
@@ -1,5 +1,72 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`correctly process indexed placeholders in few t calls 1`] = `
+import { useLingui } from "@lingui/react/macro";
+function Home() {
+  const { t } = useLingui();
+  const user = { name: "John " };
+  return (
+    <main>
+      <button onClick={() => console.log(t\`Hello \${user.name}\`)}>Hello</button>
+
+      <button onClick={() => console.log(t\`Bye \${user.name}\`)}>Bye</button>
+    </main>
+  );
+}
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { useLingui as _useLingui } from "@lingui/react";
+function Home() {
+  const { _: _t } = _useLingui();
+  const user = {
+    name: "John ",
+  };
+  return (
+    <main>
+      <button
+        onClick={() =>
+          console.log(
+            _t(
+              /*i18n*/
+              {
+                id: "Y7riaK",
+                message: "Hello {0}",
+                values: {
+                  0: user.name,
+                },
+              }
+            )
+          )
+        }
+      >
+        Hello
+      </button>
+
+      <button
+        onClick={() =>
+          console.log(
+            _t(
+              /*i18n*/
+              {
+                id: "vqOLZ6",
+                message: "Bye {0}",
+                values: {
+                  0: user.name,
+                },
+              }
+            )
+          )
+        }
+      >
+        Bye
+      </button>
+    </main>
+  );
+}
+
+`;
+
 exports[`does not crash when no params 1`] = `
 import { useLingui } from "@lingui/react/macro";
 function MyComponent() {

--- a/packages/babel-plugin-lingui-macro/test/js-useLingui.test.ts
+++ b/packages/babel-plugin-lingui-macro/test/js-useLingui.test.ts
@@ -203,6 +203,32 @@ function MyComponent2() {
 }`,
     },
     {
+      name: "correctly process indexed placeholders in few t calls",
+      code: `
+import { useLingui } from '@lingui/react/macro';
+
+function Home() {
+  const {t} = useLingui();
+  const user = {name: 'John '}
+  return (
+    <main>
+      <button onClick={() =>
+        console.log(t\`Hello \${user.name}\`)
+      }>
+        Hello
+      </button>
+
+      <button onClick={() =>
+        console.log(t\`Bye \${user.name}\`)
+      }>
+        Bye
+      </button>
+    </main>
+  );
+}
+`,
+    },
+    {
       name: "support configuring runtime module import using LinguiConfig.runtimeConfigModule",
       macroOpts: {
         linguiConfig: makeConfig(


### PR DESCRIPTION
# Description

Correctly process placeholder's indexes in `t` calls destructed from `useLingui` macro

fix: #2203

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
