### PR TITLE
fix: remove metro peer dep from metro-transformer

### DIFF
--- a/packages/metro-transformer/package.json
+++ b/packages/metro-transformer/package.json
@@ -70,7 +70,6 @@
     "@expo/metro-config": "*",
     "@react-native/metro-babel-transformer": "*",
     "expo": ">=50.0.0",
-    "metro": "*",
     "react-native": ">=0.73.0"
   },
   "peerDependenciesMeta": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2889,7 +2889,6 @@ __metadata:
     "@expo/metro-config": "*"
     "@react-native/metro-babel-transformer": "*"
     expo: ">=50.0.0"
-    metro: "*"
     react-native: ">=0.73.0"
   peerDependenciesMeta:
     "@expo/metro-config":


### PR DESCRIPTION
# Description

fixes `app@workspace:. doesn't provide metro (pb6ef8), requested by @lingui/metro-transformer.` peer dep warning. Metro is always present with react-native and the transformer already has a peer dep on react-native.

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
