### PR TITLE
feat: full concurrency for extract / compile commands

### DIFF
--- a/packages/cli/src/api/__snapshots__/catalog.test.ts.snap
+++ b/packages/cli/src/api/__snapshots__/catalog.test.ts.snap
@@ -141,17 +141,13 @@ exports[`Catalog collect should extract messages from source files 1`] = `
   },
   Hello World: {
     comments: [
-      Hello comment,
       Comment A,
       Comment A again,
+      Hello comment,
     ],
     context: undefined,
     message: undefined,
     origin: [
-      [
-        collect/componentA/index.js,
-        1,
-      ],
       [
         collect/componentA/componentA.js,
         2,
@@ -159,6 +155,10 @@ exports[`Catalog collect should extract messages from source files 1`] = `
       [
         collect/componentA/componentA.js,
         3,
+      ],
+      [
+        collect/componentA/index.js,
+        1,
       ],
     ],
     placeholders: {},
@@ -194,17 +194,13 @@ exports[`Catalog collect should extract only files passed on options 1`] = `
   },
   Hello World: {
     comments: [
-      Hello comment,
       Comment A,
       Comment A again,
+      Hello comment,
     ],
     context: undefined,
     message: undefined,
     origin: [
-      [
-        collect/componentA/index.js,
-        1,
-      ],
       [
         collect/componentA/componentA.js,
         2,
@@ -212,6 +208,10 @@ exports[`Catalog collect should extract only files passed on options 1`] = `
       [
         collect/componentA/componentA.js,
         3,
+      ],
+      [
+        collect/componentA/index.js,
+        1,
       ],
     ],
     placeholders: {},
@@ -362,9 +362,9 @@ exports[`Catalog make should collect and write catalogs 2`] = `
     },
     Hello World: {
       comments: [
-        Hello comment,
         Comment A,
         Comment A again,
+        Hello comment,
         js-lingui-explicit-id,
       ],
       context: null,
@@ -375,16 +375,16 @@ exports[`Catalog make should collect and write catalogs 2`] = `
       obsolete: false,
       origin: [
         [
-          collect/componentA/index.js,
-          1,
-        ],
-        [
           collect/componentA/componentA.js,
           2,
         ],
         [
           collect/componentA/componentA.js,
           3,
+        ],
+        [
+          collect/componentA/index.js,
+          1,
         ],
       ],
       translation: ,
@@ -429,9 +429,9 @@ exports[`Catalog make should collect and write catalogs 2`] = `
     },
     Hello World: {
       comments: [
-        Hello comment,
         Comment A,
         Comment A again,
+        Hello comment,
         js-lingui-explicit-id,
       ],
       context: null,
@@ -442,16 +442,16 @@ exports[`Catalog make should collect and write catalogs 2`] = `
       obsolete: false,
       origin: [
         [
-          collect/componentA/index.js,
-          1,
-        ],
-        [
           collect/componentA/componentA.js,
           2,
         ],
         [
           collect/componentA/componentA.js,
           3,
+        ],
+        [
+          collect/componentA/index.js,
+          1,
         ],
       ],
       translation: ,
@@ -606,9 +606,9 @@ exports[`Catalog make should merge with existing catalogs 2`] = `
     },
     Hello World: {
       comments: [
-        Hello comment,
         Comment A,
         Comment A again,
+        Hello comment,
         js-lingui-explicit-id,
       ],
       context: null,
@@ -619,16 +619,16 @@ exports[`Catalog make should merge with existing catalogs 2`] = `
       obsolete: false,
       origin: [
         [
-          collect/componentA/index.js,
-          1,
-        ],
-        [
           collect/componentA/componentA.js,
           2,
         ],
         [
           collect/componentA/componentA.js,
           3,
+        ],
+        [
+          collect/componentA/index.js,
+          1,
         ],
       ],
       translation: ,
