### PR TITLE
fix(macro): recrawl scope only if useLingui was used

### DIFF
--- a/packages/babel-plugin-lingui-macro/src/index.ts
+++ b/packages/babel-plugin-lingui-macro/src/index.ts
@@ -284,7 +284,6 @@ export default function ({
 
                 try {
                   newNode = macro.replacePath(path)
-                  path.scope.crawl()
                 } catch (e) {
                   reportUnsupportedSyntax(path, e as Error)
                 }
@@ -296,6 +295,11 @@ export default function ({
                     addImport(macroImports, state, "useLingui").reference(
                       newPath
                     )
+
+                    // rebuild scope bindings if useLingui hook was used
+                    // allow further plugins, such as React Compiler to process
+                    // source correctly
+                    path.scope.crawl()
                   }
 
                   if (macro.needsI18nImport) {


### PR DESCRIPTION
# Description

Probably i introduced a huge performance regression when added scope recrawling in https://github.com/lingui/js-lingui/pull/2356 

The scope recrawling happened for all `CallExpression|TaggedTemplateExpression` despite was it a macro or not, or was it a useLingui hook which actually need a recrawling a bindnings. 

This PR fixes that by moving scope recrawling to only when `useLingui` hook was transpiled. 

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

Potentially fixes https://github.com/lingui/js-lingui/issues/2369

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
