### PR TITLE
fix: remove unraw dependency

### DIFF
--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -1,7 +1,7 @@
 name: Size Testing
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - synchronize

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
 <h1>Lingui<sub>js</sub></h1>
 
-🌍📖 A readable, automated, and optimized (3 kb) internationalization for JavaScript
+🌍📖 A readable, automated, and optimized (2 kb) internationalization for JavaScript
 
 <hr />
 
@@ -31,7 +31,7 @@ Lingui is an easy yet powerful internationalization (i18n) framework for global 
 
 - **Unopinionated** - Integrate Lingui into your existing workflow. It supports message keys as well as auto-generated messages. Translations are stored either in JSON or standard PO files, which are supported in almost all translation tools.
 
-- **Lightweight and optimized** - Core library is less than [3 kB gzipped](https://bundlephobia.com/result?p=@lingui/core), React components are additional [1.4 kB gzipped](https://bundlephobia.com/result?p=@lingui/react).
+- **Lightweight and optimized** - Core library is less than [2 kB gzipped](https://bundlephobia.com/result?p=@lingui/core), React components are additional [1.4 kB gzipped](https://bundlephobia.com/result?p=@lingui/react).
 
 - **Active community** - Join the growing [community of developers](https://lingui.dev/community) who are using Lingui to build global products.
 

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     {
       "path": "./packages/core/dist/index.mjs",
       "import": "{ i18n }",
-      "limit": "3.5 kB"
+      "limit": "2.25 kB"
     },
     {
       "path": "./packages/detect-locale/dist/index.mjs",
@@ -100,7 +100,7 @@
     },
     {
       "path": "./packages/react/dist/index.mjs",
-      "limit": "2.3 kB",
+      "limit": "2 kB",
       "ignore": [
         "react"
       ]

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -60,8 +60,7 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.20.13",
-    "@lingui/message-utils": "5.3.2",
-    "unraw": "^3.0.0"
+    "@lingui/message-utils": "5.3.2"
   },
   "devDependencies": {
     "@lingui/jest-mocks": "*",

--- a/packages/core/src/escapeSequences.test.ts
+++ b/packages/core/src/escapeSequences.test.ts
@@ -1,0 +1,95 @@
+import {
+  ESCAPE_SEQUENCE_REGEX,
+  decodeEscapeSequences,
+} from "./escapeSequences"
+
+describe("escapeSequences", () => {
+  describe("ESCAPE_SEQUENCE_REGEX", () => {
+    it("should detect valid Unicode sequences", () => {
+      expect(ESCAPE_SEQUENCE_REGEX.test("\\u0041")).toBe(true)
+      expect(ESCAPE_SEQUENCE_REGEX.test("text\\u0041end")).toBe(true)
+    })
+
+    it("should detect valid hex sequences", () => {
+      expect(ESCAPE_SEQUENCE_REGEX.test("\\x41")).toBe(true)
+      expect(ESCAPE_SEQUENCE_REGEX.test("text\\x41end")).toBe(true)
+    })
+
+    it("should not detect invalid sequences", () => {
+      expect(ESCAPE_SEQUENCE_REGEX.test("\\u")).toBe(false)
+      expect(ESCAPE_SEQUENCE_REGEX.test("\\u123")).toBe(false)
+      expect(ESCAPE_SEQUENCE_REGEX.test("\\x")).toBe(false)
+      expect(ESCAPE_SEQUENCE_REGEX.test("\\x1")).toBe(false)
+      expect(ESCAPE_SEQUENCE_REGEX.test("plain text")).toBe(false)
+    })
+  })
+
+  describe("decodeEscapeSequences", () => {
+    describe("valid sequences", () => {
+      it("should convert basic Unicode sequences", () => {
+        expect(decodeEscapeSequences("\\u0041")).toBe("A")
+      })
+
+      it("should convert basic hex sequences", () => {
+        expect(decodeEscapeSequences("\\x41")).toBe("A")
+      })
+
+      it("should convert mixed sequences", () => {
+        expect(decodeEscapeSequences("\\u0041\\x42")).toBe("AB")
+      })
+
+      it("should handle surrogate pairs", () => {
+        // 😀 emoji (U+1F600) as surrogate pair
+        expect(decodeEscapeSequences("\\uD83D\\uDE00")).toBe("😀")
+      })
+
+      it("should handle special Unicode characters", () => {
+        expect(decodeEscapeSequences("\\u00A0")).toBe("\u00A0") // non-breaking space
+        expect(decodeEscapeSequences("\\u00A9")).toBe("©") // copyright
+        expect(decodeEscapeSequences("\\u20AC")).toBe("€") // euro
+      })
+    })
+
+    describe("invalid sequences (should remain unchanged)", () => {
+      it("should leave incomplete sequences as-is", () => {
+        expect(decodeEscapeSequences("\\u")).toBe("\\u")
+        expect(decodeEscapeSequences("\\u0")).toBe("\\u0")
+        expect(decodeEscapeSequences("\\u00")).toBe("\\u00")
+        expect(decodeEscapeSequences("\\u000")).toBe("\\u000")
+        expect(decodeEscapeSequences("\\x")).toBe("\\x")
+        expect(decodeEscapeSequences("\\x0")).toBe("\\x0")
+      })
+
+      it("should leave sequences with invalid characters as-is", () => {
+        expect(decodeEscapeSequences("\\u$$$$")).toBe("\\u$$$$")
+        expect(decodeEscapeSequences("\\x$$")).toBe("\\x$$")
+        expect(decodeEscapeSequences("\\u-123")).toBe("\\u-123")
+        expect(decodeEscapeSequences("\\x-1")).toBe("\\x-1")
+      })
+    })
+
+    describe("mixed valid and invalid sequences", () => {
+      it("should convert valid and leave invalid unchanged", () => {
+        expect(decodeEscapeSequences("\\u0041\\u123\\x42")).toBe("A\\u123B")
+        expect(decodeEscapeSequences("\\u0041\\x4\\u0042")).toBe("A\\x4B")
+      })
+    })
+
+    describe("edge cases", () => {
+      it("should handle empty string", () => {
+        expect(decodeEscapeSequences("")).toBe("")
+      })
+
+      it("should handle strings without escape sequences", () => {
+        expect(decodeEscapeSequences("Hello World")).toBe("Hello World")
+      })
+
+      it("should work with case variations", () => {
+        expect(decodeEscapeSequences("\\u005a")).toBe("Z") // lowercase hex
+        expect(decodeEscapeSequences("\\u005A")).toBe("Z") // uppercase hex
+        expect(decodeEscapeSequences("\\x5a")).toBe("Z") // lowercase hex
+        expect(decodeEscapeSequences("\\x5A")).toBe("Z") // uppercase hex
+      })
+    })
+  })
+})

--- a/packages/core/src/escapeSequences.test.ts
+++ b/packages/core/src/escapeSequences.test.ts
@@ -1,7 +1,4 @@
-import {
-  ESCAPE_SEQUENCE_REGEX,
-  decodeEscapeSequences,
-} from "./escapeSequences"
+import { ESCAPE_SEQUENCE_REGEX, decodeEscapeSequences } from "./escapeSequences"
 
 describe("escapeSequences", () => {
   describe("ESCAPE_SEQUENCE_REGEX", () => {

--- a/packages/core/src/escapeSequences.ts
+++ b/packages/core/src/escapeSequences.ts
@@ -1,0 +1,22 @@
+// Regex for detecting escape sequences (optimized for .test() without capturing groups)
+export const ESCAPE_SEQUENCE_REGEX = /\\u[a-fA-F0-9]{4}|\\x[a-fA-F0-9]{2}/
+
+/**
+ * Converts escape sequences (\uXXXX Unicode and \xXX hexadecimal) to their corresponding characters
+ */
+export const decodeEscapeSequences = (str: string): string => {
+  return str.replace(
+    // Same pattern but with capturing groups for extracting values during replacement
+    /\\u([a-fA-F0-9]{4})|\\x([a-fA-F0-9]{2})/g,
+    (match, unicode, hex) => {
+      if (unicode) {
+        const codePoint = parseInt(unicode, 16)
+        return String.fromCharCode(codePoint)
+      } else if (hex) {
+        const codePoint = parseInt(hex, 16)
+        return String.fromCharCode(codePoint)
+      }
+      return match
+    }
+  )
+}

--- a/packages/core/src/escapeSequences.ts
+++ b/packages/core/src/escapeSequences.ts
@@ -4,19 +4,18 @@ export const ESCAPE_SEQUENCE_REGEX = /\\u[a-fA-F0-9]{4}|\\x[a-fA-F0-9]{2}/
 /**
  * Converts escape sequences (\uXXXX Unicode and \xXX hexadecimal) to their corresponding characters
  */
-export const decodeEscapeSequences = (str: string): string => {
+export const decodeEscapeSequences = (str: string) => {
   return str.replace(
     // Same pattern but with capturing groups for extracting values during replacement
     /\\u([a-fA-F0-9]{4})|\\x([a-fA-F0-9]{2})/g,
-    (match, unicode, hex) => {
+    (_, unicode, hex) => {
       if (unicode) {
         const codePoint = parseInt(unicode, 16)
         return String.fromCharCode(codePoint)
-      } else if (hex) {
+      } else {
         const codePoint = parseInt(hex, 16)
         return String.fromCharCode(codePoint)
       }
-      return match
     }
   )
 }

--- a/packages/core/src/i18n.test.ts
+++ b/packages/core/src/i18n.test.ts
@@ -448,7 +448,7 @@ describe("I18n", () => {
     expect(i18n._("Software development")).toEqual("Software­entwicklung")
     expect(i18n._("Software development")).toEqual("Software­entwicklung")
   })
-  
+
   it("._ should decode escape sequences in uncompiled string messages", () => {
     const i18n = setupI18n({
       locale: "en",

--- a/packages/core/src/i18n.test.ts
+++ b/packages/core/src/i18n.test.ts
@@ -448,6 +448,20 @@ describe("I18n", () => {
     expect(i18n._("Software development")).toEqual("Software­entwicklung")
     expect(i18n._("Software development")).toEqual("Software­entwicklung")
   })
+  
+  it("._ should decode escape sequences in uncompiled string messages", () => {
+    const i18n = setupI18n({
+      locale: "en",
+      messages: { en: {} },
+    })
+
+    expect(i18n._("Hello\\u0020World")).toEqual("Hello World")
+    expect(i18n._("Hello\\x20World")).toEqual("Hello World")
+    expect(i18n._("Tab\\x09separated")).toEqual("Tab\tseparated")
+    expect(i18n._("Mixed\\u0020\\x41nd\\u0020escaped")).toEqual(
+      "Mixed And escaped"
+    )
+  })
 
   it("._ should throw a meaningful error when locale is not set", () => {
     const i18n = setupI18n({})

--- a/packages/core/src/i18n.ts
+++ b/packages/core/src/i18n.ts
@@ -4,10 +4,7 @@ import { date, defaultLocale, number } from "./formats"
 import { EventEmitter } from "./eventEmitter"
 import { compileMessage } from "@lingui/message-utils/compileMessage"
 import type { CompiledMessage } from "@lingui/message-utils/compileMessage"
-import {
-  decodeEscapeSequences,
-  ESCAPE_SEQUENCE_REGEX,
-} from "./escapeSequences"
+import { decodeEscapeSequences, ESCAPE_SEQUENCE_REGEX } from "./escapeSequences"
 
 export type MessageOptions = {
   message?: string

--- a/packages/core/src/i18n.ts
+++ b/packages/core/src/i18n.ts
@@ -1,9 +1,13 @@
-import { interpolate, UNICODE_REGEX } from "./interpolate"
+import { interpolate } from "./interpolate"
 import { isString, isFunction } from "./essentials"
 import { date, defaultLocale, number } from "./formats"
 import { EventEmitter } from "./eventEmitter"
 import { compileMessage } from "@lingui/message-utils/compileMessage"
 import type { CompiledMessage } from "@lingui/message-utils/compileMessage"
+import {
+  decodeEscapeSequences,
+  ESCAPE_SEQUENCE_REGEX,
+} from "./escapeSequences"
 
 export type MessageOptions = {
   message?: string
@@ -295,9 +299,8 @@ Please compile your catalog first.
       }
     }
 
-    // hack for parsing unicode values inside a string to get parsed in react native environments
-    if (isString(translation) && UNICODE_REGEX.test(translation))
-      return JSON.parse(`"${translation}"`) as string
+    if (isString(translation) && ESCAPE_SEQUENCE_REGEX.test(translation))
+      return decodeEscapeSequences(translation)
     if (isString(translation)) return translation
 
     return interpolate(

--- a/packages/core/src/interpolate.ts
+++ b/packages/core/src/interpolate.ts
@@ -9,10 +9,7 @@ import {
 } from "./formats"
 import { isString } from "./essentials"
 import { CompiledIcuChoices } from "@lingui/message-utils/compileMessage"
-import {
-  decodeEscapeSequences,
-  ESCAPE_SEQUENCE_REGEX,
-} from "./escapeSequences"
+import { decodeEscapeSequences, ESCAPE_SEQUENCE_REGEX } from "./escapeSequences"
 
 const OCTOTHORPE_PH = "%__lingui_octothorpe__%"
 

--- a/packages/core/src/interpolate.ts
+++ b/packages/core/src/interpolate.ts
@@ -8,10 +8,11 @@ import {
   time,
 } from "./formats"
 import { isString } from "./essentials"
-import { unraw } from "unraw"
 import { CompiledIcuChoices } from "@lingui/message-utils/compileMessage"
-
-export const UNICODE_REGEX = /\\u[a-fA-F0-9]{4}|\\x[a-fA-F0-9]{2}/
+import {
+  decodeEscapeSequences,
+  ESCAPE_SEQUENCE_REGEX,
+} from "./escapeSequences"
 
 const OCTOTHORPE_PH = "%__lingui_octothorpe__%"
 
@@ -148,11 +149,8 @@ export function interpolate(
     }
 
     const result = formatMessage(translation)
-    if (isString(result) && UNICODE_REGEX.test(result)) {
-      // convert raw unicode sequences back to normal strings
-      // note JSON.parse hack is not working as you might expect https://stackoverflow.com/a/57560631/2210610
-      // that's why special library for that purpose is used
-      return unraw(result)
+    if (isString(result) && ESCAPE_SEQUENCE_REGEX.test(result)) {
+      return decodeEscapeSequences(result)
     }
     if (isString(result)) return result
     return result ? String(result) : ""

--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -39,7 +39,7 @@ Integrate Lingui into your existing workflow. It supports explicit message keys 
 
 ### Lightweight and Optimized
 
-Core library is less than [3 kB gzipped](https://bundlephobia.com/result?p=@lingui/core), React components are additional [1.4 kB gzipped](https://bundlephobia.com/result?p=@lingui/react).
+Core library is less than [2 kB gzipped](https://bundlephobia.com/result?p=@lingui/core), React components are additional [1.4 kB gzipped](https://bundlephobia.com/result?p=@lingui/react).
 
 ### AI Translations Ready
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2722,7 +2722,6 @@ __metadata:
     "@lingui/jest-mocks": "*"
     "@lingui/message-utils": 5.3.2
     unbuild: 2.0.0
-    unraw: ^3.0.0
   peerDependencies:
     "@lingui/babel-plugin-lingui-macro": 5.3.2
     babel-plugin-macros: 2 || 3
@@ -15565,13 +15564,6 @@ __metadata:
   version: 2.0.0
   resolution: "universalify@npm:2.0.0"
   checksum: 2406a4edf4a8830aa6813278bab1f953a8e40f2f63a37873ffa9a3bc8f9745d06cc8e88f3572cb899b7e509013f7f6fcc3e37e8a6d914167a5381d8440518c44
-  languageName: node
-  linkType: hard
-
-"unraw@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "unraw@npm:3.0.0"
-  checksum: 19eee0bc500ce197d262b79723a2c8c81c1d716baaa2a62c48a4d0d6b9e1fd9d350c5df86262e51343d591ab9c8a47ed150317d0b867b2b65795cdc17ef69873
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

Replace the `unraw` library with a lightweight custom implementation for decoding escape sequences.

`unraw` functionality is too redundant and is not used in the code now. We use a regular expression that only finds valid escape sequences. So I propose to use a more lightweight and simple implementation and remove the unraw dependency. This will not change the behavior for the user.

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Examples update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
