### PR TITLE
chore: add homepage field to package.json for all packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "packages/*",
     "test/*"
   ],
+  "homepage": "https://lingui.dev",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lingui/js-lingui.git"

--- a/packages/babel-plugin-extract-messages/package.json
+++ b/packages/babel-plugin-extract-messages/package.json
@@ -29,6 +29,7 @@
     "README.md",
     "dist/"
   ],
+  "homepage": "https://lingui.dev",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lingui/js-lingui.git",

--- a/packages/babel-plugin-lingui-macro/package.json
+++ b/packages/babel-plugin-lingui-macro/package.json
@@ -70,6 +70,7 @@
     "README.md",
     "dist/"
   ],
+  "homepage": "https://lingui.dev",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lingui/js-lingui.git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,6 +12,7 @@
     "translation",
     "multilingual"
   ],
+  "homepage": "https://lingui.dev",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lingui/js-lingui.git",

--- a/packages/conf/package.json
+++ b/packages/conf/package.json
@@ -7,6 +7,7 @@
     "lingui",
     "config"
   ],
+  "homepage": "https://lingui.dev",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lingui/js-lingui.git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,6 +24,7 @@
     "build": "unbuild",
     "stub": "unbuild --stub"
   },
+  "homepage": "https://lingui.dev",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lingui/js-lingui.git",

--- a/packages/detect-locale/package.json
+++ b/packages/detect-locale/package.json
@@ -24,6 +24,7 @@
     "name": "Sergio Moreno",
     "email": "sergiomorenoalbert@gmail.com"
   },
+  "homepage": "https://lingui.dev",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lingui/js-lingui.git",

--- a/packages/extractor-vue/package.json
+++ b/packages/extractor-vue/package.json
@@ -18,6 +18,7 @@
     "multilingual",
     "lingui-extractor"
   ],
+  "homepage": "https://lingui.dev",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lingui/js-lingui.git",

--- a/packages/format-csv/package.json
+++ b/packages/format-csv/package.json
@@ -23,6 +23,7 @@
     "build": "rimraf ./dist && unbuild",
     "stub": "unbuild --stub"
   },
+  "homepage": "https://lingui.dev",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lingui/js-lingui.git",

--- a/packages/format-json/package.json
+++ b/packages/format-json/package.json
@@ -23,6 +23,7 @@
     "build": "rimraf ./dist && unbuild",
     "stub": "unbuild --stub"
   },
+  "homepage": "https://lingui.dev",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lingui/js-lingui.git",

--- a/packages/format-po-gettext/package.json
+++ b/packages/format-po-gettext/package.json
@@ -25,6 +25,7 @@
     "build": "rimraf ./dist && unbuild",
     "stub": "unbuild --stub"
   },
+  "homepage": "https://lingui.dev",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lingui/js-lingui.git",

--- a/packages/format-po/package.json
+++ b/packages/format-po/package.json
@@ -25,6 +25,7 @@
     "build": "rimraf ./dist && unbuild",
     "stub": "unbuild --stub"
   },
+  "homepage": "https://lingui.dev",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lingui/js-lingui.git",

--- a/packages/jest-mocks/package.json
+++ b/packages/jest-mocks/package.json
@@ -14,6 +14,7 @@
     "testing",
     "mock"
   ],
+  "homepage": "https://lingui.dev",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lingui/js-lingui.git",

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -26,6 +26,7 @@
     "build": "rimraf ./dist && unbuild",
     "stub": "unbuild --stub"
   },
+  "homepage": "https://lingui.dev",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lingui/js-lingui.git",

--- a/packages/macro/package.json
+++ b/packages/macro/package.json
@@ -20,6 +20,7 @@
     "translation",
     "multilingual"
   ],
+  "homepage": "https://lingui.dev",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lingui/js-lingui.git",

--- a/packages/message-utils/package.json
+++ b/packages/message-utils/package.json
@@ -30,6 +30,7 @@
     "build": "rimraf ./dist && unbuild",
     "stub": "unbuild --stub"
   },
+  "homepage": "https://lingui.dev",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lingui/js-lingui.git",

--- a/packages/metro-transformer/package.json
+++ b/packages/metro-transformer/package.json
@@ -39,6 +39,7 @@
     "build": "rimraf ./dist && unbuild",
     "stub": "unbuild --stub"
   },
+  "homepage": "https://lingui.dev",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lingui/js-lingui.git",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -30,6 +30,7 @@
     "build": "rimraf ./dist && unbuild",
     "stub": "unbuild --stub"
   },
+  "homepage": "https://lingui.dev",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lingui/js-lingui.git",

--- a/packages/remote-loader/package.json
+++ b/packages/remote-loader/package.json
@@ -26,6 +26,7 @@
     "build": "rimraf ./dist && unbuild",
     "stub": "unbuild --stub"
   },
+  "homepage": "https://lingui.dev",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lingui/js-lingui.git",

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -23,6 +23,7 @@
     "build": "rimraf ./dist && unbuild",
     "stub": "unbuild --stub"
   },
+  "homepage": "https://lingui.dev",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lingui/js-lingui.git",


### PR DESCRIPTION
# Description

Hi everyone. I need this to quickly find documentation from VScode, and from there I can go to github if needed.

<img width="910" height="266" alt="image" src="https://github.com/user-attachments/assets/3752e1a1-490c-4953-a5d6-97f36437a267" />

When you hover over a dependency in package.json, a tooltip appears with a description, what the latest version is, and a link to the homepage.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
