### PR TITLE
chore: official v6 release

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,7 +4,7 @@ contact_links:
     url: https://lingui.dev
     about: Check the official docs for answers to common questions
   - name: Chat on Discord
-    url: https://discord.gg/gFWwAYnMtA
+    url: https://discord.gg/tBZqKpeF
     about: Join the Lingui community on Discord
   - name: Ask AI
     url: https://gurubase.io/g/lingui-js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,36 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [5.9.5](https://github.com/lingui/js-lingui/compare/v5.9.4...v5.9.5) (2026-04-06)
+
+### Bug Fixes
+
+* support braces in catalog pathname ([#2495](https://github.com/lingui/js-lingui/issues/2495)) ([db14681](https://github.com/lingui/js-lingui/commit/db14681e36ae1603499fafbd2dd00942ed1c2e0b))
+
+## [5.9.4](https://github.com/lingui/js-lingui/compare/v5.9.3...v5.9.4) (2026-03-27)
+
+### Bug Fixes
+
+* really keep catalog extra from previous catalog ([#2479](https://github.com/lingui/js-lingui/issues/2479)) ([c939113](https://github.com/lingui/js-lingui/commit/c939113293b29a948b80f2a6332cf8016c47ab37))
+
+## [5.9.3](https://github.com/lingui/js-lingui/compare/v6.0.0-next.1...v5.9.3) (2026-03-13)
+
+### Bug Fixes
+
+* support vite 8 ([#2474](https://github.com/lingui/js-lingui/issues/2474)) ([e4468c7](https://github.com/lingui/js-lingui/commit/e4468c7cb01533e1f68e54c92e74a67cdfc1526d))
+
+## [5.9.2](https://github.com/lingui/js-lingui/compare/v5.9.1...v5.9.2) (2026-02-23)
+
+### Bug Fixes
+
+* extract performance caused by catalog sort ([#2460](https://github.com/lingui/js-lingui/issues/2460)) ([f26a9d9](https://github.com/lingui/js-lingui/commit/f26a9d99a62db378b2a5895aaac3cab39558b568))
+
+## [5.9.1](https://github.com/lingui/js-lingui/compare/v5.9.0...v5.9.1) (2026-02-11)
+
+### Bug Fixes
+
+* **macro:** Ignore JSX comments when generating message ids ([#2434](https://github.com/lingui/js-lingui/issues/2434)) ([c09deaa](https://github.com/lingui/js-lingui/commit/c09deaac19f2297a8c136cd98f1f3f76178891b0))
+
 # [5.9.0](https://github.com/lingui/js-lingui/compare/v5.8.0...v5.9.0) (2026-01-23)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.0.0](https://github.com/lingui/js-lingui/compare/v5.9.5...v6.0.0) (2026-04-22)
+
+This release modernizes the codebase and packages (ESM-only distribution, smaller dependency graph, deprecated API removals, improved TypeScript support) and still ships meaningful new features and bug fixes.
+
+Check out the links below for more details:
+
+- [Blog Post: Announcing Lingui 6.0](https://lingui.dev/blog/2026/04/22/announcing-lingui-6.0)
+- [Migration Guide from 5.x to 6.x](https://lingui.dev/releases/migration-6)
+- [Full Changelog](https://github.com/lingui/js-lingui/compare/v5.9.5...v6.0.0)
+
 ## [5.9.5](https://github.com/lingui/js-lingui/compare/v5.9.4...v5.9.5) (2026-04-06)
 
 ### Bug Fixes
@@ -15,7 +25,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 * really keep catalog extra from previous catalog ([#2479](https://github.com/lingui/js-lingui/issues/2479)) ([c939113](https://github.com/lingui/js-lingui/commit/c939113293b29a948b80f2a6332cf8016c47ab37))
 
-## [5.9.3](https://github.com/lingui/js-lingui/compare/v6.0.0-next.1...v5.9.3) (2026-03-13)
+## [5.9.3](https://github.com/lingui/js-lingui/compare/v5.9.2...v5.9.3) (2026-03-13)
 
 ### Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![PRs Welcome][Badge-PRWelcome]][PRWelcome]
 [![Join the community on Discord][Badge-Discord]][Discord]
 
-[**Documentation**][Documentation] · [**Quickstart**](#quickstart) · [**Example**](#example) · [**Support**](#support) · [**Contribute**](#contribute) · [**License**](#license)
+[**Documentation**][Documentation] · [**Example**](#example) · [**Support**](#support) · [**Contribute**](#contribute) · [**License**](#license)
 
 </div>
 
@@ -22,6 +22,8 @@
 > --- [ W3C Web Internationalization FAQ](https://www.w3.org/International/questions/qa-i18n)
 
 Lingui is an easy yet powerful internationalization (i18n) framework for global projects.
+
+## Key Features
 
 - **Clean and readable** - Keep your code clean and readable, while the library uses battle-tested and powerful **ICU MessageFormat** under the hood.
 
@@ -79,15 +81,6 @@ If you are having issues, please let us know.
 - If something doesn't work as documented, documentation is missing or if you just want to suggest a new feature, [create an issue][Issues].
 - You can also [Ask Lingui JS Guru](https://gurubase.io/g/lingui-js), it is a Lingui JS focused AI to answer your questions.
 
-## Docs for LLMs
-
-For developers working with AI and language models, we provide specialized documentation files following the [llms.txt specification](https://llmstxt.org/):
-
-- [llms.txt](https://lingui.dev/llms.txt) - Concise documentation optimized for LLM context windows
-- [llms-full.txt](https://lingui.dev/llms-full.txt) - Comprehensive documentation including all referenced URLs
-
-These files provide LLM-friendly content in a standardized format, helping language models understand and work with Lingui's documentation at inference time. The format is designed to be both human and LLM readable, with structured information that can be processed programmatically.
-
 ## Contribute
 
 Contribution to open-source project is everything from spreading the word, writing documentation to implement features and fixing bugs.
@@ -112,7 +105,6 @@ The project is licensed under the [MIT][License] license.
 </div>
 
 [Documentation]: https://lingui.dev
-[Examples]: https://github.com/lingui/js-lingui/tree/main/examples
 [Badge-MainSuite-GithubCI]: https://github.com/lingui/js-lingui/workflows/main-suite/badge.svg
 [Badge-ReleaseWorkflowTesting-GithubCI]: https://github.com/lingui/js-lingui/workflows/release-workflow-test/badge.svg
 [Badge-Coverage]: https://img.shields.io/codecov/c/github/lingui/js-lingui/main.svg

--- a/README.md
+++ b/README.md
@@ -124,4 +124,4 @@ The project is licensed under the [MIT][License] license.
 [Contributing]: https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md
 [Issues]: https://github.com/lingui/js-lingui/issues/new/choose
 [PRWelcome]: http://makeapullrequest.com
-[Discord]: https://discord.gg/gFWwAYnMtA
+[Discord]: https://discord.gg/tBZqKpeF

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 🌍📖 A readable, automated, and optimized (2 kb) internationalization for JavaScript
 
+🎉 **Lingui v6 is now available!** [Read the release announcement →](https://lingui.dev/blog/2026/04/22/announcing-lingui-6.0)
+
 <hr />
 
 ![Main Suite][Badge-MainSuite-GithubCI]
@@ -23,15 +25,17 @@ Lingui is an easy yet powerful internationalization (i18n) framework for global 
 
 - **Clean and readable** - Keep your code clean and readable, while the library uses battle-tested and powerful **ICU MessageFormat** under the hood.
 
-- **Universal** - Use it everywhere. `@lingui/core` provides the essential intl functionality which works in any JavaScript project while `@lingui/react` offers components to leverage React rendering, including React Server Components (RSC) support.
+- **Universal** - Use it everywhere. `@lingui/core` provides the essential intl functionality which works in any JavaScript project while `@lingui/react` offers components to leverage React rendering, including React Server Components (RSC) support. The same extract-and-compile workflow applies to React Native. Astro and Svelte work through community-supported packages.
 
-- **Full rich-text support** - Use React components inside localized messages without any limitation. Writing rich-text messages is as easy as writing JSX.
+- **Full rich-text support** - Use React components inside localized messages without any limitation. Writing rich-text messages is as easy as writing JSX. That helps keep message catalogs in sync with your source code.
 
 - **Powerful tooling** - Manage your intl workflow with the Lingui [CLI](https://lingui.dev/ref/cli), [Vite Plugin](https://lingui.dev/ref/vite-plugin), and [ESLint Plugin](https://lingui.dev/ref/eslint-plugin). The CLI extracts, compiles and validates messages, while the Vite plugin compiles catalogs on the fly, and the ESLint plugin helps catch common usage errors.
 
-- **Unopinionated** - Integrate Lingui into your existing workflow. It supports message keys as well as auto-generated messages. Translations are stored either in JSON or standard PO files, which are supported in almost all translation tools.
+- **Unopinionated** - Integrate Lingui into your existing workflow. It supports explicit message keys as well as auto-generated ones. Translations are stored in a standard PO file, which is supported in almost all translation tools. You can also use CSV or JSON, or add a custom formatter of your own.
 
 - **Lightweight and optimized** - Core library is less than [2 kB gzipped](https://bundlephobia.com/result?p=@lingui/core), React components are additional [1.3 kB gzipped](https://bundlephobia.com/result?p=@lingui/react).
+
+- **Built for AI-assisted workflows** - Good translations need context, especially for short UI strings. Lingui's localization formats let you describe where and how keys are used. Install [`lingui/skills`](https://github.com/lingui/skills) to help your AI assistant apply Lingui patterns consistently, and see [i18n with AI](https://lingui.dev/ai-tools) for MCP setup and more.
 
 - **Active community** - Join the growing [community of developers](https://lingui.dev/community) who are using Lingui to build global products.
 

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "6.0.0-next.4",
+  "version": "6.0.0",
   "packages": ["packages/*"],
   "npmClient": "yarn",
   "command": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "js-lingui-workspaces",
   "private": true,
-  "version": "5.0.0",
+  "version": "6.0.0",
   "type": "module",
   "author": {
     "name": "Tomáš Ehrlich",

--- a/packages/babel-plugin-extract-messages/CHANGELOG.md
+++ b/packages/babel-plugin-extract-messages/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [5.9.5](https://github.com/lingui/js-lingui/compare/v5.9.4...v5.9.5) (2026-04-06)
+
+**Note:** Version bump only for package @lingui/babel-plugin-extract-messages
+
+## [5.9.4](https://github.com/lingui/js-lingui/compare/v5.9.3...v5.9.4) (2026-03-27)
+
+**Note:** Version bump only for package @lingui/babel-plugin-extract-messages
+
+## [5.9.3](https://github.com/lingui/js-lingui/compare/v6.0.0-next.1...v5.9.3) (2026-03-13)
+
+**Note:** Version bump only for package @lingui/babel-plugin-extract-messages
+
+## [5.9.2](https://github.com/lingui/js-lingui/compare/v5.9.1...v5.9.2) (2026-02-23)
+
+**Note:** Version bump only for package @lingui/babel-plugin-extract-messages
+
+## [5.9.1](https://github.com/lingui/js-lingui/compare/v5.9.0...v5.9.1) (2026-02-11)
+
+**Note:** Version bump only for package @lingui/babel-plugin-extract-messages
+
 # [5.9.0](https://github.com/lingui/js-lingui/compare/v5.8.0...v5.9.0) (2026-01-23)
 
 **Note:** Version bump only for package @lingui/babel-plugin-extract-messages

--- a/packages/babel-plugin-extract-messages/CHANGELOG.md
+++ b/packages/babel-plugin-extract-messages/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [6.0.0](https://github.com/lingui/js-lingui/compare/v5.9.5...v6.0.0) (2026-04-22)
+
+- [Announcing Lingui 6.0](https://lingui.dev/blog/2026/04/22/announcing-lingui-6.0)
+
 ## [5.9.5](https://github.com/lingui/js-lingui/compare/v5.9.4...v5.9.5) (2026-04-06)
 
 **Note:** Version bump only for package @lingui/babel-plugin-extract-messages
@@ -11,7 +15,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @lingui/babel-plugin-extract-messages
 
-## [5.9.3](https://github.com/lingui/js-lingui/compare/v6.0.0-next.1...v5.9.3) (2026-03-13)
+## [5.9.3](https://github.com/lingui/js-lingui/compare/v5.9.2...v5.9.3) (2026-03-13)
 
 **Note:** Version bump only for package @lingui/babel-plugin-extract-messages
 

--- a/packages/babel-plugin-extract-messages/package.json
+++ b/packages/babel-plugin-extract-messages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lingui/babel-plugin-extract-messages",
-  "version": "6.0.0-next.4",
+  "version": "6.0.0",
   "description": "Babel plugin to extract translatable messages from source code into Lingui catalogs",
   "type": "module",
   "author": {

--- a/packages/babel-plugin-lingui-macro/CHANGELOG.md
+++ b/packages/babel-plugin-lingui-macro/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [5.9.5](https://github.com/lingui/js-lingui/compare/v5.9.4...v5.9.5) (2026-04-06)
+
+**Note:** Version bump only for package @lingui/babel-plugin-lingui-macro
+
+## [5.9.4](https://github.com/lingui/js-lingui/compare/v5.9.3...v5.9.4) (2026-03-27)
+
+**Note:** Version bump only for package @lingui/babel-plugin-lingui-macro
+
+## [5.9.3](https://github.com/lingui/js-lingui/compare/v6.0.0-next.1...v5.9.3) (2026-03-13)
+
+**Note:** Version bump only for package @lingui/babel-plugin-lingui-macro
+
+## [5.9.2](https://github.com/lingui/js-lingui/compare/v5.9.1...v5.9.2) (2026-02-23)
+
+**Note:** Version bump only for package @lingui/babel-plugin-lingui-macro
+
+## [5.9.1](https://github.com/lingui/js-lingui/compare/v5.9.0...v5.9.1) (2026-02-11)
+
+### Bug Fixes
+
+* **macro:** Ignore JSX comments when generating message ids ([#2434](https://github.com/lingui/js-lingui/issues/2434)) ([c09deaa](https://github.com/lingui/js-lingui/commit/c09deaac19f2297a8c136cd98f1f3f76178891b0))
+
 # [5.9.0](https://github.com/lingui/js-lingui/compare/v5.8.0...v5.9.0) (2026-01-23)
 
 ### Bug Fixes

--- a/packages/babel-plugin-lingui-macro/CHANGELOG.md
+++ b/packages/babel-plugin-lingui-macro/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [6.0.0](https://github.com/lingui/js-lingui/compare/v5.9.5...v6.0.0) (2026-04-22)
+
+- [Announcing Lingui 6.0](https://lingui.dev/blog/2026/04/22/announcing-lingui-6.0)
+
 ## [5.9.5](https://github.com/lingui/js-lingui/compare/v5.9.4...v5.9.5) (2026-04-06)
 
 **Note:** Version bump only for package @lingui/babel-plugin-lingui-macro
@@ -11,7 +15,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @lingui/babel-plugin-lingui-macro
 
-## [5.9.3](https://github.com/lingui/js-lingui/compare/v6.0.0-next.1...v5.9.3) (2026-03-13)
+## [5.9.3](https://github.com/lingui/js-lingui/compare/v5.9.2...v5.9.3) (2026-03-13)
 
 **Note:** Version bump only for package @lingui/babel-plugin-lingui-macro
 

--- a/packages/babel-plugin-lingui-macro/package.json
+++ b/packages/babel-plugin-lingui-macro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lingui/babel-plugin-lingui-macro",
-  "version": "6.0.0-next.4",
+  "version": "6.0.0",
   "type": "module",
   "description": "Babel plugin that transforms Lingui compile-time macros into optimized runtime calls",
   "contributors": [

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [6.0.0](https://github.com/lingui/js-lingui/compare/v5.9.5...v6.0.0) (2026-04-22)
+
+- [Announcing Lingui 6.0](https://lingui.dev/blog/2026/04/22/announcing-lingui-6.0)
+
 ## [5.9.5](https://github.com/lingui/js-lingui/compare/v5.9.4...v5.9.5) (2026-04-06)
 
 ### Bug Fixes
@@ -15,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 * really keep catalog extra from previous catalog ([#2479](https://github.com/lingui/js-lingui/issues/2479)) ([c939113](https://github.com/lingui/js-lingui/commit/c939113293b29a948b80f2a6332cf8016c47ab37))
 
-## [5.9.3](https://github.com/lingui/js-lingui/compare/v6.0.0-next.1...v5.9.3) (2026-03-13)
+## [5.9.3](https://github.com/lingui/js-lingui/compare/v5.9.2...v5.9.3) (2026-03-13)
 
 **Note:** Version bump only for package @lingui/cli
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,32 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [5.9.5](https://github.com/lingui/js-lingui/compare/v5.9.4...v5.9.5) (2026-04-06)
+
+### Bug Fixes
+
+* support braces in catalog pathname ([#2495](https://github.com/lingui/js-lingui/issues/2495)) ([db14681](https://github.com/lingui/js-lingui/commit/db14681e36ae1603499fafbd2dd00942ed1c2e0b))
+
+## [5.9.4](https://github.com/lingui/js-lingui/compare/v5.9.3...v5.9.4) (2026-03-27)
+
+### Bug Fixes
+
+* really keep catalog extra from previous catalog ([#2479](https://github.com/lingui/js-lingui/issues/2479)) ([c939113](https://github.com/lingui/js-lingui/commit/c939113293b29a948b80f2a6332cf8016c47ab37))
+
+## [5.9.3](https://github.com/lingui/js-lingui/compare/v6.0.0-next.1...v5.9.3) (2026-03-13)
+
+**Note:** Version bump only for package @lingui/cli
+
+## [5.9.2](https://github.com/lingui/js-lingui/compare/v5.9.1...v5.9.2) (2026-02-23)
+
+### Bug Fixes
+
+* extract performance caused by catalog sort ([#2460](https://github.com/lingui/js-lingui/issues/2460)) ([f26a9d9](https://github.com/lingui/js-lingui/commit/f26a9d99a62db378b2a5895aaac3cab39558b568))
+
+## [5.9.1](https://github.com/lingui/js-lingui/compare/v5.9.0...v5.9.1) (2026-02-11)
+
+**Note:** Version bump only for package @lingui/cli
+
 # [5.9.0](https://github.com/lingui/js-lingui/compare/v5.8.0...v5.9.0) (2026-01-23)
 
 ### Bug Fixes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lingui/cli",
-  "version": "6.0.0-next.4",
+  "version": "6.0.0",
   "description": "Lingui CLI to extract messages, compile catalogs, and manage translation workflows",
   "type": "module",
   "keywords": [

--- a/packages/conf/CHANGELOG.md
+++ b/packages/conf/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [6.0.0](https://github.com/lingui/js-lingui/compare/v5.9.5...v6.0.0) (2026-04-22)
+
+- [Announcing Lingui 6.0](https://lingui.dev/blog/2026/04/22/announcing-lingui-6.0)
+
 ## [5.9.5](https://github.com/lingui/js-lingui/compare/v5.9.4...v5.9.5) (2026-04-06)
 
 **Note:** Version bump only for package @lingui/conf
@@ -11,7 +15,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @lingui/conf
 
-## [5.9.3](https://github.com/lingui/js-lingui/compare/v6.0.0-next.1...v5.9.3) (2026-03-13)
+## [5.9.3](https://github.com/lingui/js-lingui/compare/v5.9.2...v5.9.3) (2026-03-13)
 
 **Note:** Version bump only for package @lingui/conf
 

--- a/packages/conf/CHANGELOG.md
+++ b/packages/conf/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [5.9.5](https://github.com/lingui/js-lingui/compare/v5.9.4...v5.9.5) (2026-04-06)
+
+**Note:** Version bump only for package @lingui/conf
+
+## [5.9.4](https://github.com/lingui/js-lingui/compare/v5.9.3...v5.9.4) (2026-03-27)
+
+**Note:** Version bump only for package @lingui/conf
+
+## [5.9.3](https://github.com/lingui/js-lingui/compare/v6.0.0-next.1...v5.9.3) (2026-03-13)
+
+**Note:** Version bump only for package @lingui/conf
+
+## [5.9.2](https://github.com/lingui/js-lingui/compare/v5.9.1...v5.9.2) (2026-02-23)
+
+**Note:** Version bump only for package @lingui/conf
+
+## [5.9.1](https://github.com/lingui/js-lingui/compare/v5.9.0...v5.9.1) (2026-02-11)
+
+**Note:** Version bump only for package @lingui/conf
+
 # [5.9.0](https://github.com/lingui/js-lingui/compare/v5.8.0...v5.9.0) (2026-01-23)
 
 **Note:** Version bump only for package @lingui/conf

--- a/packages/conf/package.json
+++ b/packages/conf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lingui/conf",
-  "version": "6.0.0-next.4",
+  "version": "6.0.0",
   "sideEffects": false,
   "description": "Resolve and validate Lingui configuration",
   "keywords": [

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [6.0.0](https://github.com/lingui/js-lingui/compare/v5.9.5...v6.0.0) (2026-04-22)
+
+- [Announcing Lingui 6.0](https://lingui.dev/blog/2026/04/22/announcing-lingui-6.0)
+
 ## [5.9.5](https://github.com/lingui/js-lingui/compare/v5.9.4...v5.9.5) (2026-04-06)
 
 **Note:** Version bump only for package @lingui/core
@@ -11,7 +15,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @lingui/core
 
-## [5.9.3](https://github.com/lingui/js-lingui/compare/v6.0.0-next.1...v5.9.3) (2026-03-13)
+## [5.9.3](https://github.com/lingui/js-lingui/compare/v5.9.2...v5.9.3) (2026-03-13)
 
 **Note:** Version bump only for package @lingui/core
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [5.9.5](https://github.com/lingui/js-lingui/compare/v5.9.4...v5.9.5) (2026-04-06)
+
+**Note:** Version bump only for package @lingui/core
+
+## [5.9.4](https://github.com/lingui/js-lingui/compare/v5.9.3...v5.9.4) (2026-03-27)
+
+**Note:** Version bump only for package @lingui/core
+
+## [5.9.3](https://github.com/lingui/js-lingui/compare/v6.0.0-next.1...v5.9.3) (2026-03-13)
+
+**Note:** Version bump only for package @lingui/core
+
+## [5.9.2](https://github.com/lingui/js-lingui/compare/v5.9.1...v5.9.2) (2026-02-23)
+
+**Note:** Version bump only for package @lingui/core
+
+## [5.9.1](https://github.com/lingui/js-lingui/compare/v5.9.0...v5.9.1) (2026-02-11)
+
+**Note:** Version bump only for package @lingui/core
+
 # [5.9.0](https://github.com/lingui/js-lingui/compare/v5.8.0...v5.9.0) (2026-01-23)
 
 **Note:** Version bump only for package @lingui/core

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lingui/core",
-  "version": "6.0.0-next.4",
+  "version": "6.0.0",
   "sideEffects": false,
   "description": "Internationalization (i18n) tools for JavaScript",
   "type": "module",

--- a/packages/detect-locale/CHANGELOG.md
+++ b/packages/detect-locale/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [5.9.5](https://github.com/lingui/js-lingui/compare/v5.9.4...v5.9.5) (2026-04-06)
+
+**Note:** Version bump only for package @lingui/detect-locale
+
+## [5.9.4](https://github.com/lingui/js-lingui/compare/v5.9.3...v5.9.4) (2026-03-27)
+
+**Note:** Version bump only for package @lingui/detect-locale
+
+## [5.9.3](https://github.com/lingui/js-lingui/compare/v6.0.0-next.1...v5.9.3) (2026-03-13)
+
+**Note:** Version bump only for package @lingui/detect-locale
+
+## [5.9.2](https://github.com/lingui/js-lingui/compare/v5.9.1...v5.9.2) (2026-02-23)
+
+**Note:** Version bump only for package @lingui/detect-locale
+
+## [5.9.1](https://github.com/lingui/js-lingui/compare/v5.9.0...v5.9.1) (2026-02-11)
+
+**Note:** Version bump only for package @lingui/detect-locale
+
 # [5.9.0](https://github.com/lingui/js-lingui/compare/v5.8.0...v5.9.0) (2026-01-23)
 
 **Note:** Version bump only for package @lingui/detect-locale

--- a/packages/detect-locale/CHANGELOG.md
+++ b/packages/detect-locale/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [6.0.0](https://github.com/lingui/js-lingui/compare/v5.9.5...v6.0.0) (2026-04-22)
+
+- [Announcing Lingui 6.0](https://lingui.dev/blog/2026/04/22/announcing-lingui-6.0)
+
 ## [5.9.5](https://github.com/lingui/js-lingui/compare/v5.9.4...v5.9.5) (2026-04-06)
 
 **Note:** Version bump only for package @lingui/detect-locale
@@ -11,7 +15,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @lingui/detect-locale
 
-## [5.9.3](https://github.com/lingui/js-lingui/compare/v6.0.0-next.1...v5.9.3) (2026-03-13)
+## [5.9.3](https://github.com/lingui/js-lingui/compare/v5.9.2...v5.9.3) (2026-03-13)
 
 **Note:** Version bump only for package @lingui/detect-locale
 

--- a/packages/detect-locale/package.json
+++ b/packages/detect-locale/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lingui/detect-locale",
-  "version": "6.0.0-next.4",
+  "version": "6.0.0",
   "type": "module",
   "sideEffects": false,
   "description": "Locale detection utilities for Lingui apps across browser, server, and common runtimes",

--- a/packages/extractor-vue/CHANGELOG.md
+++ b/packages/extractor-vue/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [6.0.0](https://github.com/lingui/js-lingui/compare/v5.9.5...v6.0.0) (2026-04-22)
+
+- [Announcing Lingui 6.0](https://lingui.dev/blog/2026/04/22/announcing-lingui-6.0)
+
 ## [5.9.5](https://github.com/lingui/js-lingui/compare/v5.9.4...v5.9.5) (2026-04-06)
 
 **Note:** Version bump only for package @lingui/extractor-vue
@@ -11,7 +15,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @lingui/extractor-vue
 
-## [5.9.3](https://github.com/lingui/js-lingui/compare/v6.0.0-next.1...v5.9.3) (2026-03-13)
+## [5.9.3](https://github.com/lingui/js-lingui/compare/v5.9.2...v5.9.3) (2026-03-13)
 
 **Note:** Version bump only for package @lingui/extractor-vue
 

--- a/packages/extractor-vue/CHANGELOG.md
+++ b/packages/extractor-vue/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [5.9.5](https://github.com/lingui/js-lingui/compare/v5.9.4...v5.9.5) (2026-04-06)
+
+**Note:** Version bump only for package @lingui/extractor-vue
+
+## [5.9.4](https://github.com/lingui/js-lingui/compare/v5.9.3...v5.9.4) (2026-03-27)
+
+**Note:** Version bump only for package @lingui/extractor-vue
+
+## [5.9.3](https://github.com/lingui/js-lingui/compare/v6.0.0-next.1...v5.9.3) (2026-03-13)
+
+**Note:** Version bump only for package @lingui/extractor-vue
+
+## [5.9.2](https://github.com/lingui/js-lingui/compare/v5.9.1...v5.9.2) (2026-02-23)
+
+**Note:** Version bump only for package @lingui/extractor-vue
+
+## [5.9.1](https://github.com/lingui/js-lingui/compare/v5.9.0...v5.9.1) (2026-02-11)
+
+**Note:** Version bump only for package @lingui/extractor-vue
+
 # [5.9.0](https://github.com/lingui/js-lingui/compare/v5.8.0...v5.9.0) (2026-01-23)
 
 **Note:** Version bump only for package @lingui/extractor-vue

--- a/packages/extractor-vue/package.json
+++ b/packages/extractor-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lingui/extractor-vue",
-  "version": "6.0.0-next.4",
+  "version": "6.0.0",
   "type": "module",
   "description": "Vue single-file component extractor for the Lingui CLI",
   "keywords": [

--- a/packages/format-csv/CHANGELOG.md
+++ b/packages/format-csv/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [6.0.0](https://github.com/lingui/js-lingui/compare/v5.9.5...v6.0.0) (2026-04-22)
+
+- [Announcing Lingui 6.0](https://lingui.dev/blog/2026/04/22/announcing-lingui-6.0)
+
 ## [5.9.5](https://github.com/lingui/js-lingui/compare/v5.9.4...v5.9.5) (2026-04-06)
 
 **Note:** Version bump only for package @lingui/format-csv
@@ -11,7 +15,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @lingui/format-csv
 
-## [5.9.3](https://github.com/lingui/js-lingui/compare/v6.0.0-next.1...v5.9.3) (2026-03-13)
+## [5.9.3](https://github.com/lingui/js-lingui/compare/v5.9.2...v5.9.3) (2026-03-13)
 
 **Note:** Version bump only for package @lingui/format-csv
 

--- a/packages/format-csv/CHANGELOG.md
+++ b/packages/format-csv/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [5.9.5](https://github.com/lingui/js-lingui/compare/v5.9.4...v5.9.5) (2026-04-06)
+
+**Note:** Version bump only for package @lingui/format-csv
+
+## [5.9.4](https://github.com/lingui/js-lingui/compare/v5.9.3...v5.9.4) (2026-03-27)
+
+**Note:** Version bump only for package @lingui/format-csv
+
+## [5.9.3](https://github.com/lingui/js-lingui/compare/v6.0.0-next.1...v5.9.3) (2026-03-13)
+
+**Note:** Version bump only for package @lingui/format-csv
+
+## [5.9.2](https://github.com/lingui/js-lingui/compare/v5.9.1...v5.9.2) (2026-02-23)
+
+**Note:** Version bump only for package @lingui/format-csv
+
+## [5.9.1](https://github.com/lingui/js-lingui/compare/v5.9.0...v5.9.1) (2026-02-11)
+
+**Note:** Version bump only for package @lingui/format-csv
+
 # [5.9.0](https://github.com/lingui/js-lingui/compare/v5.8.0...v5.9.0) (2026-01-23)
 
 **Note:** Version bump only for package @lingui/format-csv

--- a/packages/format-csv/package.json
+++ b/packages/format-csv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lingui/format-csv",
-  "version": "6.0.0-next.4",
+  "version": "6.0.0",
   "description": "CSV formatter for Lingui message catalogs",
   "type": "module",
   "exports": {

--- a/packages/format-json/CHANGELOG.md
+++ b/packages/format-json/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [5.9.5](https://github.com/lingui/js-lingui/compare/v5.9.4...v5.9.5) (2026-04-06)
+
+**Note:** Version bump only for package @lingui/format-json
+
+## [5.9.4](https://github.com/lingui/js-lingui/compare/v5.9.3...v5.9.4) (2026-03-27)
+
+**Note:** Version bump only for package @lingui/format-json
+
+## [5.9.3](https://github.com/lingui/js-lingui/compare/v6.0.0-next.1...v5.9.3) (2026-03-13)
+
+**Note:** Version bump only for package @lingui/format-json
+
+## [5.9.2](https://github.com/lingui/js-lingui/compare/v5.9.1...v5.9.2) (2026-02-23)
+
+**Note:** Version bump only for package @lingui/format-json
+
+## [5.9.1](https://github.com/lingui/js-lingui/compare/v5.9.0...v5.9.1) (2026-02-11)
+
+**Note:** Version bump only for package @lingui/format-json
+
 # [5.9.0](https://github.com/lingui/js-lingui/compare/v5.8.0...v5.9.0) (2026-01-23)
 
 **Note:** Version bump only for package @lingui/format-json

--- a/packages/format-json/CHANGELOG.md
+++ b/packages/format-json/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [6.0.0](https://github.com/lingui/js-lingui/compare/v5.9.5...v6.0.0) (2026-04-22)
+
+- [Announcing Lingui 6.0](https://lingui.dev/blog/2026/04/22/announcing-lingui-6.0)
+
 ## [5.9.5](https://github.com/lingui/js-lingui/compare/v5.9.4...v5.9.5) (2026-04-06)
 
 **Note:** Version bump only for package @lingui/format-json
@@ -11,7 +15,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @lingui/format-json
 
-## [5.9.3](https://github.com/lingui/js-lingui/compare/v6.0.0-next.1...v5.9.3) (2026-03-13)
+## [5.9.3](https://github.com/lingui/js-lingui/compare/v5.9.2...v5.9.3) (2026-03-13)
 
 **Note:** Version bump only for package @lingui/format-json
 

--- a/packages/format-json/package.json
+++ b/packages/format-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lingui/format-json",
-  "version": "6.0.0-next.4",
+  "version": "6.0.0",
   "type": "module",
   "description": "JSON formatter for Lingui message catalogs",
   "exports": {

--- a/packages/format-po-gettext/CHANGELOG.md
+++ b/packages/format-po-gettext/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [5.9.5](https://github.com/lingui/js-lingui/compare/v5.9.4...v5.9.5) (2026-04-06)
+
+**Note:** Version bump only for package @lingui/format-po-gettext
+
+## [5.9.4](https://github.com/lingui/js-lingui/compare/v5.9.3...v5.9.4) (2026-03-27)
+
+**Note:** Version bump only for package @lingui/format-po-gettext
+
+## [5.9.3](https://github.com/lingui/js-lingui/compare/v6.0.0-next.1...v5.9.3) (2026-03-13)
+
+**Note:** Version bump only for package @lingui/format-po-gettext
+
+## [5.9.2](https://github.com/lingui/js-lingui/compare/v5.9.1...v5.9.2) (2026-02-23)
+
+**Note:** Version bump only for package @lingui/format-po-gettext
+
+## [5.9.1](https://github.com/lingui/js-lingui/compare/v5.9.0...v5.9.1) (2026-02-11)
+
+**Note:** Version bump only for package @lingui/format-po-gettext
+
 # [5.9.0](https://github.com/lingui/js-lingui/compare/v5.8.0...v5.9.0) (2026-01-23)
 
 **Note:** Version bump only for package @lingui/format-po-gettext

--- a/packages/format-po-gettext/CHANGELOG.md
+++ b/packages/format-po-gettext/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [6.0.0](https://github.com/lingui/js-lingui/compare/v5.9.5...v6.0.0) (2026-04-22)
+
+- [Announcing Lingui 6.0](https://lingui.dev/blog/2026/04/22/announcing-lingui-6.0)
+
 ## [5.9.5](https://github.com/lingui/js-lingui/compare/v5.9.4...v5.9.5) (2026-04-06)
 
 **Note:** Version bump only for package @lingui/format-po-gettext
@@ -11,7 +15,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @lingui/format-po-gettext
 
-## [5.9.3](https://github.com/lingui/js-lingui/compare/v6.0.0-next.1...v5.9.3) (2026-03-13)
+## [5.9.3](https://github.com/lingui/js-lingui/compare/v5.9.2...v5.9.3) (2026-03-13)
 
 **Note:** Version bump only for package @lingui/format-po-gettext
 

--- a/packages/format-po-gettext/package.json
+++ b/packages/format-po-gettext/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lingui/format-po-gettext",
-  "version": "6.0.0-next.4",
+  "version": "6.0.0",
   "description": "Gettext PO formatter for Lingui message catalogs using gettext-style plural rules",
   "type": "module",
   "sideEffects": false,

--- a/packages/format-po/CHANGELOG.md
+++ b/packages/format-po/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [5.9.5](https://github.com/lingui/js-lingui/compare/v5.9.4...v5.9.5) (2026-04-06)
+
+**Note:** Version bump only for package @lingui/format-po
+
+## [5.9.4](https://github.com/lingui/js-lingui/compare/v5.9.3...v5.9.4) (2026-03-27)
+
+**Note:** Version bump only for package @lingui/format-po
+
+## [5.9.3](https://github.com/lingui/js-lingui/compare/v6.0.0-next.1...v5.9.3) (2026-03-13)
+
+**Note:** Version bump only for package @lingui/format-po
+
+## [5.9.2](https://github.com/lingui/js-lingui/compare/v5.9.1...v5.9.2) (2026-02-23)
+
+**Note:** Version bump only for package @lingui/format-po
+
+## [5.9.1](https://github.com/lingui/js-lingui/compare/v5.9.0...v5.9.1) (2026-02-11)
+
+**Note:** Version bump only for package @lingui/format-po
+
 # [5.9.0](https://github.com/lingui/js-lingui/compare/v5.8.0...v5.9.0) (2026-01-23)
 
 **Note:** Version bump only for package @lingui/format-po

--- a/packages/format-po/CHANGELOG.md
+++ b/packages/format-po/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [6.0.0](https://github.com/lingui/js-lingui/compare/v5.9.5...v6.0.0) (2026-04-22)
+
+- [Announcing Lingui 6.0](https://lingui.dev/blog/2026/04/22/announcing-lingui-6.0)
+
 ## [5.9.5](https://github.com/lingui/js-lingui/compare/v5.9.4...v5.9.5) (2026-04-06)
 
 **Note:** Version bump only for package @lingui/format-po
@@ -11,7 +15,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @lingui/format-po
 
-## [5.9.3](https://github.com/lingui/js-lingui/compare/v6.0.0-next.1...v5.9.3) (2026-03-13)
+## [5.9.3](https://github.com/lingui/js-lingui/compare/v5.9.2...v5.9.3) (2026-03-13)
 
 **Note:** Version bump only for package @lingui/format-po
 

--- a/packages/format-po/package.json
+++ b/packages/format-po/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lingui/format-po",
-  "version": "6.0.0-next.4",
+  "version": "6.0.0",
   "description": "Gettext PO formatter for Lingui message catalogs",
   "type": "module",
   "sideEffects": false,

--- a/packages/loader/CHANGELOG.md
+++ b/packages/loader/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [5.9.5](https://github.com/lingui/js-lingui/compare/v5.9.4...v5.9.5) (2026-04-06)
+
+**Note:** Version bump only for package @lingui/loader
+
+## [5.9.4](https://github.com/lingui/js-lingui/compare/v5.9.3...v5.9.4) (2026-03-27)
+
+**Note:** Version bump only for package @lingui/loader
+
+## [5.9.3](https://github.com/lingui/js-lingui/compare/v6.0.0-next.1...v5.9.3) (2026-03-13)
+
+**Note:** Version bump only for package @lingui/loader
+
+## [5.9.2](https://github.com/lingui/js-lingui/compare/v5.9.1...v5.9.2) (2026-02-23)
+
+**Note:** Version bump only for package @lingui/loader
+
+## [5.9.1](https://github.com/lingui/js-lingui/compare/v5.9.0...v5.9.1) (2026-02-11)
+
+**Note:** Version bump only for package @lingui/loader
+
 # [5.9.0](https://github.com/lingui/js-lingui/compare/v5.8.0...v5.9.0) (2026-01-23)
 
 **Note:** Version bump only for package @lingui/loader

--- a/packages/loader/CHANGELOG.md
+++ b/packages/loader/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [6.0.0](https://github.com/lingui/js-lingui/compare/v5.9.5...v6.0.0) (2026-04-22)
+
+- [Announcing Lingui 6.0](https://lingui.dev/blog/2026/04/22/announcing-lingui-6.0)
+
 ## [5.9.5](https://github.com/lingui/js-lingui/compare/v5.9.4...v5.9.5) (2026-04-06)
 
 **Note:** Version bump only for package @lingui/loader
@@ -11,7 +15,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @lingui/loader
 
-## [5.9.3](https://github.com/lingui/js-lingui/compare/v6.0.0-next.1...v5.9.3) (2026-03-13)
+## [5.9.3](https://github.com/lingui/js-lingui/compare/v5.9.2...v5.9.3) (2026-03-13)
 
 **Note:** Version bump only for package @lingui/loader
 

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lingui/loader",
-  "version": "6.0.0-next.4",
+  "version": "6.0.0",
   "type": "module",
   "description": "A webpack-compatible loader to load and compile Lingui message catalogs at build time",
   "exports": {

--- a/packages/message-utils/CHANGELOG.md
+++ b/packages/message-utils/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [6.0.0](https://github.com/lingui/js-lingui/compare/v5.9.5...v6.0.0) (2026-04-22)
+
+- [Announcing Lingui 6.0](https://lingui.dev/blog/2026/04/22/announcing-lingui-6.0)
+
 ## [5.9.5](https://github.com/lingui/js-lingui/compare/v5.9.4...v5.9.5) (2026-04-06)
 
 **Note:** Version bump only for package @lingui/message-utils
@@ -11,7 +15,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @lingui/message-utils
 
-## [5.9.3](https://github.com/lingui/js-lingui/compare/v6.0.0-next.1...v5.9.3) (2026-03-13)
+## [5.9.3](https://github.com/lingui/js-lingui/compare/v5.9.2...v5.9.3) (2026-03-13)
 
 **Note:** Version bump only for package @lingui/message-utils
 

--- a/packages/message-utils/CHANGELOG.md
+++ b/packages/message-utils/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [5.9.5](https://github.com/lingui/js-lingui/compare/v5.9.4...v5.9.5) (2026-04-06)
+
+**Note:** Version bump only for package @lingui/message-utils
+
+## [5.9.4](https://github.com/lingui/js-lingui/compare/v5.9.3...v5.9.4) (2026-03-27)
+
+**Note:** Version bump only for package @lingui/message-utils
+
+## [5.9.3](https://github.com/lingui/js-lingui/compare/v6.0.0-next.1...v5.9.3) (2026-03-13)
+
+**Note:** Version bump only for package @lingui/message-utils
+
+## [5.9.2](https://github.com/lingui/js-lingui/compare/v5.9.1...v5.9.2) (2026-02-23)
+
+**Note:** Version bump only for package @lingui/message-utils
+
+## [5.9.1](https://github.com/lingui/js-lingui/compare/v5.9.0...v5.9.1) (2026-02-11)
+
+**Note:** Version bump only for package @lingui/message-utils
+
 # [5.9.0](https://github.com/lingui/js-lingui/compare/v5.8.0...v5.9.0) (2026-01-23)
 
 ### Features

--- a/packages/message-utils/package.json
+++ b/packages/message-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lingui/message-utils",
-  "version": "6.0.0-next.4",
+  "version": "6.0.0",
   "description": "Low-level Lingui utilities to compile ICU MessageFormat messages and generate stable message IDs",
   "license": "MIT",
   "keywords": [

--- a/packages/metro-transformer/CHANGELOG.md
+++ b/packages/metro-transformer/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [5.9.5](https://github.com/lingui/js-lingui/compare/v5.9.4...v5.9.5) (2026-04-06)
+
+**Note:** Version bump only for package @lingui/metro-transformer
+
+## [5.9.4](https://github.com/lingui/js-lingui/compare/v5.9.3...v5.9.4) (2026-03-27)
+
+**Note:** Version bump only for package @lingui/metro-transformer
+
+## [5.9.3](https://github.com/lingui/js-lingui/compare/v6.0.0-next.1...v5.9.3) (2026-03-13)
+
+**Note:** Version bump only for package @lingui/metro-transformer
+
+## [5.9.2](https://github.com/lingui/js-lingui/compare/v5.9.1...v5.9.2) (2026-02-23)
+
+**Note:** Version bump only for package @lingui/metro-transformer
+
+## [5.9.1](https://github.com/lingui/js-lingui/compare/v5.9.0...v5.9.1) (2026-02-11)
+
+**Note:** Version bump only for package @lingui/metro-transformer
+
 # [5.9.0](https://github.com/lingui/js-lingui/compare/v5.8.0...v5.9.0) (2026-01-23)
 
 **Note:** Version bump only for package @lingui/metro-transformer

--- a/packages/metro-transformer/CHANGELOG.md
+++ b/packages/metro-transformer/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [6.0.0](https://github.com/lingui/js-lingui/compare/v5.9.5...v6.0.0) (2026-04-22)
+
+- [Announcing Lingui 6.0](https://lingui.dev/blog/2026/04/22/announcing-lingui-6.0)
+
 ## [5.9.5](https://github.com/lingui/js-lingui/compare/v5.9.4...v5.9.5) (2026-04-06)
 
 **Note:** Version bump only for package @lingui/metro-transformer
@@ -11,7 +15,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @lingui/metro-transformer
 
-## [5.9.3](https://github.com/lingui/js-lingui/compare/v6.0.0-next.1...v5.9.3) (2026-03-13)
+## [5.9.3](https://github.com/lingui/js-lingui/compare/v5.9.2...v5.9.3) (2026-03-13)
 
 **Note:** Version bump only for package @lingui/metro-transformer
 

--- a/packages/metro-transformer/package.json
+++ b/packages/metro-transformer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lingui/metro-transformer",
-  "version": "6.0.0-next.4",
+  "version": "6.0.0",
   "type": "commonjs",
   "description": "Metro transformer for Lingui catalogs in React Native and Expo projects",
   "exports": {

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [5.9.5](https://github.com/lingui/js-lingui/compare/v5.9.4...v5.9.5) (2026-04-06)
+
+**Note:** Version bump only for package @lingui/react
+
+## [5.9.4](https://github.com/lingui/js-lingui/compare/v5.9.3...v5.9.4) (2026-03-27)
+
+**Note:** Version bump only for package @lingui/react
+
+## [5.9.3](https://github.com/lingui/js-lingui/compare/v6.0.0-next.1...v5.9.3) (2026-03-13)
+
+**Note:** Version bump only for package @lingui/react
+
+## [5.9.2](https://github.com/lingui/js-lingui/compare/v5.9.1...v5.9.2) (2026-02-23)
+
+**Note:** Version bump only for package @lingui/react
+
+## [5.9.1](https://github.com/lingui/js-lingui/compare/v5.9.0...v5.9.1) (2026-02-11)
+
+**Note:** Version bump only for package @lingui/react
+
 # [5.9.0](https://github.com/lingui/js-lingui/compare/v5.8.0...v5.9.0) (2026-01-23)
 
 **Note:** Version bump only for package @lingui/react

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [6.0.0](https://github.com/lingui/js-lingui/compare/v5.9.5...v6.0.0) (2026-04-22)
+
+- [Announcing Lingui 6.0](https://lingui.dev/blog/2026/04/22/announcing-lingui-6.0)
+
 ## [5.9.5](https://github.com/lingui/js-lingui/compare/v5.9.4...v5.9.5) (2026-04-06)
 
 **Note:** Version bump only for package @lingui/react
@@ -11,7 +15,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @lingui/react
 
-## [5.9.3](https://github.com/lingui/js-lingui/compare/v6.0.0-next.1...v5.9.3) (2026-03-13)
+## [5.9.3](https://github.com/lingui/js-lingui/compare/v5.9.2...v5.9.3) (2026-03-13)
 
 **Note:** Version bump only for package @lingui/react
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lingui/react",
-  "version": "6.0.0-next.4",
+  "version": "6.0.0",
   "sideEffects": false,
   "description": "React bindings for Lingui with Trans components, providers, and compile-time macros",
   "type": "module",

--- a/packages/vite-plugin/CHANGELOG.md
+++ b/packages/vite-plugin/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [6.0.0](https://github.com/lingui/js-lingui/compare/v5.9.5...v6.0.0) (2026-04-22)
+
+- [Announcing Lingui 6.0](https://lingui.dev/blog/2026/04/22/announcing-lingui-6.0)
+
 ## [5.9.5](https://github.com/lingui/js-lingui/compare/v5.9.4...v5.9.5) (2026-04-06)
 
 **Note:** Version bump only for package @lingui/vite-plugin
@@ -11,7 +15,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @lingui/vite-plugin
 
-## [5.9.3](https://github.com/lingui/js-lingui/compare/v6.0.0-next.1...v5.9.3) (2026-03-13)
+## [5.9.3](https://github.com/lingui/js-lingui/compare/v5.9.2...v5.9.3) (2026-03-13)
 
 ### Bug Fixes
 

--- a/packages/vite-plugin/CHANGELOG.md
+++ b/packages/vite-plugin/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [5.9.5](https://github.com/lingui/js-lingui/compare/v5.9.4...v5.9.5) (2026-04-06)
+
+**Note:** Version bump only for package @lingui/vite-plugin
+
+## [5.9.4](https://github.com/lingui/js-lingui/compare/v5.9.3...v5.9.4) (2026-03-27)
+
+**Note:** Version bump only for package @lingui/vite-plugin
+
+## [5.9.3](https://github.com/lingui/js-lingui/compare/v6.0.0-next.1...v5.9.3) (2026-03-13)
+
+### Bug Fixes
+
+* support vite 8 ([#2474](https://github.com/lingui/js-lingui/issues/2474)) ([e4468c7](https://github.com/lingui/js-lingui/commit/e4468c7cb01533e1f68e54c92e74a67cdfc1526d))
+
+## [5.9.2](https://github.com/lingui/js-lingui/compare/v5.9.1...v5.9.2) (2026-02-23)
+
+**Note:** Version bump only for package @lingui/vite-plugin
+
+## [5.9.1](https://github.com/lingui/js-lingui/compare/v5.9.0...v5.9.1) (2026-02-11)
+
+**Note:** Version bump only for package @lingui/vite-plugin
+
 # [5.9.0](https://github.com/lingui/js-lingui/compare/v5.8.0...v5.9.0) (2026-01-23)
 
 **Note:** Version bump only for package @lingui/vite-plugin

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lingui/vite-plugin",
-  "version": "6.0.0-next.4",
+  "version": "6.0.0",
   "description": "Vite plugin to integrate Lingui message catalogs with the CLI and bundler pipeline",
   "type": "module",
   "exports": {

--- a/website/blog/2026-04-22-announcing-lingui-6.0/index.md
+++ b/website/blog/2026-04-22-announcing-lingui-6.0/index.md
@@ -33,7 +33,6 @@ In line with the principles of [Semantic Versioning](https://semver.org/), this 
   - [Stronger Type Safety](#stronger-type-safety)
   - [New Example](#new-example)
 - [Conclusion](#conclusion)
-- [Links](#links)
 
 ## What is Lingui?
 
@@ -279,9 +278,4 @@ We now have a [React Webpack Po-Gettext](https://github.com/lingui/js-lingui/tre
 
 We're excited to continue improving Lingui and hope you enjoy using Lingui 6.0. We look forward to hearing your feedback!
 
-A huge thank you to everyone who contributed to this release - it simply wouldn't have been possible without the amazing [community](/community)!
-
-## Links
-
-- [Migration guide](/releases/migration-6)
-- [Release notes & changelog](https://github.com/lingui/js-lingui/releases/tag/v6.0.0)
+A huge thank you to everyone who helped with this release - it simply wouldn't have been possible without the amazing [community](/community) and [contributors](https://github.com/lingui/js-lingui/graphs/contributors)!

--- a/website/docs/community.md
+++ b/website/docs/community.md
@@ -15,7 +15,7 @@ Before participating, please take a moment to review our [Code of Conduct](https
 
 ### Discussion Forums
 
-The [Lingui Discord Server](https://discord.gg/gFWwAYnMtA) is a place where you can learn, share, and collaborate about anything and everything Lingui.
+The [Lingui Discord Server](https://discord.gg/tBZqKpeF) is a place where you can learn, share, and collaborate about anything and everything Lingui.
 
 ![Join the community on Discord](https://img.shields.io/discord/974702239358783608.svg?label=Discord&logo=Discord&colorB=7289da&style=flat-square)
 

--- a/website/docs/releases/migration-4.md
+++ b/website/docs/releases/migration-4.md
@@ -9,7 +9,7 @@ Minimal required versions are:
 
 :::info
 
-If you encounter any difficulties during the migration process, don't hesitate to ask for assistance on the Lingui [Discord server](https://discord.gg/gFWwAYnMtA).
+If you encounter any difficulties during the migration process, don't hesitate to ask for assistance on the Lingui [Discord server](https://discord.gg/tBZqKpeF).
 
 :::
 

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -23,6 +23,13 @@ const config: Config = {
       disableSwitch: false,
       respectPrefersColorScheme: true,
     },
+    announcementBar: {
+      id: "lingui-6.0",
+      content: `🚀  Lingui <strong>6.0</strong> is now available. <a href="/blog/2026/04/22/announcing-lingui-6.0">Read the release announcement</a> for what's new. ✨`,
+      backgroundColor: "#0d9488",
+      textColor: "#ffffff",
+      isCloseable: true,
+    },
     metadata: [
       {
         name: "title",

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -25,7 +25,7 @@ const config: Config = {
     },
     announcementBar: {
       id: "lingui-6.0",
-      content: `🚀  Lingui <strong>6.0</strong> is now available. <a href="/blog/2026/04/22/announcing-lingui-6.0">Read the release announcement</a> for what's new. ✨`,
+      content: `✨ Lingui <strong>6.0</strong> is now available. <a href="/blog/2026/04/22/announcing-lingui-6.0">Read the release announcement</a> for what's new ✨`,
       backgroundColor: "#0d9488",
       textColor: "#ffffff",
       isCloseable: true,

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -83,7 +83,7 @@ const config: Config = {
           "aria-label": "GitHub repository",
         },
         {
-          href: "https://discord.gg/gFWwAYnMtA",
+          href: "https://discord.gg/tBZqKpeF",
           position: "right",
           className: "header-discord-link",
           title: "Discord",

--- a/website/src/components/site-footer.tsx
+++ b/website/src/components/site-footer.tsx
@@ -26,7 +26,7 @@ const COLUMNS: FooterColumn[] = [
   {
     title: "Community",
     links: [
-      { label: "Discord", href: "https://discord.gg/gFWwAYnMtA", external: true },
+      { label: "Discord", href: "https://discord.gg/tBZqKpeF", external: true },
       {
         label: "Stack Overflow",
         href: "https://stackoverflow.com/questions/tagged/linguijs",


### PR DESCRIPTION
- [x]  Changelogs: add missing v5 entries
- [x] Changelogs: add custom v6 entry
- [x] Update version in packages (`6.0.0` instead of `6.0.0-next.*`)
- [x] Update Readme
- [x] Lock the `stable-5.x` branch
- [x] https://github.com/lingui/swc-plugin/pull/206
- [ ] Swap branches (`main` -> `next`)
