### PR TITLE
chore: update prettier v3 import to use named format function

### DIFF
--- a/packages/babel-plugin-lingui-macro/test/macroTester.ts
+++ b/packages/babel-plugin-lingui-macro/test/macroTester.ts
@@ -1,6 +1,6 @@
 import linguiMacroPlugin, { LinguiPluginOpts } from "../src"
 import { transformFileSync, transformSync, TransformOptions } from "@babel/core"
-import prettier from "prettier"
+import { format } from "prettier"
 import path from "path"
 import fs from "fs"
 import linguiMacro from "../src/macro"
@@ -44,9 +44,7 @@ export function macroTester(opts: MacroTesterOptions) {
   process.env.LINGUI_CONFIG = path.join(__dirname, "lingui.config.js")
 
   const clean = (value: string) =>
-    prettier
-      .format(value, { parser: "typescript" })
-      .then((c) => c.replace(/\n+/, "\n"))
+    format(value, { parser: "typescript" }).then((c) => c.replace(/\n+/, "\n"))
 
   opts.cases.forEach((testCase, index) => {
     const {


### PR DESCRIPTION
# Description

Fix Prettier v3 import in macro tests. Named import `{ format }` works correctly with Prettier's async API in Vitest environment.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)

