### PR TITLE
Update metro-transformer.mdx

### DIFF
--- a/website/docs/ref/metro-transformer.mdx
+++ b/website/docs/ref/metro-transformer.mdx
@@ -74,6 +74,44 @@ const config = {
 
 module.exports = mergeConfig(defaultConfig, config);
 ```
+# Expo mutliple babelTransformerPath
+
+When you use with react-native-svg-transformer
+
+```js
+// File: metro.transformer.js
+
+const upstreamTransformer = require("@expo/metro-config/babel-transformer");
+const svgTransformer = require("react-native-svg-transformer/expo");
+const linguiTransformer = require("@lingui/metro-transformer/expo");
+
+module.exports.transform = function ({ src, filename, options }) {
+  if (filename.endsWith(".svg")) {
+    return svgTransformer.transform({ src, filename, options });
+  } else if (filename.endsWith(".po")) {
+    return linguiTransformer.transform({ src, filename, options });
+  }
+  return upstreamTransformer.transform({ src, filename, options });
+};
+```
+```js
+// File : metro.config.js
+
+// Learn more https://docs.expo.io/guides/customizing-metro
+const { getDefaultConfig } = require("expo/metro-config");
+const config = getDefaultConfig(__dirname);
+const { transformer, resolver } = config;
+
+config.transformer = {
+  ...transformer,
+  babelTransformerPath: require.resolve("./metro.transformer.js")
+};
+config.resolver = {
+  ...resolver,
+  sourceExts: [...resolver.sourceExts, "po", "pot"],
+};
+module.exports = config;
+```
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
- Expo multiple babelTransformer
- In your project might have multiple transformer

# Description
There is the case in my project with multiple `babelTransformerPath`
```js
const upstreamTransformer = require("@expo/metro-config/babel-transformer");
const svgTransformer = require("react-native-svg-transformer/expo");
const linguiTransformer = require("@lingui/metro-transformer/expo");

module.exports.transform = function ({ src, filename, options }) {
  if (filename.endsWith(".svg")) {
    return svgTransformer.transform({ src, filename, options });
  } else if (filename.endsWith(".po")) {
    return linguiTransformer.transform({ src, filename, options });
  }
  return upstreamTransformer.transform({ src, filename, options });
};
```
[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Examples update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
