### PR TITLE
fix(cli): allow using PO formatter function with Translation.IO

### DIFF
--- a/packages/cli/src/services/translationIO.ts
+++ b/packages/cli/src/services/translationIO.ts
@@ -47,7 +47,7 @@ const validCatalogFormat = (config: LinguiConfigNormalized): boolean => {
   if (typeof config.format === "string") {
     return config.format === "po"
   }
-  return config.format.catalogExtension === ".pot"
+  return config.format.catalogExtension === ".po"
 }
 
 // Main sync method, call "Init" or "Sync" depending on the project context


### PR DESCRIPTION
# Description

Translation.io sync checks if `config.format === 'po'` which is insufficient because the formatter can also be the function exported from the `format-po` package.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

Fixes https://github.com/lingui/js-lingui/issues/2374

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
