### PR TITLE
feat(core): Add global formats options for setupI18n

### DIFF
--- a/packages/core/src/i18n.test.ts
+++ b/packages/core/src/i18n.test.ts
@@ -476,6 +476,77 @@ describe("I18n", () => {
     `)
   })
 
+  describe("global custom formats", () => {
+    const i18n = setupI18n({
+      locale: "fr",
+      formats: {
+        myDateStyle: {
+          day: "numeric",
+        },
+        myNumberStyle: {
+          maximumFractionDigits: 2,
+        },
+      },
+      messages: { fr: {} },
+    })
+
+    const date = new Date("2014-12-06")
+
+    const number = 123.4567
+
+    it("._ should respect global custom date formats", () => {
+      expect(
+        i18n._("It starts on {someDate, date, myDateStyle}", {
+          someDate: date,
+        })
+      ).toMatchInlineSnapshot(`"It starts on 6"`)
+    })
+
+    it("._ should respect global custom number formats", () => {
+      expect(
+        i18n._("Number is {someNumber, number, myNumberStyle}", {
+          someNumber: number,
+        })
+      ).toMatchInlineSnapshot(`"Number is 123,46"`)
+    })
+
+    it("._ should override global custom date formats with local ones", () => {
+      expect(
+        i18n._(
+          "It starts on {someDate, date, myDateStyle}",
+          {
+            someDate: date,
+          },
+          {
+            formats: {
+              myDateStyle: {
+                day: "2-digit",
+              },
+            },
+          }
+        )
+      ).toMatchInlineSnapshot(`"It starts on 06"`)
+    })
+
+    it("._ should override global custom number formats with local ones", () => {
+      expect(
+        i18n._(
+          "Number is {someNumber, number, myNumberStyle}",
+          {
+            someNumber: number,
+          },
+          {
+            formats: {
+              myNumberStyle: {
+                maximumFractionDigits: 3,
+              },
+            },
+          }
+        )
+      ).toMatchInlineSnapshot(`"Number is 123,457"`)
+    })
+  })
+
   describe("ICU date format", () => {
     const i18n = setupI18n({
       locale: "fr",

--- a/packages/core/src/i18n.ts
+++ b/packages/core/src/i18n.ts
@@ -65,6 +65,11 @@ export type I18nProps = {
    */
   localeData?: AllLocaleData
   missing?: MissingHandler
+  /**
+   * Global custom formats to be used in all `i18n._` calls.
+   * Additional passed formats in the `i18n._` call will be merged with the global ones.
+   */
+  formats?: Formats
 }
 
 type Events = {
@@ -89,6 +94,7 @@ export class I18n extends EventEmitter<Events> {
   private _localeData: AllLocaleData = {}
   private _messages: AllMessages = {}
   private _missing?: MissingHandler
+  private _formats: Formats = {}
   private _messageCompiler?: MessageCompiler
 
   constructor(params: I18nProps) {
@@ -104,6 +110,7 @@ export class I18n extends EventEmitter<Events> {
     if (typeof params.locale === "string" || params.locales) {
       this.activate(params.locale ?? defaultLocale, params.locales)
     }
+    if (params.formats != null) this._formats = params.formats
   }
 
   get locale() {
@@ -304,7 +311,7 @@ Please compile your catalog first.
       translation,
       this._locale,
       this._locales
-    )(values, options?.formats)
+    )(values, { ...this._formats, ...options?.formats })
   }
 
   /**

--- a/website/docs/ref/core.md
+++ b/website/docs/ref/core.md
@@ -364,6 +364,25 @@ const i18n = setupI18n({ missing });
 i18n._("missing translation"); // Triggers an alert
 ```
 
+### `options.formats`
+
+Custom format definitions for number, dates and times. An object where keys are format names and values are either `Intl.DateTimeFormatOptions` or `Intl.NumberFormatOptions`.
+
+```tsx
+import { setupI18n } from "@lingui/core";
+
+const i18n = setupI18n({
+  formats: {
+    myDateStyle: {
+      day: "numeric",
+    },
+  }
+});
+i18n._("It starts on {someDate, date, myDateStyle}", {
+  someDate: new Date("2014-12-06"),
+}) === "It starts on 6";
+```
+
 ## AllMessages
 
 The `AllMessages` parameter in the [`I18n.load`](#i18n.load) method is of the following type:


### PR DESCRIPTION
# Description

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

This PR resolves part of the discussed changes in https://github.com/lingui/js-lingui/issues/2279. It adds an opportunity configure formats as an optional parameter in `setupI18n`

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Examples update

Fixes https://github.com/lingui/js-lingui/issues/2279

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
