### PR TITLE
chore: replace picocolors with node:util for styling in CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "mock-fs": "^5.2.0",
     "npm-cli-login": "^0.1.1",
     "ora": "^5.1.0",
-    "picocolors": "^1.1.1",
     "prettier": "3.8.1",
     "semver": "^7.3.2",
     "size-limit": "^11.1.6",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -68,7 +68,6 @@
     "ms": "^2.1.3",
     "normalize-path": "^3.0.0",
     "ora": "^9.1.0",
-    "picocolors": "^1.1.1",
     "pofile": "^1.1.4",
     "pseudolocale": "^2.2.0",
     "source-map": "^0.7.6",

--- a/packages/cli/src/api/catalog/extractFromFiles.ts
+++ b/packages/cli/src/api/catalog/extractFromFiles.ts
@@ -1,5 +1,5 @@
 import type { ExtractedMessage, LinguiConfigNormalized } from "@lingui/conf"
-import pico from "picocolors"
+import { styleText } from "node:util"
 import path from "path"
 import extract from "../extractors/index.js"
 import { ExtractedCatalogType, MessageOrigin } from "../types.js"
@@ -89,11 +89,12 @@ export function mergeExtractedMessage(
 
   if (prev.message && next.message && prev.message !== next.message) {
     throw new Error(
-      `Encountered different default translations for message ${pico.yellow(
+      `Encountered different default translations for message ${styleText(
+        "yellow",
         next.id,
       )}` +
-        `\n${pico.yellow(prettyOrigin(prev.origin))} ${prev.message}` +
-        `\n${pico.yellow(prettyOrigin([nextOrigin || [""]]))} ${next.message}`,
+        `\n${styleText("yellow", prettyOrigin(prev.origin))} ${prev.message}` +
+        `\n${styleText("yellow", prettyOrigin([nextOrigin || [""]]))} ${next.message}`,
     )
   }
 

--- a/packages/cli/src/api/compile/compileLocale.ts
+++ b/packages/cli/src/api/compile/compileLocale.ts
@@ -1,6 +1,6 @@
 import { Catalog, writeCompiled } from "../catalog.js"
 import { LinguiConfigNormalized } from "@lingui/conf"
-import pico from "picocolors"
+import { styleText } from "node:util"
 import { getMergedCatalogPath } from "../catalog/getCatalogs.js"
 import { CliCompileOptions } from "../../lingui-compile.js"
 import { ProgramExit } from "../ProgramExit.js"
@@ -35,13 +35,14 @@ export async function compileLocale(
       missingMessages.length > 0
     ) {
       logger.error(
-        pico.red(
-          `Error: Failed to compile catalog for locale ${pico.bold(locale)}!`,
+        styleText(
+          "red",
+          `Error: Failed to compile catalog for locale ${styleText("bold", locale)}!`,
         ),
       )
 
       if (options.verbose) {
-        logger.error(pico.red("Missing translations:"))
+        logger.error(styleText("red", "Missing translations:"))
         missingMessages.forEach((missing) => {
           const source =
             missing.source || missing.source === missing.id
@@ -52,7 +53,7 @@ export async function compileLocale(
         })
       } else {
         logger.error(
-          pico.red(`Missing ${missingMessages.length} translation(s)`),
+          styleText("red", `Missing ${missingMessages.length} translation(s)`),
         )
       }
       logger.error("")
@@ -121,11 +122,11 @@ async function compileAndWrite(
 
     if (options.failOnCompileError) {
       message += `These errors fail command execution because \`--strict\` option passed`
-      logger.error(pico.red(message))
+      logger.error(styleText("red", message))
       return false
     } else {
       message += `You can fail command execution on these errors by passing \`--strict\` option`
-      logger.error(pico.red(message))
+      logger.error(styleText("red", message))
     }
   }
 
@@ -138,6 +139,7 @@ async function compileAndWrite(
 
   compiledPath = normalizePath(nodepath.relative(config.rootDir, compiledPath))
 
-  options.verbose && logger.error(pico.green(`${locale} ⇒ ${compiledPath}`))
+  options.verbose &&
+    logger.error(styleText("green", `${locale} ⇒ ${compiledPath}`))
   return true
 }

--- a/packages/cli/src/api/messages.ts
+++ b/packages/cli/src/api/messages.ts
@@ -1,5 +1,5 @@
 import { TranslationMissingEvent } from "./catalog/getTranslationsForCatalog.js"
-import pico from "picocolors"
+import { styleText } from "node:util"
 import { MessageCompilationError } from "./compile.js"
 
 export function createMissingErrorMessage(
@@ -7,7 +7,7 @@ export function createMissingErrorMessage(
   missingMessages: TranslationMissingEvent[],
   configurationMsg: string,
 ) {
-  let message = `Failed to compile catalog for locale ${pico.bold(locale)}!
+  let message = `Failed to compile catalog for locale ${styleText("bold", locale)}!
 
 Missing ${missingMessages.length} translation(s):
 \n`
@@ -28,7 +28,7 @@ export function createCompilationErrorMessage(
   locale: string,
   errors: MessageCompilationError[],
 ) {
-  let message = `Failed to compile catalog for locale ${pico.bold(locale)}!
+  let message = `Failed to compile catalog for locale ${styleText("bold", locale)}!
 
 Compilation error for ${errors.length} translation(s):
 \n`

--- a/packages/cli/src/api/stats.ts
+++ b/packages/cli/src/api/stats.ts
@@ -1,5 +1,5 @@
 import Table from "cli-table3"
-import pico from "picocolors"
+import { styleText } from "node:util"
 
 import { LinguiConfigNormalized } from "@lingui/conf"
 
@@ -43,7 +43,7 @@ export function printStats(
       const [all, translated] = catalog ? getStats(catalog) : ["-", "-"]
 
       if (config.sourceLocale === locale) {
-        table.push({ [`${pico.bold(locale)} (source)`]: [all, "-"] })
+        table.push({ [`${styleText("bold", locale)} (source)`]: [all, "-"] })
       } else {
         table.push({ [locale]: [all, translated] })
       }

--- a/packages/cli/src/extract-experimental/writeCatalogs.ts
+++ b/packages/cli/src/extract-experimental/writeCatalogs.ts
@@ -4,7 +4,7 @@ import {
   CatalogType,
   ExtractedCatalogType,
 } from "../api/index.js"
-import pico from "picocolors"
+import { styleText } from "node:util"
 import { resolveCatalogPath } from "./resolveCatalogPath.js"
 import { mergeCatalog } from "../api/catalog/mergeCatalog.js"
 import { printStats } from "../api/stats.js"
@@ -103,8 +103,9 @@ export async function writeTemplate(
   )
 
   return {
-    statMessage: `${pico.bold(
-      Object.keys(messages).length,
+    statMessage: `${styleText(
+      "bold",
+      String(Object.keys(messages).length),
     )} message(s) extracted`,
   }
 }

--- a/packages/cli/src/lingui-compile.ts
+++ b/packages/cli/src/lingui-compile.ts
@@ -1,4 +1,4 @@
-import pico from "picocolors"
+import { styleText } from "node:util"
 import chokidar from "chokidar"
 import { program } from "commander"
 
@@ -190,7 +190,7 @@ if (esMain(import.meta)) {
 
   // Check if Watch Mode is enabled
   if (options.watch) {
-    console.info(pico.bold("Initializing Watch Mode..."))
+    console.info(styleText("bold", "Initializing Watch Mode..."))
     ;(async function initWatch() {
       const { paths } = await getPathsForCompileWatcher(config)
 
@@ -199,7 +199,7 @@ if (esMain(import.meta)) {
       })
 
       const onReady = () => {
-        console.info(pico.green(pico.bold("Watcher is ready!")))
+        console.info(styleText(["green", "bold"], "Watcher is ready!"))
         watcher
           .on("add", () => dispatchCompile())
           .on("change", () => dispatchCompile())

--- a/packages/cli/src/lingui-extract-experimental.ts
+++ b/packages/cli/src/lingui-extract-experimental.ts
@@ -8,7 +8,7 @@ import normalizePath from "normalize-path"
 
 import { bundleSource } from "./extract-experimental/bundleSource.js"
 import { getEntryPoints } from "./extract-experimental/getEntryPoints.js"
-import pico from "picocolors"
+import { styleText } from "node:util"
 import {
   resolveWorkersOptions,
   WorkersOptions,
@@ -42,7 +42,8 @@ export default async function command(
   }
 
   console.log(
-    pico.yellow(
+    styleText(
+      "yellow",
       [
         "You have using an experimental feature",
         "Experimental features are not covered by semver, and may cause unexpected or broken application behavior." +

--- a/packages/cli/src/lingui-extract-template.ts
+++ b/packages/cli/src/lingui-extract-template.ts
@@ -1,4 +1,4 @@
-import pico from "picocolors"
+import { styleText } from "node:util"
 import { program } from "commander"
 
 import { getConfig, LinguiConfigNormalized } from "@lingui/conf"
@@ -67,7 +67,7 @@ export default async function command(
   }
   Object.entries(catalogStats).forEach(([key, value]) => {
     console.log(
-      `Catalog statistics for ${pico.bold(key)}: ${pico.green(value)} messages`,
+      `Catalog statistics for ${styleText("bold", key)}: ${styleText("green", String(value))} messages`,
     )
     console.log()
   })

--- a/packages/cli/src/lingui-extract.ts
+++ b/packages/cli/src/lingui-extract.ts
@@ -1,4 +1,4 @@
-import pico from "picocolors"
+import { styleText } from "node:util"
 import chokidar from "chokidar"
 import { program } from "commander"
 import nodepath from "path"
@@ -106,12 +106,14 @@ export default async function command(
 
   if (!options.watch) {
     console.log(
-      `(Use "${pico.yellow(
+      `(Use "${styleText(
+        "yellow",
         helpRun("extract"),
       )}" to update catalogs with new messages.)`,
     )
     console.log(
-      `(Use "${pico.yellow(
+      `(Use "${styleText(
+        "yellow",
         helpRun("compile"),
       )}" to compile catalogs for production. Alternatively, use bundler plugins: https://lingui.dev/ref/cli#compiling-catalogs-in-ci)`,
     )
@@ -200,7 +202,9 @@ if (esMain(import.meta)) {
 
     if (missingLocale) {
       hasErrors = true
-      console.error(`Locale ${pico.bold(missingLocale)} does not exist.`)
+      console.error(
+        `Locale ${styleText("bold", missingLocale)} does not exist.`,
+      )
       console.error()
     }
   }
@@ -244,7 +248,7 @@ if (esMain(import.meta)) {
 
   // Check if Watch Mode is enabled
   if (options.watch) {
-    console.info(pico.bold("Initializing Watch Mode..."))
+    console.info(styleText("bold", "Initializing Watch Mode..."))
     ;(async function initWatch() {
       const { paths, ignored } = await getPathsForExtractWatcher(config)
 
@@ -257,7 +261,7 @@ if (esMain(import.meta)) {
       })
 
       const onReady = () => {
-        console.info(pico.green(pico.bold("Watcher is ready!")))
+        console.info(styleText(["green", "bold"], "Watcher is ready!"))
         watcher
           .on("add", (path) => dispatchExtract([path]))
           .on("change", (path) => dispatchExtract([path]))

--- a/packages/conf/package.json
+++ b/packages/conf/package.json
@@ -33,8 +33,7 @@
   "dependencies": {
     "jest-validate": "^29.4.3",
     "jiti": "^2.5.1",
-    "lilconfig": "^3.1.3",
-    "picocolors": "^1.1.1"
+    "lilconfig": "^3.1.3"
   },
   "files": [
     "LICENSE",

--- a/packages/conf/src/getConfig.ts
+++ b/packages/conf/src/getConfig.ts
@@ -4,7 +4,7 @@ import { lilconfigSync, LoaderSync } from "lilconfig"
 import path from "path"
 import { makeConfig } from "./makeConfig"
 import { createJiti } from "jiti"
-import pico from "picocolors"
+import { styleText } from "node:util"
 
 function configExists(path?: string): path is string {
   return !!path && fs.existsSync(path)
@@ -67,9 +67,11 @@ export function getConfig({
   if (!result) {
     console.error("Lingui was unable to find a config!\n")
     console.error(
-      `Create ${pico.bold(
+      `Create ${styleText(
+        "bold",
         "'lingui.config.js'",
-      )} file with LinguiJS configuration in root of your project (next to package.json). See ${pico.underline(
+      )} file with LinguiJS configuration in root of your project (next to package.json). See ${styleText(
+        "underline",
         "https://lingui.dev/ref/conf",
       )}`,
     )

--- a/packages/conf/src/makeConfig.ts
+++ b/packages/conf/src/makeConfig.ts
@@ -3,7 +3,7 @@ import type {
   LinguiConfig,
   LinguiConfigNormalized,
 } from "./types"
-import pico from "picocolors"
+import { styleText } from "node:util"
 import { replaceRootDir } from "./utils/replaceRootDir"
 import { multipleValidOptions, validate } from "jest-validate"
 import { setCldrParentLocales } from "./migrations/setCldrParentLocales"
@@ -144,9 +144,11 @@ function validateLocales(config: LinguiConfig) {
   if (!Array.isArray(config.locales) || !config.locales.length) {
     console.error("No locales defined!\n")
     console.error(
-      `Add ${pico.yellow(
+      `Add ${styleText(
+        "yellow",
         "'locales'",
-      )} to your configuration. See ${pico.underline(
+      )} to your configuration. See ${styleText(
+        "underline",
         "https://lingui.dev/ref/conf#locales",
       )}`,
     )

--- a/scripts/verdaccio-release.ts
+++ b/scripts/verdaccio-release.ts
@@ -1,6 +1,6 @@
 import { exec as _exec, type ExecOptions } from "child_process"
 import ora from "ora"
-import pico from "picocolors"
+import { styleText } from "node:util"
 
 async function main() {
   const spinner = ora()
@@ -26,7 +26,8 @@ async function main() {
 
   console.log()
   console.log(
-    `Done! Run ${pico.yellow(
+    `Done! Run ${styleText(
+      "yellow",
       "npm install --registry http://0.0.0.0:4873 @lingui/[package]",
     )} in target project to install development version of package.`,
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -3261,7 +3261,6 @@ __metadata:
     msw: ^2.12.7
     normalize-path: ^3.0.0
     ora: ^9.1.0
-    picocolors: ^1.1.1
     pofile: ^1.1.4
     pseudolocale: ^2.2.0
     source-map: ^0.7.6
@@ -3280,7 +3279,6 @@ __metadata:
     jest-validate: ^29.4.3
     jiti: ^2.5.1
     lilconfig: ^3.1.3
-    picocolors: ^1.1.1
     unbuild: ^2.0.0
     vitest: 4.0.18
   languageName: unknown
@@ -11189,7 +11187,6 @@ __metadata:
     mock-fs: ^5.2.0
     npm-cli-login: ^0.1.1
     ora: ^5.1.0
-    picocolors: ^1.1.1
     prettier: 3.8.1
     semver: ^7.3.2
     size-limit: ^11.1.6


### PR DESCRIPTION
# Description

Replace `picocolors` dependency with Node.js built-in `util.styleText` function.

This reduces external dependencies by using native Node.js styling functionality available since Node.js v20.12.0 (stable in v22.13.0).

Reference: https://nodejs.org/en/blog/migrations/chalk-to-styletext

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)

