### PR TITLE
revert: "fix: use makePathRegexSafe with globSync (#2242)"

### DIFF
--- a/packages/cli/src/api/__snapshots__/catalog.test.ts.snap
+++ b/packages/cli/src/api/__snapshots__/catalog.test.ts.snap
@@ -19,23 +19,6 @@ exports[`Catalog POT Flow Should get translations from template if locale file n
 }
 `;
 
-exports[`Catalog collect should extract files with special characters in the include path 1`] = `
-{
-  Component D: {
-    comments: [],
-    context: undefined,
-    message: undefined,
-    origin: [
-      [
-        collect/[componentD]/index.js,
-        1,
-      ],
-    ],
-    placeholders: {},
-  },
-}
-`;
-
 exports[`Catalog collect should extract files with special characters when passed in options 1`] = `
 {
   Component C: {

--- a/packages/cli/src/api/catalog.test.ts
+++ b/packages/cli/src/api/catalog.test.ts
@@ -351,21 +351,6 @@ describe("Catalog", () => {
       expect(messages).toMatchSnapshot()
     })
 
-    it("should extract files with special characters in the include path", async () => {
-      const catalog = new Catalog(
-        {
-          name: "messages",
-          path: "locales/{locale}",
-          include: [fixture("collect/[componentD]")],
-          exclude: [],
-          format,
-        },
-        mockConfig()
-      )
-      const messages = await catalog.collect()
-      expect(messages).toMatchSnapshot()
-    })
-
     it("should throw an error when duplicate identifier with different defaults found", async () => {
       const catalog = new Catalog(
         {

--- a/packages/cli/src/api/catalog.ts
+++ b/packages/cli/src/api/catalog.ts
@@ -246,24 +246,22 @@ export class Catalog {
   }
 
   get sourcePaths() {
-    const includeGlobs = this.include
-      .map((includePath) => {
-        const isDir = isDirectory(includePath)
-        /**
-         * glob library results from absolute patterns such as /foo/* are mounted onto the root setting using path.join.
-         * On windows, this will by default result in /foo/* matching C:\foo\bar.txt.
-         */
-        return isDir
-          ? normalize(
-              path.resolve(
-                process.cwd(),
-                includePath === "/" ? "" : includePath,
-                "**/*.*"
-              )
+    const includeGlobs = this.include.map((includePath) => {
+      const isDir = isDirectory(includePath)
+      /**
+       * glob library results from absolute patterns such as /foo/* are mounted onto the root setting using path.join.
+       * On windows, this will by default result in /foo/* matching C:\foo\bar.txt.
+       */
+      return isDir
+        ? normalize(
+            path.resolve(
+              process.cwd(),
+              includePath === "/" ? "" : includePath,
+              "**/*.*"
             )
-          : includePath
-      })
-      .map(makePathRegexSafe)
+          )
+        : includePath
+    })
 
     return globSync(includeGlobs, { ignore: this.exclude, mark: true })
   }


### PR DESCRIPTION
This reverts commit 7a8256c7b8699b73d1181f6f34bfe3734e9996ac.

fixes https://github.com/lingui/js-lingui/issues/2352


# Description

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
