### PR TITLE
fix: orderByMessage should also order by context

### DIFF
--- a/packages/cli/src/api/catalog.test.ts
+++ b/packages/cli/src/api/catalog.test.ts
@@ -617,7 +617,7 @@ describe("order", () => {
     expect(Object.keys(orderedCatalogs)).toMatchSnapshot()
   })
 
-  it("should order messages by message", () => {
+  it("should order messages by message and then by context", () => {
     const catalog = {
       msg1: makeNextMessage({
         message: "B",
@@ -630,6 +630,7 @@ describe("order", () => {
       msg2: makeNextMessage({
         // message is optional.
         translation: "A",
+        context: "context1",
         origin: [["file2.js", 3]],
       }),
       msg3: makeNextMessage({
@@ -642,6 +643,18 @@ describe("order", () => {
         translation: "C",
         origin: [["file1.js", 1]],
       }),
+      msg5: makeNextMessage({
+        message: "B",
+        translation: "B",
+        context: "context3",
+        origin: [["file2.js", 4]],
+      }),
+      msg6: makeNextMessage({
+        message: "B",
+        translation: "B",
+        context: "context2",
+        origin: [["file2.js", 5]],
+      }),
     }
 
     const orderedCatalogs = order("message", catalog)
@@ -651,6 +664,8 @@ describe("order", () => {
       [
         msg2,
         msg1,
+        msg6,
+        msg5,
         msg4,
         msg3,
       ]

--- a/packages/cli/src/api/catalog.ts
+++ b/packages/cli/src/api/catalog.ts
@@ -376,7 +376,9 @@ export function orderByMessage<T extends ExtractedCatalogType>(messages: T): T {
     .sort((a, b) => {
       const aMsg = messages[a].message || ""
       const bMsg = messages[b].message || ""
-      return collator.compare(aMsg, bMsg)
+      const aCtxt = messages[a].context || ""
+      const bCtxt = messages[b].context || ""
+      return collator.compare(aMsg, bMsg) || collator.compare(aCtxt, bCtxt)
     })
     .reduce((acc, key) => {
       ;(acc as any)[key] = messages[key]


### PR DESCRIPTION
# Description

Fixed a bug causing inconsistent ordering of extracted messages when messages differ only by context.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

Fixes https://github.com/lingui/js-lingui/issues/2336

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
