### PR TITLE
feat: allow custom props in Trans macro

### DIFF
--- a/packages/react/src/TransNoContext.tsx
+++ b/packages/react/src/TransNoContext.tsx
@@ -30,6 +30,7 @@ export type TransProps = {
   components?: { [key: string]: React.ElementType | any }
   formats?: MessageOptions["formats"]
   comment?: string
+  [key: string]: any
 } & TransRenderCallbackOrComponent
 
 /**
@@ -50,6 +51,7 @@ export function TransNoContext(
     message,
     formats,
     lingui: { i18n, defaultComponent },
+    ...textProps,
   } = props
 
   const { values, components } = getInterpolationValuesAndComponents(props)
@@ -72,7 +74,8 @@ export function TransNoContext(
   const FallbackComponent: React.ComponentType<TransRenderProps> =
     defaultComponent || RenderFragment
 
-  const i18nProps: TransRenderProps = {
+  const renderProps: TransRenderProps = {
+    ...textProps,
     id,
     message,
     translation,
@@ -94,20 +97,20 @@ export function TransNoContext(
     console.error(
       `Invalid value supplied to prop \`component\`. It must be a React component, provided ${component}`
     )
-    return React.createElement(FallbackComponent, i18nProps, translation)
+    return React.createElement(FallbackComponent, renderProps, translation)
   }
 
   // Rendering using a render prop
   if (typeof render === "function") {
     // Component: render={(props) => <a title={props.translation}>x</a>}
-    return render(i18nProps)
+    return render(renderProps)
   }
 
   // `component` prop has a higher precedence over `defaultComponent`
   const Component: React.ComponentType<TransRenderProps> =
     component || FallbackComponent
 
-  return React.createElement(Component, i18nProps, translation)
+  return React.createElement(Component, renderProps, translation)
 }
 
 const RenderFragment = ({ children }: TransRenderProps) => {


### PR DESCRIPTION
# Description

Improves DX by expanding the [LocalConfiguration](https://lingui.dev/ref/react#local-configuration) with `[key: string]: any`, which was only possible before with `render` or `component` props

### Before

```tsx
const Header = props => (
  <Text {...props} style={{ fontSize: 20 }} />
);

<Trans component={Header}>Hello</Trans>
```

### After

```tsx
<Trans style={{ fontSize: 20 }}>Hello</Trans>
```

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)