### PR TITLE
fix: keep catalog extra from previous catalog

### DIFF
--- a/packages/cli/src/api/catalog/mergeCatalog.test.ts
+++ b/packages/cli/src/api/catalog/mergeCatalog.test.ts
@@ -151,4 +151,37 @@ describe("mergeCatalog", () => {
       }),
     })
   })
+
+  it("should keep message extra from the previous catalog", () => {
+    const prevCatalog: CatalogType = {
+      Hello: {
+        translation: "Hallo",
+        extra: { flags: ["myTag"] },
+      },
+    }
+
+    const nextCatalog: ExtractedCatalogType = {
+      Hello: {
+        message: "Hello",
+        origin: [["src/app.ts", 1]],
+      },
+    }
+
+    const result = mergeCatalog(prevCatalog, nextCatalog, false, {})
+    expect(result["Hello"]).toMatchInlineSnapshot(`
+      {
+        flags: [
+          myTag,
+        ],
+        message: Hello,
+        origin: [
+          [
+            src/app.ts,
+            1,
+          ],
+        ],
+        translation: Hallo,
+      }
+    `)
+  })
 })

--- a/packages/cli/src/api/catalog/mergeCatalog.ts
+++ b/packages/cli/src/api/catalog/mergeCatalog.ts
@@ -38,8 +38,9 @@ export function mergeCatalog(
         : prevCatalog[key].translation
 
       const { obsolete, ...rest } = nextCatalog[key]
+      const { extra } = prevCatalog[key]
 
-      return [key, { ...rest, translation }]
+      return [key, { ...extra, ...rest, translation }]
     })
   )
 


### PR DESCRIPTION
# Description

Keep the whole `extra` from previous catalog on merge

fixes https://github.com/lingui/js-lingui/issues/2398

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