@@ -757,9 +757,9 @@ exports[`Catalog make should merge with existing catalogs 2`] = `
     },
     Hello World: {
       comments: [
-        Hello comment,
         Comment A,
         Comment A again,
+        Hello comment,
         js-lingui-explicit-id,
       ],
       context: null,
@@ -770,16 +770,16 @@ exports[`Catalog make should merge with existing catalogs 2`] = `
       obsolete: false,
       origin: [
         [
-          collect/componentA/index.js,
-          1,
-        ],
-        [
           collect/componentA/componentA.js,
           2,
         ],
         [
           collect/componentA/componentA.js,
           3,
+        ],
+        [
+          collect/componentA/index.js,
+          1,
         ],
       ],
       translation: ,
@@ -849,9 +849,9 @@ exports[`Catalog make should only update the specified locale 2`] = `
     },
     Hello World: {
       comments: [
-        Hello comment,
         Comment A,
         Comment A again,
+        Hello comment,
         js-lingui-explicit-id,
       ],
       context: null,
@@ -862,16 +862,16 @@ exports[`Catalog make should only update the specified locale 2`] = `
       obsolete: false,
       origin: [
         [
-          collect/componentA/index.js,
-          1,
-        ],
-        [
           collect/componentA/componentA.js,
           2,
         ],
         [
           collect/componentA/componentA.js,
           3,
+        ],
+        [
+          collect/componentA/index.js,
+          1,
         ],
       ],
       translation: ,
@@ -922,9 +922,9 @@ exports[`Catalog makeTemplate should collect and write a template 2`] = `
   },
   Hello World: {
     comments: [
-      Hello comment,
       Comment A,
       Comment A again,
+      Hello comment,
       js-lingui-explicit-id,
     ],
     context: null,
@@ -935,16 +935,16 @@ exports[`Catalog makeTemplate should collect and write a template 2`] = `
     obsolete: false,
     origin: [
       [
-        collect/componentA/index.js,
-        1,
-      ],
-      [
         collect/componentA/componentA.js,
         2,
       ],
       [
         collect/componentA/componentA.js,
         3,
+      ],
+      [
+        collect/componentA/index.js,
+        1,
       ],
     ],
     translation: ,

