### PR TITLE
refactor: avoid unnecessary object spreads in Trans

### DIFF
--- a/packages/react/src/TransNoContext.tsx
+++ b/packages/react/src/TransNoContext.tsx
@@ -52,39 +52,7 @@ export function TransNoContext(
     lingui: { i18n, defaultComponent },
   } = props
 
-  const values = { ...props.values }
-  const components = { ...props.components }
-
-  if (values) {
-    /*
-      Replace values placeholders with <INDEX /> and add values to `components`.
-      This makes them processed as JSX children and follow JSX semantics.
-
-      Related discussion: https://github.com/lingui/js-lingui/issues/1904
-
-      Another use-case is when React components directly passed as values:
-
-      Example:
-      Translation: 'Hello {name}'
-      Values: { name: <strong>Jane</strong> }
-
-      It'll become "Hello <0 />" with components=[<strong>Jane</strong>]
-
-      Related discussion: https://github.com/lingui/js-lingui/issues/183
-    */
-    Object.keys(values).forEach((key) => {
-      const index = Object.keys(components).length
-
-      // simple scalars should be processed as values to be able to apply formatting
-      if (typeof values[key] === "string" || typeof values[key] === "number") {
-        return
-      }
-
-      // react components, arrays, falsy values, all should be processed as JSX children
-      components[index] = <>{values[key] as ReactNode}</>
-      values[key] = `<${index}/>`
-    })
-  }
+  const { values, components } = getInterpolationValuesAndComponents(props)
 
   const _translation: string =
     i18n && typeof i18n._ === "function"
@@ -145,4 +113,43 @@ export function TransNoContext(
 const RenderFragment = ({ children }: TransRenderProps) => {
   // cannot use React.Fragment directly because we're passing in props that it doesn't support
   return <React.Fragment>{children}</React.Fragment>
+}
+
+const getInterpolationValuesAndComponents = (props: TransProps) => {
+  if (!props.values) {
+    return {
+      values: undefined,
+      components: props.components,
+    }
+  }
+
+  const values = { ...props.values }
+  const components = { ...props.components }
+  /*
+      Replace values placeholders with <INDEX /> and add values to `components`.
+      This makes them processed as JSX children and follow JSX semantics.
+
+      Related discussion: https://github.com/lingui/js-lingui/issues/1904
+
+      Another use-case is when React components are directly passed as values:
+
+      Example:
+      Translation: 'Hello {name}'
+      Values: { name: <strong>Jane</strong> }
+
+      It'll become "Hello <0 />" with components=[<strong>Jane</strong>]
+
+      Related discussion: https://github.com/lingui/js-lingui/issues/183
+    */
+  Object.entries(props.values).forEach(([key, valueForKey]) => {
+    // simple scalars should be processed as values to be able to apply formatting
+    if (typeof valueForKey === "string" || typeof valueForKey === "number") {
+      return
+    }
+    const index = Object.keys(components).length
+    // react components, arrays, falsy values, all should be processed as JSX children
+    components[index] = <>{valueForKey as ReactNode}</>
+    values[key] = `<${index}/>`
+  })
+  return { values, components }
 }

--- a/packages/react/src/format.ts
+++ b/packages/react/src/format.ts
@@ -27,19 +27,19 @@ const voidElementTags = {
 /**
  * `formatElements` - parse string and return tree of react elements
  *
- * `value` is string to be formatted with <tag>Paired<tag/> or <tag/> (unpaired)
- * placeholders. `elements` is a array of react elements which indexes
- * correspond to element indexes in formatted string
+ * `value` is a string to be formatted with <tag>Paired<tag/> or <tag/> (unpaired)
+ * placeholders. `elements` is an array of react elements whose indexes
+ * correspond to element indexes in the formatted string
  */
 function formatElements(
   value: string,
   elements: { [key: string]: React.ReactElement } = {}
 ): string | React.ReactElement | Array<React.ReactElement | string> {
-  const uniqueId = makeCounter(0, "$lingui$")
   const parts = value.split(tagRe)
-
   // no inline elements, return
   if (parts.length === 1) return value
+
+  const uniqueId = makeCounter(0, "$lingui$")
 
   const tree: Array<React.ReactElement | string> = []
 


### PR DESCRIPTION
# Description

This is a fairly small refactor that just avoids object spreads for `values` and `components`, and the following `if (values) {...` condition (which, due to the spread would always evaluate to true), where it isn't needed.

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] internal refactor, non breaking

## Test plan

- green CI

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
