### PR TITLE
fix(macro): Ignore JSX comments when generating message ids

### DIFF
--- a/packages/babel-plugin-lingui-macro/src/macroJsx.ts
+++ b/packages/babel-plugin-lingui-macro/src/macroJsx.ts
@@ -220,6 +220,12 @@ export class MacroJSX {
     if (path.isJSXExpressionContainer()) {
       const exp = path.get("expression") as NodePath<Expression>
 
+      // Ignore JSX comments like {/* comment */} - they should not affect
+      // the message or consume expression indices
+      if (exp.isJSXEmptyExpression()) {
+        return []
+      }
+
       if (exp.isStringLiteral()) {
         return [this.tokenizeText(exp.node.value)]
       }

--- a/packages/babel-plugin-lingui-macro/test/__snapshots__/jsx-trans.test.ts.snap
+++ b/packages/babel-plugin-lingui-macro/test/__snapshots__/jsx-trans.test.ts.snap
@@ -311,6 +311,60 @@ import { Trans as _Trans } from "@lingui/react";
 
 `;
 
+exports[`JSX comment should not affect expression index 1`] = `
+import { Trans } from "@lingui/react/macro";
+// Without comment - expression gets index 0
+<Trans>
+  Click here
+  <Link>{getText()}</Link>
+</Trans>;
+// With comment before expression - expression should STILL get index 0
+<Trans>
+  Click here
+  <Link>
+    {/* @ts-expect-error */}
+    {getText()}
+  </Link>
+</Trans>;
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+// Without comment - expression gets index 0
+import { Trans as _Trans } from "@lingui/react";
+<_Trans
+  {
+    /*i18n*/
+    ...{
+      id: "HW7Brx",
+      message: "Click here<0>{0}</0>",
+      values: {
+        0: getText(),
+      },
+      components: {
+        0: <Link />,
+      },
+    }
+  }
+/>;
+// With comment before expression - expression should STILL get index 0
+<_Trans
+  {
+    /*i18n*/
+    ...{
+      id: "HW7Brx",
+      message: "Click here<0>{0}</0>",
+      values: {
+        0: getText(),
+      },
+      components: {
+        0: <Link />,
+      },
+    }
+  }
+/>;
+
+`;
+
 exports[`Labeled expressions are supported 1`] = `
 import { Trans } from "@lingui/react/macro";
 <Trans>

--- a/packages/babel-plugin-lingui-macro/test/jsx-trans.test.ts
+++ b/packages/babel-plugin-lingui-macro/test/jsx-trans.test.ts
@@ -311,6 +311,27 @@ macroTester({
       `,
     },
     {
+      name: "JSX comment should not affect expression index",
+      code: `
+        import { Trans } from '@lingui/react/macro';
+        // Without comment - expression gets index 0
+        <Trans>
+          Click here
+          <Link>
+            {getText()}
+          </Link>
+        </Trans>;
+        // With comment before expression - expression should STILL get index 0
+        <Trans>
+          Click here
+          <Link>
+            {/* @ts-expect-error */}
+            {getText()}
+          </Link>
+        </Trans>;
+      `,
+    },
+    {
       name: "Use decoded html entities",
       code: `
         import { Trans } from "@lingui/react/macro";


### PR DESCRIPTION
# Description

JSX comments like `{/* @ts-expect-error */}` were consuming expression indices during message extraction, causing different hashes when comments were added/removed. I noticed this in a production build when compiling a Next.js application with `@lingui/swc-plugin` (which does not have this bug).

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
