### PR TITLE
fix(vite-plugin): add missing peer deps for rolldown babel

### DIFF
--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -46,15 +46,23 @@
     "@lingui/conf": "workspace:*"
   },
   "peerDependencies": {
+    "@babel/core": "^7.29.0 || ^8.0.0-rc.1",
     "@lingui/babel-plugin-lingui-macro": "^5 || ^6",
     "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+    "rolldown": "^1.0.0-rc.5",
     "vite": "^6.3.0 || ^7 || ^8"
   },
   "peerDependenciesMeta": {
+    "@babel/core": {
+      "optional": true
+    },
     "@lingui/babel-plugin-lingui-macro": {
       "optional": true
     },
     "@rolldown/plugin-babel": {
+      "optional": true
+    },
+    "rolldown": {
       "optional": true
     }
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2401,13 +2401,19 @@ __metadata:
     vite-plugin-babel-macros: ^1.0.6
     vitest: 4.0.18
   peerDependencies:
+    "@babel/core": ^7.29.0 || ^8.0.0-rc.1
     "@lingui/babel-plugin-lingui-macro": ^5 || ^6
     "@rolldown/plugin-babel": ^0.1.7 || ^0.2.0
+    rolldown: ^1.0.0-rc.5
     vite: ^6.3.0 || ^7 || ^8
   peerDependenciesMeta:
+    "@babel/core":
+      optional: true
     "@lingui/babel-plugin-lingui-macro":
       optional: true
     "@rolldown/plugin-babel":
+      optional: true
+    rolldown:
       optional: true
   languageName: unknown
   linkType: soft
@@ -3227,23 +3233,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/pluginutils@npm:^5.0.1":
-  version: 5.0.3
-  resolution: "@rollup/pluginutils@npm:5.0.3"
-  dependencies:
-    "@types/estree": ^1.0.0
-    estree-walker: ^2.0.2
-    picomatch: ^2.3.1
-  peerDependencies:
-    rollup: ^1.20.0||^2.0.0||^3.0.0
-  peerDependenciesMeta:
-    rollup:
-      optional: true
-  checksum: 8efbdeac53c58ba7b26c353a0a95acb0286cb6afec9816e0c52c3537404be80af11d897f78416a3339a8a76cbce8600269bdf4853edfdebcc89b2e90c56bf3d9
-  languageName: node
-  linkType: hard
-
-"@rollup/pluginutils@npm:^5.1.0, @rollup/pluginutils@npm:^5.2.0":
+"@rollup/pluginutils@npm:^5.0.1, @rollup/pluginutils@npm:^5.1.0, @rollup/pluginutils@npm:^5.2.0":
   version: 5.3.0
   resolution: "@rollup/pluginutils@npm:5.3.0"
   dependencies:


### PR DESCRIPTION
# Description

This change fixes Yarn peer dependency warnings for `@lingui/vite-plugin` during `yarn install`.

Before this change, the issue looked like this:

```text
❯ yarn install
➤ YN0000: ┌ Resolution step
➤ YN0002: │ @lingui/vite-plugin@workspace:packages/vite-plugin doesn't provide @babel/core (p3ca71), requested by @rolldown/plugin-babel
➤ YN0002: │ @lingui/vite-plugin@workspace:packages/vite-plugin doesn't provide rolldown (p6aa94), requested by @rolldown/plugin-babel
```

The package exposes integration with `@rolldown/plugin-babel`, but its package metadata did not declare the minimal peer dependencies required by that integration. This PR adds optional peer dependencies for `@babel/core` and `rolldown` to make the contract explicit and align the package metadata with the supported setup.

The lockfile is also updated so `@rollup/pluginutils` resolves to `5.3.0`, which removes the outdated Rollup peer mismatch warning from the dependency tree.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
