### PR TITLE
chore: replace cosmiconfig with lilconfig in configuration handling

### DIFF
--- a/packages/conf/package.json
+++ b/packages/conf/package.json
@@ -30,9 +30,9 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.20.13",
-    "cosmiconfig": "^8.0.0",
     "jest-validate": "^29.4.3",
     "jiti": "^1.17.1",
+    "lilconfig": "^3.1.3",
     "picocolors": "^1.1.1"
   },
   "files": [

--- a/packages/conf/src/getConfig.ts
+++ b/packages/conf/src/getConfig.ts
@@ -1,6 +1,6 @@
 import fs from "fs"
 import { LinguiConfigNormalized } from "./types"
-import { cosmiconfigSync, LoaderSync } from "cosmiconfig"
+import { lilconfigSync, LoaderSync } from "lilconfig"
 import path from "path"
 import { makeConfig } from "./makeConfig"
 import type { JITIOptions } from "jiti/dist/types"
@@ -11,7 +11,7 @@ function configExists(path: string) {
 }
 
 function JitiLoader(): LoaderSync {
-  return (filepath, content) => {
+  return (filepath) => {
     const opts: JITIOptions = {
       interopDefault: true,
     }
@@ -22,7 +22,7 @@ function JitiLoader(): LoaderSync {
 
 const moduleName = "lingui"
 
-const configExplorer = cosmiconfigSync(moduleName, {
+const configExplorer = lilconfigSync(moduleName, {
   searchPlaces: [
     `${moduleName}.config.js`,
     `${moduleName}.config.cjs`,
@@ -31,8 +31,6 @@ const configExplorer = cosmiconfigSync(moduleName, {
     "package.json",
     `.${moduleName}rc`,
     `.${moduleName}rc.json`,
-    `.${moduleName}rc.yaml`,
-    `.${moduleName}rc.yml`,
     `.${moduleName}rc.ts`,
     `.${moduleName}rc.js`,
   ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2706,9 +2706,9 @@ __metadata:
   dependencies:
     "@babel/runtime": ^7.20.13
     "@lingui/jest-mocks": "*"
-    cosmiconfig: ^8.0.0
     jest-validate: ^29.4.3
     jiti: ^1.17.1
+    lilconfig: ^3.1.3
     picocolors: ^1.1.1
     unbuild: ^2.0.0
   languageName: unknown
@@ -6338,18 +6338,6 @@ __metadata:
     path-type: ^4.0.0
     yaml: ^1.10.0
   checksum: c53bf7befc1591b2651a22414a5e786cd5f2eeaa87f3678a3d49d6069835a9d8d1aef223728e98aa8fec9a95bf831120d245096db12abe019fecb51f5696c96f
-  languageName: node
-  linkType: hard
-
-"cosmiconfig@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "cosmiconfig@npm:8.0.0"
-  dependencies:
-    import-fresh: ^3.2.1
-    js-yaml: ^4.1.0
-    parse-json: ^5.0.0
-    path-type: ^4.0.0
-  checksum: ff4cdf89ac1ae52e7520816622c21a9e04380d04b82d653f5139ec581aa4f7f29e096d46770bc76c4a63c225367e88a1dfa233ea791669a35101f5f9b972c7d1
   languageName: node
   linkType: hard
 
@@ -10997,7 +10985,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lilconfig@npm:^3.1.2":
+"lilconfig@npm:^3.1.2, lilconfig@npm:^3.1.3":
   version: 3.1.3
   resolution: "lilconfig@npm:3.1.3"
   checksum: 644eb10830350f9cdc88610f71a921f510574ed02424b57b0b3abb66ea725d7a082559552524a842f4e0272c196b88dfe1ff7d35ffcc6f45736777185cd67c9a


### PR DESCRIPTION
# Description

Replace cosmiconfig with lilconfig. A zero-dependency alternative with the same API.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
