### PR TITLE
fix: extract performance caused by catalog sort

### DIFF
--- a/packages/cli/src/api/catalog.ts
+++ b/packages/cli/src/api/catalog.ts
@@ -373,11 +373,11 @@ export async function writeCompiled(
   return filename
 }
 
-export const orderByMessage: OrderByFn = (a, b) => {
-  // hardcoded en-US locale to have consistent sorting
-  // @see https://github.com/lingui/js-lingui/pull/1808
-  const collator = new Intl.Collator("en-US")
+// hardcoded en-US locale to have consistent sorting
+// @see https://github.com/lingui/js-lingui/pull/1808
+const collator = new Intl.Collator("en-US")
 
+export const orderByMessage: OrderByFn = (a, b) => {
   const aMsg = a.entry.message || ""
   const bMsg = b.entry.message || ""
   const aCtxt = a.entry.context || ""


### PR DESCRIPTION
# Description

Fix `extract` performance caused by catalog sorting.  `new Intl.Collator("en-US")` created on every sort comparator fn invocation and caused ordering a catalog to be much slower. 

Before: 

```
$ lingui extract --clean --verbose --workers 4
Extracting messages from source files…
Use worker pool of size 4
collecting: 1.524s (tasks inside goes in parallel)
  - readAll: 415.598ms
  - extracting from files: 1.501s
merging: 412.112ms
sorting: 3.981s
  order en: 93.221ms
  order an: 94.806ms
  order ast: 95.919ms
  [...]
write: 596.106ms
✔ Done in 7s
```

With a patch: 

```
sorting: 138.494ms
  order en: 5.282ms
  order an: 5.81ms
  order ast: 3.125ms
```

So sorting become approximately 28 times faster. 

Ref: https://github.com/bluesky-social/social-app/pull/9905

@andrii-bodnar i propose to merge this to v5 as hotfix and cherry-pick to next.

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