--- a/packages/cli/src/api/catalog.ts
+++ b/packages/cli/src/api/catalog.ts
@@ -80,9 +80,12 @@ export class Catalog {
   }
 
   async make(options: MakeOptions): Promise<AllCatalogsType | false> {
-    const nextCatalog = await this.collect({ files: options.files })
+    const [nextCatalog, prevCatalogs] = await Promise.all([
+      this.collect({ files: options.files }),
+      this.readAll(),
+    ])
+
     if (!nextCatalog) return false
-    const prevCatalogs = await this.readAll()
 
     const catalogs = this.merge(prevCatalogs, nextCatalog, {
       overwrite: options.overwrite,

--- a/packages/cli/src/api/catalog/extractFromFiles.ts
+++ b/packages/cli/src/api/catalog/extractFromFiles.ts
@@ -74,9 +74,11 @@ export async function extractFromFiles(
             ...prev,
             message: prev.message ?? next.message,
             comments: next.comment
-              ? [...prev.comments, next.comment]
+              ? [...prev.comments, next.comment].sort()
               : prev.comments,
-            origin: [...prev.origin, [filename, next.origin[1]]],
+            origin: (
+              [...prev.origin, [filename, next.origin[1]]] as MessageOrigin[]
+            ).sort((a, b) => a[0].localeCompare(b[0])),
             placeholders: mergePlaceholders(
               prev.placeholders,
               next.placeholders

--- a/packages/cli/src/api/compile.ts
+++ b/packages/cli/src/api/compile.ts
@@ -49,24 +49,26 @@ export function createCompiledCatalog(
 
   const errors: MessageCompilationError[] = []
 
-  const compiledMessages = Object.keys(messages).reduce<{
-    [msgId: string]: CompiledMessage
-  }>((obj, key: string) => {
-    // Don't use `key` as a fallback translation in strict mode.
-    const translation = (messages[key] || (!strict ? key : "")) as string
+  const compiledMessages = Object.keys(messages)
+    .sort()
+    .reduce<{
+      [msgId: string]: CompiledMessage
+    }>((obj, key: string) => {
+      // Don't use `key` as a fallback translation in strict mode.
+      const translation = (messages[key] || (!strict ? key : "")) as string
 
-    try {
-      obj[key] = compile(translation, shouldPseudolocalize)
-    } catch (e) {
-      errors.push({
-        id: key,
-        source: translation,
-        error: e as Error,
-      })
-    }
+      try {
+        obj[key] = compile(translation, shouldPseudolocalize)
+      } catch (e) {
+        errors.push({
+          id: key,
+          source: translation,
+          error: e as Error,
+        })
+      }
 
-    return obj
-  }, {})
+      return obj
+    }, {})
 
   if (namespace === "json") {
     return { source: JSON.stringify({ messages: compiledMessages }), errors }

--- a/packages/cli/src/lingui-extract.ts
+++ b/packages/cli/src/lingui-extract.ts
@@ -33,18 +33,20 @@ export default async function command(
 
   const spinner = ora().start()
 
-  for (const catalog of catalogs) {
-    const result = await catalog.make({
-      ...(options as CliExtractOptions),
-      orderBy: config.orderBy,
+  await Promise.all(
+    catalogs.map(async (catalog) => {
+      const result = await catalog.make({
+        ...(options as CliExtractOptions),
+        orderBy: config.orderBy,
+      })
+
+      catalogStats[
+        normalizePath(nodepath.relative(config.rootDir, catalog.path))
+      ] = result || {}
+
+      commandSuccess &&= Boolean(result)
     })
-
-    catalogStats[
-      normalizePath(nodepath.relative(config.rootDir, catalog.path))
-    ] = result || {}
-
-    commandSuccess &&= Boolean(result)
-  }
+  )
 
   if (commandSuccess) {
     spinner.succeed()

--- a/packages/cli/src/test/__snapshots__/compile.test.ts.snap
+++ b/packages/cli/src/test/__snapshots__/compile.test.ts.snap
@@ -45,6 +45,6 @@ Reason: Unexpected message end at line 1 col 13:
 These errors fail command execution because \`--strict\` option passed
 `;
 
-exports[`CLI Command: Compile merge Should merge individual catalogs if  catalogsMergePath specified in lingui config 1`] = `/*eslint-disable*/module.exports={messages:JSON.parse("{\\"Z3YTTJ\\":[\\"Foo Hello World\\"],\\"iWZSiH\\":[\\"Bar Hello World\\"]}")};`;
+exports[`CLI Command: Compile merge Should merge individual catalogs if catalogsMergePath specified in lingui config 1`] = `/*eslint-disable*/module.exports={messages:JSON.parse("{\\"Z3YTTJ\\":[\\"Foo Hello World\\"],\\"iWZSiH\\":[\\"Bar Hello World\\"]}")};`;
 
-exports[`CLI Command: Compile merge Should merge individual catalogs if  catalogsMergePath specified in lingui config 2`] = `/*eslint-disable*/module.exports={messages:JSON.parse("{\\"Z3YTTJ\\":[\\"[PL] Foo Hello World\\"],\\"iWZSiH\\":[\\"[PL] Bar Hello World\\"]}")};`;
+exports[`CLI Command: Compile merge Should merge individual catalogs if catalogsMergePath specified in lingui config 2`] = `/*eslint-disable*/module.exports={messages:JSON.parse("{\\"Z3YTTJ\\":[\\"[PL] Foo Hello World\\"],\\"iWZSiH\\":[\\"[PL] Bar Hello World\\"]}")};`;

--- a/packages/cli/src/test/__snapshots__/compile.test.ts.snap
+++ b/packages/cli/src/test/__snapshots__/compile.test.ts.snap
@@ -17,19 +17,22 @@ exports[`CLI Command: Compile allowEmpty = false Should show error and stop comp
 Error: Failed to compile catalog for locale en!
 Missing 1 translation(s)
 
+Error: Failed to compile catalog for locale pl!
+Missing 1 translation(s)
+
 `;
 
 exports[`CLI Command: Compile allowEmpty = false Should show missing messages verbosely when verbose = true 1`] = `
-en ⇒ en.js
 Error: Failed to compile catalog for locale pl!
 Missing translations:
 mY42CM: (Hello World)
 2ZeN02: (Test String)
 
+en ⇒ en.js
 `;
 
 exports[`CLI Command: Compile failOnCompileError = true Should show error and stop compilation of catalog if message has compilation error 1`] = `
-Failed to compile catalog for locale en!
+Failed to compile catalog for locale pl!
 
 Compilation error for 1 translation(s):
 

--- a/packages/cli/src/test/compile.test.ts
+++ b/packages/cli/src/test/compile.test.ts
@@ -209,7 +209,7 @@ msgstr "Hello {hello"
       })
     }
 
-    it("Should merge individual catalogs if  catalogsMergePath specified in lingui config", async () => {
+    it("Should merge individual catalogs if catalogsMergePath specified in lingui config", async () => {
       expect.assertions(4)
 
       const rootDir = await createFixtures({

--- a/packages/cli/src/test/compile.test.ts
+++ b/packages/cli/src/test/compile.test.ts
@@ -161,6 +161,10 @@ msgstr ""
         const rootDir = await createFixtures({
           "en.po": `
 msgid "Hello World"
+msgstr "Hello {hello}"
+        `,
+          "pl.po": `
+msgid "Hello World"
 msgstr "Hello {hello"
         `,
         })
@@ -174,7 +178,7 @@ msgstr "Hello {hello"
           })
           const actualFiles = readFsToListing(config.rootDir)
 
-          expect(actualFiles["en.js"]).toBeFalsy()
+          expect(actualFiles["pl.js"]).toBeFalsy()
 
           const log = getConsoleMockCalls(console.error)
           expect(log).toMatchSnapshot()

--- a/packages/cli/test/extractor-experimental-template/expected/about.page.en.js
+++ b/packages/cli/test/extractor-experimental-template/expected/about.page.en.js
@@ -1,1 +1,1 @@
-/*eslint-disable*/module.exports={messages:JSON.parse("{\"u5PTM8\":[\"about page message\"],\"1TzdHc\":[\"aliased module message\"],\"LGGfGX\":[\"header message\"],\"8Pj7KC\":[\"JSX: about page message\"]}")};
+/*eslint-disable*/module.exports={messages:JSON.parse("{\"1TzdHc\":[\"aliased module message\"],\"8Pj7KC\":[\"JSX: about page message\"],\"LGGfGX\":[\"header message\"],\"u5PTM8\":[\"about page message\"]}")};

--- a/packages/cli/test/extractor-experimental-template/expected/about.page.pl.js
+++ b/packages/cli/test/extractor-experimental-template/expected/about.page.pl.js
@@ -1,1 +1,1 @@
-/*eslint-disable*/module.exports={messages:JSON.parse("{\"u5PTM8\":[\"about page message\"],\"1TzdHc\":[\"aliased module message\"],\"LGGfGX\":[\"header message\"],\"8Pj7KC\":[\"JSX: about page message\"]}")};
+/*eslint-disable*/module.exports={messages:JSON.parse("{\"1TzdHc\":[\"aliased module message\"],\"8Pj7KC\":[\"JSX: about page message\"],\"LGGfGX\":[\"header message\"],\"u5PTM8\":[\"about page message\"]}")};

--- a/packages/cli/test/extractor-experimental/expected/about.page.en.js
+++ b/packages/cli/test/extractor-experimental/expected/about.page.en.js
@@ -1,1 +1,1 @@
-/*eslint-disable*/module.exports={messages:JSON.parse("{\"u5PTM8\":[\"about page message\"],\"VmkjGB\":[\"Green\"],\"LGGfGX\":[\"header message\"]}")};
+/*eslint-disable*/module.exports={messages:JSON.parse("{\"LGGfGX\":[\"header message\"],\"VmkjGB\":[\"Green\"],\"u5PTM8\":[\"about page message\"]}")};

--- a/packages/cli/test/extractor-experimental/expected/about.page.pl.js
+++ b/packages/cli/test/extractor-experimental/expected/about.page.pl.js
@@ -1,1 +1,1 @@
-/*eslint-disable*/module.exports={messages:JSON.parse("{\"u5PTM8\":[\"about page message\"],\"VmkjGB\":[\"Green\"],\"LGGfGX\":[\"translation: header message\"],\"nPi9F1\":[\"this should be marked as obsolete\"]}")};
+/*eslint-disable*/module.exports={messages:JSON.parse("{\"LGGfGX\":[\"translation: header message\"],\"VmkjGB\":[\"Green\"],\"nPi9F1\":[\"this should be marked as obsolete\"],\"u5PTM8\":[\"about page message\"]}")};

--- a/packages/metro-transformer/test/metroTransformer.test.ts
+++ b/packages/metro-transformer/test/metroTransformer.test.ts
@@ -15,41 +15,44 @@ describe("Lingui Metro transformer tests", () => {
     process.chdir(priorCwd)
   })
 
-  it.each([
-    [
-      "English PO file",
-      "en",
-      `/*eslint-disable*/export const messages=JSON.parse("{\\"p1AaTM\\":[\\"Add a message to your inbox\\"],\\"dEgA5A\\":[\\"Cancel\\"]}");`,
-    ],
-    [
-      "Czech PO file with fallback to English",
-      "cs",
-      `/*eslint-disable*/export const messages=JSON.parse("{\\"p1AaTM\\":[\\"Přidat zprávu do doručené pošty\\"],\\"dEgA5A\\":[\\"Cancel\\"]}");`,
-    ],
-  ])(
-    "should transform %s to a JS export",
-    async (_label, langCode, expectedSnapshot) => {
-      const filename = path.relative(
-        testProjectDir,
-        path.join(catalogsDir, langCode, "messages.po")
-      )
-      const result = await transformFile({
-        filename,
-      })
+  it("should transform English PO file to a JS export", async () => {
+    const filename = path.relative(
+      testProjectDir,
+      path.join(catalogsDir, "en", "messages.po")
+    )
+    const result = await transformFile({
+      filename,
+    })
 
-      expect(result).toMatchInlineSnapshot(expectedSnapshot)
-    }
-  )
+    expect(result).toMatchInlineSnapshot(
+      `/*eslint-disable*/export const messages=JSON.parse("{\\"dEgA5A\\":[\\"Cancel\\"],\\"p1AaTM\\":[\\"Add a message to your inbox\\"]}");`
+    )
+  })
+
+  it("should transform Czech PO file with fallback to English to a JS export", async () => {
+    const filename = path.relative(
+      testProjectDir,
+      path.join(catalogsDir, "cs", "messages.po")
+    )
+    const result = await transformFile({
+      filename,
+    })
+
+    expect(result).toMatchInlineSnapshot(
+      `/*eslint-disable*/export const messages=JSON.parse("{\\"dEgA5A\\":[\\"Cancel\\"],\\"p1AaTM\\":[\\"Přidat zprávu do doručené pošty\\"]}");`
+    )
+  })
 
   it("given a valid absolute path (not relative to lingui config root), transformer will turn it into path relative to lingui config and succeed", async () => {
     // this is not how the `transformFile` function would be called in a real project and covers an implementation detail
     const filename = path.join(catalogsDir, "en", "messages.po")
-    await expect(
-      transformFile({
-        filename,
-      })
-    ).resolves.toMatchInlineSnapshot(
-      `/*eslint-disable*/export const messages=JSON.parse("{\\"p1AaTM\\":[\\"Add a message to your inbox\\"],\\"dEgA5A\\":[\\"Cancel\\"]}");`
+
+    const result = await transformFile({
+      filename,
+    })
+
+    expect(result).toMatchInlineSnapshot(
+      `/*eslint-disable*/export const messages=JSON.parse("{\\"dEgA5A\\":[\\"Cancel\\"],\\"p1AaTM\\":[\\"Add a message to your inbox\\"]}");`
     )
   })
 


### PR DESCRIPTION
# Description

Closes https://github.com/lingui/js-lingui/issues/2253

This PR enables full concurrency execution for extract and compile comands.

Instead of 

```js
for (item of items) {
  await doJob()
}
```

Using 
```js
Promise.all(items.map(async () => {
  await doJob()
}))
```


[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
