### PR TITLE
build: Remove lodash.get dependency in conf package

### DIFF
--- a/packages/conf/package.json
+++ b/packages/conf/package.json
@@ -29,8 +29,7 @@
     "chalk": "^4.1.0",
     "cosmiconfig": "^8.0.0",
     "jest-validate": "^29.4.3",
-    "jiti": "^1.17.1",
-    "lodash.get": "^4.4.2"
+    "jiti": "^1.17.1"
   },
   "files": [
     "LICENSE",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2714,7 +2714,6 @@ __metadata:
     cosmiconfig: ^8.0.0
     jest-validate: ^29.4.3
     jiti: ^1.17.1
-    lodash.get: ^4.4.2
     tsd: ^0.26.1
     unbuild: ^2.0.0
   languageName: unknown


### PR DESCRIPTION
# Description
Remove lodash.get dependency in conf package, it is unused and causes deprecation warnings during `npm install`.

```
> npm install
npm warn deprecated lodash.get@4.4.2: This package is deprecated. Use the optional chaining (?.) operator instead.
```

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
