### PR TITLE
feat(macro): Add arg macro tests, docs and typings

### DIFF
--- a/packages/babel-plugin-lingui-macro/src/macro.ts
+++ b/packages/babel-plugin-lingui-macro/src/macro.ts
@@ -29,6 +29,8 @@ function macro({ state, babel, config }: MacroParams) {
 ;[
   JsMacroName.defineMessage,
   JsMacroName.msg,
+  JsMacroName.arg,
+  JsMacroName.ph,
   JsMacroName.t,
   JsMacroName.useLingui,
   JsMacroName.plural,

--- a/packages/babel-plugin-lingui-macro/test/__snapshots__/js-defineMessage.test.ts.snap
+++ b/packages/babel-plugin-lingui-macro/test/__snapshots__/js-defineMessage.test.ts.snap
@@ -106,7 +106,7 @@ const message =
 `;
 
 exports[`should expand macros in message property 1`] = `
-import { defineMessage, plural, arg } from "@lingui/core/macro";
+import { defineMessage, plural } from "@lingui/core/macro";
 const message = defineMessage({
   comment: "Description",
   message: plural(value, { one: "book", other: "books" }),

--- a/packages/babel-plugin-lingui-macro/test/__snapshots__/js-plural.test.ts.snap
+++ b/packages/babel-plugin-lingui-macro/test/__snapshots__/js-plural.test.ts.snap
@@ -147,6 +147,31 @@ _i18n._(
 
 `;
 
+exports[`Macro with utility arg macro usage in options 1`] = `
+import { plural, arg } from "@lingui/core/macro";
+plural(count, {
+  one: \`# book on {\${arg(today)}, date}\`,
+  other: \`# books on {\${arg(today)}, date}\`,
+});
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { i18n as _i18n } from "@lingui/core";
+_i18n._(
+  /*i18n*/
+  {
+    id: "lEIbMo",
+    message:
+      "{count, plural, one {# book on {today, date}} other {# books on {today, date}}}",
+    values: {
+      count: count,
+      today: today,
+    },
+  }
+);
+
+`;
+
 exports[`plural macro could be renamed 1`] = `
 import { plural as plural2 } from "@lingui/core/macro";
 const a = plural2(count, {

--- a/packages/babel-plugin-lingui-macro/test/__snapshots__/js-t.test.ts.snap
+++ b/packages/babel-plugin-lingui-macro/test/__snapshots__/js-t.test.ts.snap
@@ -534,6 +534,37 @@ _i18n._(
 
 `;
 
+exports[`Variables with arg macro supports named placeholders syntax 1`] = `
+import { t, arg, ph } from "@lingui/core/macro";
+t\`Number {\${arg({ num: getNum() })}, number, myNumberStyle}\`;
+t\`Number {\${arg(ph({ num: getNum() }))}, number, myNumberStyle}\`;
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { i18n as _i18n } from "@lingui/core";
+_i18n._(
+  /*i18n*/
+  {
+    id: "6HvXd1",
+    message: "Number {num, number, myNumberStyle}",
+    values: {
+      num: getNum(),
+    },
+  }
+);
+_i18n._(
+  /*i18n*/
+  {
+    id: "6HvXd1",
+    message: "Number {num, number, myNumberStyle}",
+    values: {
+      num: getNum(),
+    },
+  }
+);
+
+`;
+
 exports[`Variables with escaped double quotes are correctly formatted 1`] = `
 import { t } from "@lingui/core/macro";
 t\`Variable "name"\`;

--- a/packages/babel-plugin-lingui-macro/test/__snapshots__/js-t.test.ts.snap
+++ b/packages/babel-plugin-lingui-macro/test/__snapshots__/js-t.test.ts.snap
@@ -514,6 +514,26 @@ _i18n._(
 
 `;
 
+exports[`Variables with arg macro is not wrapped in curly brackets 1`] = `
+import { t, arg } from "@lingui/core/macro";
+t\`Number {\${arg(num)}, number, myNumberStyle}\`;
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { i18n as _i18n } from "@lingui/core";
+_i18n._(
+  /*i18n*/
+  {
+    id: "6HvXd1",
+    message: "Number {num, number, myNumberStyle}",
+    values: {
+      num: num,
+    },
+  }
+);
+
+`;
+
 exports[`Variables with escaped double quotes are correctly formatted 1`] = `
 import { t } from "@lingui/core/macro";
 t\`Variable "name"\`;

--- a/packages/babel-plugin-lingui-macro/test/js-defineMessage.test.ts
+++ b/packages/babel-plugin-lingui-macro/test/js-defineMessage.test.ts
@@ -21,7 +21,7 @@ macroTester({
     {
       name: "should expand macros in message property",
       code: `
-        import { defineMessage, plural, arg } from '@lingui/core/macro';
+        import { defineMessage, plural } from '@lingui/core/macro';
         const message = defineMessage({
           comment: "Description",
           message: plural(value, { one: "book", other: "books" })

--- a/packages/babel-plugin-lingui-macro/test/js-plural.test.ts
+++ b/packages/babel-plugin-lingui-macro/test/js-plural.test.ts
@@ -70,6 +70,17 @@ macroTester({
     },
 
     {
+      name: "Macro with utility arg macro usage in options",
+      code: `
+        import { plural, arg } from '@lingui/core/macro';
+        plural(count, {
+          "one": \`# book on {\${arg(today)}, date}\`,
+          other: \`# books on {\${arg(today)}, date}\`
+        });
+      `,
+    },
+
+    {
       useTypescriptPreset: true,
       name: "Macro with labeled expression with `as` expression",
       code: `

--- a/packages/babel-plugin-lingui-macro/test/js-t.test.ts
+++ b/packages/babel-plugin-lingui-macro/test/js-t.test.ts
@@ -117,6 +117,14 @@ macroTester({
       `,
     },
     {
+      name: "Variables with arg macro supports named placeholders syntax",
+      code: `
+        import { t, arg, ph } from '@lingui/core/macro';
+        t\`Number {\${arg({num: getNum()})}, number, myNumberStyle}\`;
+        t\`Number {\${arg(ph({num: getNum()}))}, number, myNumberStyle}\`;
+      `,
+    },
+    {
       name: "Newlines are preserved",
       code: `
         import { t } from '@lingui/core/macro';

--- a/packages/babel-plugin-lingui-macro/test/js-t.test.ts
+++ b/packages/babel-plugin-lingui-macro/test/js-t.test.ts
@@ -110,6 +110,13 @@ macroTester({
     `,
     },
     {
+      name: "Variables with arg macro is not wrapped in curly brackets",
+      code: `
+        import { t, arg } from '@lingui/core/macro';
+        t\`Number {\${arg(num)}, number, myNumberStyle}\`;
+      `,
+    },
+    {
       name: "Newlines are preserved",
       code: `
         import { t } from '@lingui/core/macro';

--- a/packages/core/macro/__typetests__/index.tst.ts
+++ b/packages/core/macro/__typetests__/index.tst.ts
@@ -9,6 +9,7 @@ import {
   selectOrdinal,
   select,
   ph,
+  arg,
 } from "@lingui/core/macro"
 
 const name = "Jack"
@@ -295,3 +296,16 @@ expect(
 
 // should accept only strings
 expect(select).type.not.toBeCallableWith("male", { male: 5, other: 5 })
+
+///////////////////
+//// Arg
+///////////////////
+
+// simple
+expect(t`Hello ${arg(name)}`).type.toBe<string>()
+
+// with labeled value
+expect(t`Hello ${arg({ name: user.name })}`).type.toBe<string>()
+
+// with ph labeled value
+expect(t`Hello ${arg(ph({ name: user.name }))}`).type.toBe<string>()

--- a/packages/core/macro/index.d.ts
+++ b/packages/core/macro/index.d.ts
@@ -233,3 +233,15 @@ export const msg: typeof defineMessage
  * Helps to define a name for a variable in the message
  */
 export function ph(def: LabeledExpression<string | number>): string
+
+/**
+ * Helps to inject a variable into the other macro usage without automatically wrapping it in curly brackets,
+ * so it can be used with custom formats.
+ *
+ * @example
+ * ```
+ * import { t, arg } from "@lingui/core/macro";
+ * t`Number {${arg(num)}, number, myNumberStyle}`;
+ * ```
+ */
+export function arg(def: string | number): string

--- a/packages/core/macro/index.d.ts
+++ b/packages/core/macro/index.d.ts
@@ -236,7 +236,7 @@ export function ph(def: LabeledExpression<string | number>): string
 
 /**
  * Helps to inject a variable into the other macro usage without automatically wrapping it in curly brackets,
- * so it can be used with custom formats.
+ * so it can be used with custom ICU expressions.
  *
  * @example
  * ```
@@ -244,4 +244,4 @@ export function ph(def: LabeledExpression<string | number>): string
  * t`Number {${arg(num)}, number, myNumberStyle}`;
  * ```
  */
-export function arg(def: string | number): string
+export function arg(def: MessagePlaceholder): string

--- a/website/docs/ref/macro.mdx
+++ b/website/docs/ref/macro.mdx
@@ -499,6 +499,35 @@ const message = /*i18n*/ {
 
 :::
 
+### `arg`
+
+The `arg` macro is a utility macro that helps to inject a message variables into the other macro usage without automatically wrapping them in curly brackets.
+
+```ts
+arg(value: string | number)
+```
+
+It can be used to apply custom formatting to a variable inside the other macro call. It is an escape hatch for writing message syntax using [ICU MessageFormat](/guides/message-format) on your own.
+
+```js
+import { t, arg } from "@lingui/core/macro";
+const message = t`Number {${arg(num)}, number, myNumberStyle}`;
+
+// ↓ ↓ ↓ ↓ ↓ ↓
+
+import { i18n } from "@lingui/core";
+
+const message = i18n._(
+  /*i18n*/ {
+    id: "6HvXd1",
+    message: "Number {num, number, myNumberStyle}",
+    values: { num },
+  }
+);
+```
+
+:::
+
 ## React Macros
 
 React (JSX) Macros are used in JSX elements and are transformed into the [`Trans`](/ref/react#trans) component imported from the [`@lingui/react`](/ref/react) package.


### PR DESCRIPTION
# Description

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

This PR resolves part of the discussed changes in https://github.com/lingui/js-lingui/issues/2279. It adds tests, docs and typings for the `arg` macro that was already available in the babel plugin.

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Examples update

Fixes https://github.com/lingui/js-lingui/issues/2279

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
