### PR TITLE
fix: really keep catalog extra from previous catalog

### DIFF
--- a/packages/cli/src/api/catalog/mergeCatalog.test.ts
+++ b/packages/cli/src/api/catalog/mergeCatalog.test.ts
@@ -170,9 +170,11 @@ describe("mergeCatalog", () => {
     const result = mergeCatalog(prevCatalog, nextCatalog, false, {})
     expect(result["Hello"]).toMatchInlineSnapshot(`
       {
-        flags: [
-          myTag,
-        ],
+        extra: {
+          flags: [
+            myTag,
+          ],
+        },
         message: Hello,
         origin: [
           [

--- a/packages/cli/src/api/catalog/mergeCatalog.ts
+++ b/packages/cli/src/api/catalog/mergeCatalog.ts
@@ -40,7 +40,7 @@ export function mergeCatalog(
       const { obsolete, ...rest } = nextCatalog[key]
       const { extra } = prevCatalog[key]
 
-      return [key, { ...extra, ...rest, translation }]
+      return [key, { ...rest, extra, translation }]
     })
   )
 


### PR DESCRIPTION
25cfdde3b0c3d95697752a0e698bff9ede6d9a4e tries to keep `flags`, but it is incorrectly spreading `extra`, when it should not, causing `flags` to be lost.

Additionally, move `extra` after `rest` to ensure it is not overwritten. Not sure if this is needed, but the original commit hints it should be always preferred.

See also #2399.

Running the full test suite seems to fail on my machine, but the relevant tests pass.

# Description

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

Fixes #2398.

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
