### PR TITLE
feat: add list format convenience wrapper

### DIFF
--- a/packages/core/src/formats.test.ts
+++ b/packages/core/src/formats.test.ts
@@ -1,4 +1,4 @@
-import { number } from "./formats"
+import { list, number } from "./formats"
 
 describe("@lingui/core/formats", () => {
   describe("number", () => {
@@ -23,6 +23,31 @@ describe("@lingui/core/formats", () => {
       expect(
         number(["en-US", "pl"], 1000, { style: "currency", currency: "EUR" })
       ).toBe("€1,000.00")
+    })
+  })
+
+  describe("list", () => {
+    it("should pass format options", () => {
+      expect(list(["en"], ["a", "b", "c"], { type: "conjunction" })).toBe(
+        "a, b, and c"
+      )
+
+      expect(list(["en"], ["a", "b", "c"], { type: "disjunction" })).toBe(
+        "a, b, or c"
+      )
+    })
+
+    it("should respect passed locale(s)", () => {
+      expect(list(["pl"], ["a", "b", "c"], { type: "conjunction" })).toBe(
+        "a, b i c"
+      )
+
+      expect(
+        list(["pl", "en-US"], ["a", "b", "c"], { type: "conjunction" })
+      ).toBe("a, b i c")
+      expect(
+        list(["en-US", "pl"], ["a", "b", "c"], { type: "conjunction" })
+      ).toBe("a, b, and c")
     })
   })
 })

--- a/packages/core/src/formats.ts
+++ b/packages/core/src/formats.ts
@@ -107,6 +107,22 @@ export function number(
 
   return formatter.format(value)
 }
+
+export function list(
+  locales: Locales,
+  values: string[],
+  format?: Intl.ListFormatOptions
+): string {
+  const _locales = normalizeLocales(locales)
+
+  const formatter = getMemoized(
+    () => cacheKey("list", _locales, format),
+    () => new Intl.ListFormat(_locales, format)
+  )
+
+  return formatter.format(values)
+}
+
 export type PluralOptions = { [key: string]: Intl.LDMLPluralRule } & {
   offset: number
   other: string

--- a/packages/core/src/i18n.ts
+++ b/packages/core/src/i18n.ts
@@ -1,6 +1,6 @@
 import { interpolate, UNICODE_REGEX } from "./interpolate"
 import { isString, isFunction } from "./essentials"
-import { date, defaultLocale, number } from "./formats"
+import { date, defaultLocale, list, number } from "./formats"
 import { EventEmitter } from "./eventEmitter"
 import { compileMessage } from "@lingui/message-utils/compileMessage"
 import type { CompiledMessage } from "@lingui/message-utils/compileMessage"
@@ -318,6 +318,10 @@ Please compile your catalog first.
 
   number(value: number, format?: Intl.NumberFormatOptions): string {
     return number(this._locales || this._locale, value, format)
+  }
+
+  list(values: string[], format?: Intl.ListFormatOptions): string {
+    return list(this._locales || this._locale, values, format)
   }
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "noUnusedLocals": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "target": "es2017",
+    "target": "es2021",
     "paths": {
       "@lingui/babel-plugin-extract-messages": [
         "./packages/babel-plugin-extract-messages/src"

--- a/website/docs/ref/core.md
+++ b/website/docs/ref/core.md
@@ -272,6 +272,31 @@ i18n.number(12345.678, { style: "currency", currency: "CZK" });
 // Returns "12 345,68 Kč"
 ```
 
+### `i18n.list(values: string[][, format: Intl.ListFormatOptions])` {#i18n.list}
+
+Format a list using the conventional format for the active language.
+
+- `string[]`: list of strings to be formatted
+- `format`: an optional object that is passed to the `options` argument of the [`Intl.ListFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat/ListFormat) constructor. This allows for customization of the list formatting.
+
+```ts
+import { i18n } from "@lingui/core";
+
+i18n.activate("en");
+i18n.list(["JavaScript", "TypeScript", "React"]);
+// Returns "JavaScript, TypeScript, and React"
+
+i18n.list(["JavaScript", "TypeScript", "React"], { style: "long", type: "disjunction" });
+// Returns "JavaScript, TypeScript, or React"
+
+i18n.activate("cs");
+i18n.list(["JavaScript", "TypeScript", "React"]);
+// Returns "JavaScript, TypeScript a React"
+
+i18n.list(["JavaScript", "TypeScript", "React"], { style: "long", type: "disjunction" });
+// Returns "JavaScript, TypeScript nebo React"
+```
+
 ## `setupI18n([options])` {#setupi18n}
 
 Initialize and return a new `I18n` instance. Typically, you should call this function only once and then use the returned `i18n` object throughout your entire codebase.


### PR DESCRIPTION
# Description

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

Add a new convenience wrapper for [`Intl.ListFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat) with `i18n.list`. Similarly to `i18n.number` is for [`Intl.NumberFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat)  and `i18n.date` is for [`Intl.DateTimeFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat).

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - The ES target change might need to be considered breaking change, though this new functionality is opt-in and existing features should work as before.
- [ ] Documentation update
- [ ] Examples update

Fixes #2222 

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
