### PR TITLE
docs: Add note about react compiler

### DIFF
--- a/website/docs/installation.mdx
+++ b/website/docs/installation.mdx
@@ -56,6 +56,10 @@ Follow these steps to set up Lingui with Babel:
 When using a preset, first check if it includes the `macros` plugin. If so, then you don't need to install and set up `@lingui/babel-plugin-lingui-macro`. For example, `react-scripts` already includes the `macros` plugin.
 :::
 
+:::caution
+If you're using [React Compiler](https://react.dev/learn/react-compiler), make sure that `@lingui/babel-plugin-lingui-macro` comes **before** the React Compiler plugin in the Babel plugins list. This ensures macros are expanded correctly before the compiler processes the code.
+:::
+
 </TabItem>
 <TabItem value="swc" label="SWC">
 
@@ -75,6 +79,12 @@ Follow these steps to set up Lingui with SWC:
 
 :::caution
 SWC Plugin support is still experimental. Semver backwards compatibility between different `@swc/core` versions is not guaranteed. See the [SWC compatibility](/ref/swc-plugin#swc-compatibility) for more information.
+:::
+
+:::caution
+If you're using [React Compiler](https://react.dev/learn/react-compiler) with SWC, the `@lingui/swc-plugin` must run **before** the React Compiler plugin. This is necessary because Lingui macros need to be expanded before the React Compiler processes your code.
+
+However, in Next.js, the React Compiler is enabled via a simple boolean flag (`reactCompiler: true`) in `next.config.js`, and there's currently no way to control plugin ordering. As a result, Lingui may not work correctly with the React Compiler in SWC-based setups like Next.js.
 :::
 
 </TabItem>
@@ -153,10 +163,6 @@ The `@vitejs/plugin-react` plugin uses Babel to transform your code. To use Ling
       ],
     });
     ```
-
-:::caution
-If you're using [React Compiler](https://react.dev/learn/react-compiler), make sure that `@lingui/babel-plugin-lingui-macro` comes **before** the React Compiler plugin in the Babel plugins list. This ensures macros are expanded correctly before the compiler processes the code.
-:::
 
 :::info
 The `@vitejs/plugin-react` does not use the Babel config (e.g. `babel.rc`) from your project by default. You have to enable it manually or specify Babel options directly in `vite.config.ts`.

--- a/website/docs/installation.mdx
+++ b/website/docs/installation.mdx
@@ -154,6 +154,10 @@ The `@vitejs/plugin-react` plugin uses Babel to transform your code. To use Ling
     });
     ```
 
+:::caution
+If you're using [React Compiler](https://react.dev/learn/react-compiler), make sure that `@lingui/babel-plugin-lingui-macro` comes **before** the React Compiler plugin in the Babel plugins list. This ensures macros are expanded correctly before the compiler processes the code.
+:::
+
 :::info
 The `@vitejs/plugin-react` does not use the Babel config (e.g. `babel.rc`) from your project by default. You have to enable it manually or specify Babel options directly in `vite.config.ts`.
 :::


### PR DESCRIPTION
# Description

While setting up Lingui in my Vite project, I noticed that the macros were unstable — some worked, others didn't. After several tests, I realized that my `macros` plugin was listed after the `babel-plugin-react-compiler`. Once I swapped the order of the plugins, everything worked perfectly.

## Types of changes

- [x] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added the necessary documentation
