### PR TITLE
fix: trans values typing and runtime

### DIFF
--- a/packages/core/__typetests__/index.tst.ts
+++ b/packages/core/__typetests__/index.tst.ts
@@ -1,6 +1,14 @@
 import { i18n } from "../src"
 import { expect } from "tstyche"
 
+const supportedValues = {
+  deadline: new Date(),
+  total: BigInt(1),
+  active: false,
+  optional: null,
+  missing: undefined,
+}
+
 expect(i18n._("message.id")).type.toBe<string>()
 expect(
   i18n._({
@@ -15,28 +23,13 @@ expect(
     { message: "Hello {name}", comment: "", formats: {} },
   ),
 ).type.toBe<string>()
-expect(i18n._).type.toBeCallableWith("message.id", { deadline: new Date() })
-expect(i18n._).type.toBeCallableWith("message.id", { total: BigInt(1) })
-expect(i18n._).type.toBeCallableWith("message.id", { optional: null })
-expect(i18n._).type.toBeCallableWith("message.id", { optional: undefined })
+expect(i18n._).type.toBeCallableWith("message.id", supportedValues)
 expect(i18n._).type.not.toBeCallableWith("message.id", {
   payload: { nested: true },
 })
 expect(i18n._).type.toBeCallableWith({
   id: "message.id",
-  values: { deadline: new Date() },
-})
-expect(i18n._).type.toBeCallableWith({
-  id: "message.id",
-  values: { total: BigInt(1) },
-})
-expect(i18n._).type.toBeCallableWith({
-  id: "message.id",
-  values: { optional: null },
-})
-expect(i18n._).type.toBeCallableWith({
-  id: "message.id",
-  values: { optional: undefined },
+  values: supportedValues,
 })
 expect(i18n._).type.not.toBeCallableWith({
   id: "message.id",

--- a/packages/core/__typetests__/index.tst.ts
+++ b/packages/core/__typetests__/index.tst.ts
@@ -1,4 +1,4 @@
-import { i18n } from "@lingui/core"
+import { i18n } from "../src"
 import { expect } from "tstyche"
 
 expect(i18n._("message.id")).type.toBe<string>()
@@ -15,6 +15,18 @@ expect(
     { message: "Hello {name}", comment: "", formats: {} },
   ),
 ).type.toBe<string>()
+expect(i18n._).type.toBeCallableWith("message.id", { deadline: new Date() })
+expect(i18n._).type.not.toBeCallableWith("message.id", {
+  payload: { nested: true },
+})
+expect(i18n._).type.toBeCallableWith({
+  id: "message.id",
+  values: { deadline: new Date() },
+})
+expect(i18n._).type.not.toBeCallableWith({
+  id: "message.id",
+  values: { payload: { nested: true } },
+})
 expect(i18n._).type.not.toBeCallableWith(
   // cannot use message descriptor together with rest of params
   {

--- a/packages/core/__typetests__/index.tst.ts
+++ b/packages/core/__typetests__/index.tst.ts
@@ -16,12 +16,27 @@ expect(
   ),
 ).type.toBe<string>()
 expect(i18n._).type.toBeCallableWith("message.id", { deadline: new Date() })
+expect(i18n._).type.toBeCallableWith("message.id", { total: BigInt(1) })
+expect(i18n._).type.toBeCallableWith("message.id", { optional: null })
+expect(i18n._).type.toBeCallableWith("message.id", { optional: undefined })
 expect(i18n._).type.not.toBeCallableWith("message.id", {
   payload: { nested: true },
 })
 expect(i18n._).type.toBeCallableWith({
   id: "message.id",
   values: { deadline: new Date() },
+})
+expect(i18n._).type.toBeCallableWith({
+  id: "message.id",
+  values: { total: BigInt(1) },
+})
+expect(i18n._).type.toBeCallableWith({
+  id: "message.id",
+  values: { optional: null },
+})
+expect(i18n._).type.toBeCallableWith({
+  id: "message.id",
+  values: { optional: undefined },
 })
 expect(i18n._).type.not.toBeCallableWith({
   id: "message.id",

--- a/packages/core/macro/__typetests__/index.tst.ts
+++ b/packages/core/macro/__typetests__/index.tst.ts
@@ -15,6 +15,7 @@ const name = "Jack"
 const user = { name: "Jack" }
 const i18n: I18n = null as any
 const numberValue = 2
+const bigintValue = BigInt(1)
 const deadline = new Date()
 
 // simple
@@ -29,8 +30,9 @@ expect(t`Hello ${ph({ name: user.name })}`).type.toBe<string>()
 
 // allow numbers
 expect(t`Hello ${numberValue}`).type.toBe<string>()
-expect(t`Hello ${{ active: false }}`).type.toBe<string>()
-expect(t`Hello ${{ deadline }}`).type.toBe<string>()
+expect(
+  t`Hello ${bigintValue} ${deadline} ${{ active: false }}`,
+).type.toBe<string>()
 
 // with custom i18n
 expect(t(i18n)`With custom i18n instance`).type.toBe<string>()
@@ -101,9 +103,6 @@ expect(
 // allow numbers
 expect(msg`Hello ${numberValue}`).type.toBe<MessageDescriptor>()
 expect(defineMessage`Hello ${numberValue}`).type.toBe<MessageDescriptor>()
-expect(msg`Hello ${{ active: false }}`).type.toBe<MessageDescriptor>()
-expect(defineMessage`Hello ${{ deadline }}`).type.toBe<MessageDescriptor>()
-expect(ph({ active: false })).type.toBe<string>()
 expect(ph({ deadline })).type.toBe<string>()
 expect(ph).type.not.toBeCallableWith({ payload: { nested: true } })
 

--- a/packages/core/macro/__typetests__/index.tst.ts
+++ b/packages/core/macro/__typetests__/index.tst.ts
@@ -15,6 +15,7 @@ const name = "Jack"
 const user = { name: "Jack" }
 const i18n: I18n = null as any
 const numberValue = 2
+const deadline = new Date()
 
 // simple
 expect(t`Hello world`).type.toBe<string>()
@@ -28,6 +29,8 @@ expect(t`Hello ${ph({ name: user.name })}`).type.toBe<string>()
 
 // allow numbers
 expect(t`Hello ${numberValue}`).type.toBe<string>()
+expect(t`Hello ${{ active: false }}`).type.toBe<string>()
+expect(t`Hello ${{ deadline }}`).type.toBe<string>()
 
 // with custom i18n
 expect(t(i18n)`With custom i18n instance`).type.toBe<string>()
@@ -98,6 +101,11 @@ expect(
 // allow numbers
 expect(msg`Hello ${numberValue}`).type.toBe<MessageDescriptor>()
 expect(defineMessage`Hello ${numberValue}`).type.toBe<MessageDescriptor>()
+expect(msg`Hello ${{ active: false }}`).type.toBe<MessageDescriptor>()
+expect(defineMessage`Hello ${{ deadline }}`).type.toBe<MessageDescriptor>()
+expect(ph({ active: false })).type.toBe<string>()
+expect(ph({ deadline })).type.toBe<string>()
+expect(ph).type.not.toBeCallableWith({ payload: { nested: true } })
 
 expect(
   defineMessage({

--- a/packages/core/macro/index.d.mts
+++ b/packages/core/macro/index.d.mts
@@ -60,9 +60,11 @@ export type MacroMessageDescriptor = (
 export function t(descriptor: MacroMessageDescriptor): string
 
 export type LabeledExpression<T> = Record<string, T>
+export type LabeledMessagePlaceholder =
+  LabeledExpression<MessagePlaceholderValue>
 export type MessagePlaceholder =
   | MessagePlaceholderValue
-  | LabeledExpression<MessagePlaceholderValue>
+  | LabeledMessagePlaceholder
 
 /**
  * Translates a template string using the global I18n instance
@@ -238,4 +240,4 @@ export const msg: typeof defineMessage
 /**
  * Helps to define a name for a variable in the message
  */
-export function ph(def: LabeledExpression<MessagePlaceholderValue>): string
+export function ph(def: LabeledMessagePlaceholder): string

--- a/packages/core/macro/index.d.mts
+++ b/packages/core/macro/index.d.mts
@@ -1,4 +1,8 @@
-import type { I18n, MessageDescriptor, MessageValue } from "@lingui/core"
+import type {
+  I18n,
+  MessageDescriptor,
+  MessagePlaceholderValue,
+} from "@lingui/core"
 
 export type ChoiceOptions = {
   /** Offset of value when calculating plural forms */
@@ -56,7 +60,6 @@ export type MacroMessageDescriptor = (
 export function t(descriptor: MacroMessageDescriptor): string
 
 export type LabeledExpression<T> = Record<string, T>
-export type MessagePlaceholderValue = MessageValue
 export type MessagePlaceholder =
   | MessagePlaceholderValue
   | LabeledExpression<MessagePlaceholderValue>
@@ -109,6 +112,9 @@ export function t(i18n: I18n): {
   (descriptor: MacroMessageDescriptor): string
 }
 
+export type PluralValue = number | string | LabeledExpression<number | string>
+export type SelectValue = string | LabeledExpression<string>
+
 /**
  * Pluralize a message
  *
@@ -125,7 +131,7 @@ export function t(i18n: I18n): {
  * @param options Object with available plural forms
  */
 export function plural(
-  value: number | string | LabeledExpression<number | string>,
+  value: PluralValue,
   options: ChoiceOptions
 ): string
 
@@ -150,7 +156,7 @@ export function plural(
  * @param options Object with available plural forms
  */
 export function selectOrdinal(
-  value: number | string | LabeledExpression<number | string>,
+  value: PluralValue,
   options: ChoiceOptions
 ): string
 
@@ -181,7 +187,7 @@ type SelectOptions = {
  * @param choices
  */
 export function select(
-  value: string | LabeledExpression<string>,
+  value: SelectValue,
   choices: SelectOptions
 ): string
 

--- a/packages/core/macro/index.d.mts
+++ b/packages/core/macro/index.d.mts
@@ -1,4 +1,4 @@
-import type { I18n, MessageDescriptor } from "@lingui/core"
+import type { I18n, MessageDescriptor, MessageValue } from "@lingui/core"
 
 export type ChoiceOptions = {
   /** Offset of value when calculating plural forms */
@@ -56,10 +56,10 @@ export type MacroMessageDescriptor = (
 export function t(descriptor: MacroMessageDescriptor): string
 
 export type LabeledExpression<T> = Record<string, T>
+export type MessagePlaceholderValue = MessageValue
 export type MessagePlaceholder =
-  | string
-  | number
-  | LabeledExpression<string | number>
+  | MessagePlaceholderValue
+  | LabeledExpression<MessagePlaceholderValue>
 
 /**
  * Translates a template string using the global I18n instance
@@ -232,4 +232,4 @@ export const msg: typeof defineMessage
 /**
  * Helps to define a name for a variable in the message
  */
-export function ph(def: LabeledExpression<string | number>): string
+export function ph(def: LabeledExpression<MessagePlaceholderValue>): string

--- a/packages/core/src/i18n.ts
+++ b/packages/core/src/i18n.ts
@@ -26,7 +26,16 @@ export type Formats = Record<
   Intl.DateTimeFormatOptions | Intl.NumberFormatOptions
 >
 
-export type Values = Record<string, unknown>
+export type MessageValue =
+  | string
+  | number
+  | bigint
+  | boolean
+  | null
+  | undefined
+  | Date
+
+export type Values = Record<string, MessageValue>
 
 export type UncompiledMessage = string
 export type Messages = Record<string, UncompiledMessage | CompiledMessage>
@@ -37,7 +46,7 @@ export type MessageDescriptor = {
   id: string
   comment?: string
   message?: string
-  values?: Record<string, unknown>
+  values?: Values
 }
 
 export type MissingMessageEvent = {

--- a/packages/core/src/i18n.ts
+++ b/packages/core/src/i18n.ts
@@ -35,8 +35,6 @@ export type MessagePlaceholderValue =
   | undefined
   | Date
 
-// left it as a compatible alias to MessagePlaceholderValue so as not to break the external API.
-export type MessageValue = MessagePlaceholderValue
 export type Values = Record<string, MessagePlaceholderValue>
 
 export type UncompiledMessage = string

--- a/packages/core/src/i18n.ts
+++ b/packages/core/src/i18n.ts
@@ -26,7 +26,7 @@ export type Formats = Record<
   Intl.DateTimeFormatOptions | Intl.NumberFormatOptions
 >
 
-export type MessageValue =
+export type MessagePlaceholderValue =
   | string
   | number
   | bigint
@@ -35,7 +35,9 @@ export type MessageValue =
   | undefined
   | Date
 
-export type Values = Record<string, MessageValue>
+// left it as a compatible alias to MessagePlaceholderValue so as not to break the external API.
+export type MessageValue = MessagePlaceholderValue
+export type Values = Record<string, MessagePlaceholderValue>
 
 export type UncompiledMessage = string
 export type Messages = Record<string, UncompiledMessage | CompiledMessage>

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,10 +3,12 @@ export { setupI18n, I18n } from "./i18n"
 export type {
   AllMessages,
   MessageDescriptor,
+  MessageValue,
   Messages,
   Locale,
   Locales,
   MessageOptions,
+  Values,
 } from "./i18n"
 
 // Default i18n object

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,7 @@ export { setupI18n, I18n } from "./i18n"
 export type {
   AllMessages,
   MessageDescriptor,
+  MessagePlaceholderValue,
   MessageValue,
   Messages,
   Locale,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,7 +4,6 @@ export type {
   AllMessages,
   MessageDescriptor,
   MessagePlaceholderValue,
-  MessageValue,
   Messages,
   Locale,
   Locales,

--- a/packages/react/__typetests__/index.tst.tsx
+++ b/packages/react/__typetests__/index.tst.tsx
@@ -5,8 +5,11 @@ type Values = NonNullable<TransProps["values"]>
 
 expect({ name: "Tim" }).type.toBeAssignableTo<Values>()
 expect({ count: 1 }).type.toBeAssignableTo<Values>()
+expect({ total: BigInt(1) }).type.toBeAssignableTo<Values>()
 expect({ active: false }).type.toBeAssignableTo<Values>()
 expect({ deadline: new Date() }).type.toBeAssignableTo<Values>()
+expect({ optional: null }).type.toBeAssignableTo<Values>()
+expect({ optional: undefined }).type.toBeAssignableTo<Values>()
 expect({ name: <strong>Tim</strong> }).type.toBeAssignableTo<Values>()
 expect({
   name: ["Mr. ", <strong key="1">Tim</strong>],

--- a/packages/react/__typetests__/index.tst.tsx
+++ b/packages/react/__typetests__/index.tst.tsx
@@ -3,16 +3,16 @@ import type { TransProps } from "../src"
 
 type Values = NonNullable<TransProps["values"]>
 
-expect({ name: "Tim" }).type.toBeAssignableTo<Values>()
-expect({ count: 1 }).type.toBeAssignableTo<Values>()
-expect({ total: BigInt(1) }).type.toBeAssignableTo<Values>()
-expect({ active: false }).type.toBeAssignableTo<Values>()
-expect({ deadline: new Date() }).type.toBeAssignableTo<Values>()
-expect({ optional: null }).type.toBeAssignableTo<Values>()
-expect({ optional: undefined }).type.toBeAssignableTo<Values>()
-expect({ name: <strong>Tim</strong> }).type.toBeAssignableTo<Values>()
 expect({
-  name: ["Mr. ", <strong key="1">Tim</strong>],
+  name: "Tim",
+  count: 1,
+  total: BigInt(1),
+  active: false,
+  deadline: new Date(),
+  optional: null,
+  missing: undefined,
+  richName: <strong>Tim</strong>,
+  parts: ["Mr. ", <strong key="1">Tim</strong>],
 }).type.toBeAssignableTo<Values>()
 
 expect({

--- a/packages/react/__typetests__/index.tst.tsx
+++ b/packages/react/__typetests__/index.tst.tsx
@@ -1,0 +1,17 @@
+import { expect } from "tstyche"
+import type { TransProps } from "../src"
+
+type Values = NonNullable<TransProps["values"]>
+
+expect({ name: "Tim" }).type.toBeAssignableTo<Values>()
+expect({ count: 1 }).type.toBeAssignableTo<Values>()
+expect({ active: false }).type.toBeAssignableTo<Values>()
+expect({ deadline: new Date() }).type.toBeAssignableTo<Values>()
+expect({ name: <strong>Tim</strong> }).type.toBeAssignableTo<Values>()
+expect({
+  name: ["Mr. ", <strong key="1">Tim</strong>],
+}).type.toBeAssignableTo<Values>()
+
+expect({
+  payload: { nested: true },
+}).type.not.toBeAssignableTo<Values>()

--- a/packages/react/macro/__typetests__/index.tst.tsx
+++ b/packages/react/macro/__typetests__/index.tst.tsx
@@ -149,6 +149,9 @@ m = <Select value={gender} male="..." female=".." other={"..."} />
 
 m = <Select value={{ gender }} _male="..." _female=".." other={"..."} />
 
+// @ts-expect-error: labeled value for Select should be string only
+m = <Select value={{ gender: 1 }} _male="..." _female=".." other={"..."} />
+
 // should support JSX in props
 m = (
   <Select

--- a/packages/react/macro/__typetests__/index.tst.tsx
+++ b/packages/react/macro/__typetests__/index.tst.tsx
@@ -32,7 +32,6 @@ m = (
 m = <Trans id="custom.id" comment="comment" context="context" />
 
 m = <Trans>Hello {{ username: user.name }}</Trans>
-m = <Trans>Hello {{ active: false }}</Trans>
 m = <Trans>Hello {{ deadline: new Date() }}</Trans>
 m = (
   <Trans>

--- a/packages/react/macro/__typetests__/index.tst.tsx
+++ b/packages/react/macro/__typetests__/index.tst.tsx
@@ -32,6 +32,16 @@ m = (
 m = <Trans id="custom.id" comment="comment" context="context" />
 
 m = <Trans>Hello {{ username: user.name }}</Trans>
+m = <Trans>Hello {{ active: false }}</Trans>
+m = <Trans>Hello {{ deadline: new Date() }}</Trans>
+m = (
+  <Trans>
+    {
+      // @ts-expect-error: nested objects are not supported as interpolation values
+      { payload: { nested: true } }
+    }
+  </Trans>
+)
 
 m = (
   <Trans>

--- a/packages/react/macro/index.d.mts
+++ b/packages/react/macro/index.d.mts
@@ -3,10 +3,9 @@ import type {
   TransRenderCallbackOrComponent,
   I18nContext,
 } from "@lingui/react"
-import type { MessagePlaceholderValue } from "@lingui/core"
 import type {
   MacroMessageDescriptor,
-  LabeledExpression,
+  LabeledMessagePlaceholder,
   PluralValue,
   SelectValue,
 } from "@lingui/core/macro"
@@ -17,7 +16,7 @@ type CommonProps = TransRenderCallbackOrComponent & {
   context?: string
 }
 
-type TransChildren = ReactNode | LabeledExpression<MessagePlaceholderValue>
+type TransChildren = ReactNode | LabeledMessagePlaceholder
 type TransProps = {
   children: TransChildren | TransChildren[]
 } & CommonProps

--- a/packages/react/macro/index.d.mts
+++ b/packages/react/macro/index.d.mts
@@ -1,5 +1,9 @@
 import type { ReactNode } from "react"
-import type { TransRenderCallbackOrComponent, I18nContext } from "@lingui/react"
+import type {
+  TransRenderCallbackOrComponent,
+  I18nContext,
+} from "@lingui/react"
+import type { MessageValue } from "@lingui/core"
 import type {
   MacroMessageDescriptor,
   LabeledExpression,
@@ -11,7 +15,7 @@ type CommonProps = TransRenderCallbackOrComponent & {
   context?: string
 }
 
-type TransChildren = ReactNode | LabeledExpression<string | number>
+type TransChildren = ReactNode | LabeledExpression<MessageValue>
 type TransProps = {
   children: TransChildren | TransChildren[]
 } & CommonProps

--- a/packages/react/macro/index.d.mts
+++ b/packages/react/macro/index.d.mts
@@ -3,10 +3,12 @@ import type {
   TransRenderCallbackOrComponent,
   I18nContext,
 } from "@lingui/react"
-import type { MessageValue } from "@lingui/core"
+import type { MessagePlaceholderValue } from "@lingui/core"
 import type {
   MacroMessageDescriptor,
   LabeledExpression,
+  PluralValue,
+  SelectValue,
 } from "@lingui/core/macro"
 
 type CommonProps = TransRenderCallbackOrComponent & {
@@ -15,13 +17,13 @@ type CommonProps = TransRenderCallbackOrComponent & {
   context?: string
 }
 
-type TransChildren = ReactNode | LabeledExpression<MessageValue>
+type TransChildren = ReactNode | LabeledExpression<MessagePlaceholderValue>
 type TransProps = {
   children: TransChildren | TransChildren[]
 } & CommonProps
 
 type PluralChoiceProps = {
-  value: string | number | LabeledExpression<string | number>
+  value: PluralValue
   /** Offset of value when calculating plural forms */
   offset?: number
   zero?: ReactNode
@@ -37,7 +39,7 @@ type PluralChoiceProps = {
 } & CommonProps
 
 type SelectChoiceProps = {
-  value: string | LabeledExpression<string | number>
+  value: SelectValue
   /** Catch-all option */
   other: ReactNode
   [option: `_${string}`]: ReactNode

--- a/packages/react/src/Trans.test.tsx
+++ b/packages/react/src/Trans.test.tsx
@@ -351,6 +351,34 @@ describe("Trans component", () => {
     )
   })
 
+  it("should preserve false values for i18n interpolation", () => {
+    const translation = html(
+      <Trans
+        id="msg.bool.false"
+        message="Flag {active}"
+        values={{
+          active: false,
+        }}
+      />,
+    )
+
+    expect(translation).toEqual("Flag false")
+  })
+
+  it("should preserve true values for i18n interpolation", () => {
+    const translation = html(
+      <Trans
+        id="msg.bool.true"
+        message="Flag {active}"
+        values={{
+          active: true,
+        }}
+      />,
+    )
+
+    expect(translation).toEqual("Flag true")
+  })
+
   it("should preserve __proto__ values for i18n interpolation", () => {
     const translation = html(
       <Trans

--- a/packages/react/src/Trans.test.tsx
+++ b/packages/react/src/Trans.test.tsx
@@ -351,6 +351,20 @@ describe("Trans component", () => {
     )
   })
 
+  it("should preserve bigint values for i18n interpolation", () => {
+    const translation = html(
+      <Trans
+        id="msg.bigint"
+        message="Count {total}"
+        values={{
+          total: BigInt(1),
+        }}
+      />,
+    )
+
+    expect(translation).toEqual("Count 1")
+  })
+
   it("should preserve false values for i18n interpolation", () => {
     const translation = html(
       <Trans
@@ -378,6 +392,26 @@ describe("Trans component", () => {
 
     expect(translation).toEqual("Flag true")
   })
+
+  it.each([
+    ["null", null],
+    ["undefined", undefined],
+  ] as const)(
+    "should omit %s values during i18n interpolation",
+    (_label, optional) => {
+      const translation = html(
+        <Trans
+          id="msg.empty"
+          message="Value {optional}"
+          values={{
+            optional,
+          }}
+        />,
+      )
+
+      expect(translation).toEqual("Value ")
+    },
+  )
 
   it("should preserve __proto__ values for i18n interpolation", () => {
     const translation = html(

--- a/packages/react/src/Trans.test.tsx
+++ b/packages/react/src/Trans.test.tsx
@@ -351,6 +351,20 @@ describe("Trans component", () => {
     )
   })
 
+  it("should preserve __proto__ values for i18n interpolation", () => {
+    const translation = html(
+      <Trans
+        id="msg.proto"
+        message="Hello {__proto__}"
+        values={{
+          ["__proto__"]: "John",
+        }}
+      />,
+    )
+
+    expect(translation).toEqual("Hello John")
+  })
+
   it("should render plural", () => {
     const render = (count: number) =>
       html(

--- a/packages/react/src/Trans.test.tsx
+++ b/packages/react/src/Trans.test.tsx
@@ -330,6 +330,27 @@ describe("Trans component", () => {
     expect(translation).toEqual("1,00 €")
   })
 
+  it("should preserve Date values for i18n interpolation", () => {
+    const deadline = new Date("2014-12-06T17:40:00.000Z")
+    const translation = html(
+      <Trans
+        id="msg.date"
+        message="It starts on {deadline} <0>{name}</0>"
+        values={{
+          deadline,
+          name: "John",
+        }}
+        components={{
+          0: <span />,
+        }}
+      />,
+    )
+
+    expect(translation).toEqual(
+      `It starts on ${deadline.toString()} <span>John</span>`,
+    )
+  })
+
   it("should render plural", () => {
     const render = (count: number) =>
       html(

--- a/packages/react/src/Trans.test.tsx
+++ b/packages/react/src/Trans.test.tsx
@@ -157,6 +157,21 @@ describe("Trans component", () => {
       html(
         <Trans
           id="unknown"
+          message={"foo <0>{active}</0> bar"}
+          values={{
+            active: false,
+          }}
+          components={{
+            0: <span />,
+          }}
+        />,
+      ),
+    ).toEqual("foo <span></span> bar")
+
+    expect(
+      html(
+        <Trans
+          id="unknown"
           message={"foo <0>{0}</0> bar"}
           values={{
             0: "lol",
@@ -365,7 +380,7 @@ describe("Trans component", () => {
     expect(translation).toEqual("Count 1")
   })
 
-  it("should preserve false values for i18n interpolation", () => {
+  it("should omit false values during Trans interpolation", () => {
     const translation = html(
       <Trans
         id="msg.bool.false"
@@ -376,10 +391,10 @@ describe("Trans component", () => {
       />,
     )
 
-    expect(translation).toEqual("Flag false")
+    expect(translation).toEqual("Flag ")
   })
 
-  it("should preserve true values for i18n interpolation", () => {
+  it("should omit true values during Trans interpolation", () => {
     const translation = html(
       <Trans
         id="msg.bool.true"
@@ -390,7 +405,7 @@ describe("Trans component", () => {
       />,
     )
 
-    expect(translation).toEqual("Flag true")
+    expect(translation).toEqual("Flag ")
   })
 
   it.each([

--- a/packages/react/src/Trans.test.tsx
+++ b/packages/react/src/Trans.test.tsx
@@ -157,21 +157,6 @@ describe("Trans component", () => {
       html(
         <Trans
           id="unknown"
-          message={"foo <0>{active}</0> bar"}
-          values={{
-            active: false,
-          }}
-          components={{
-            0: <span />,
-          }}
-        />,
-      ),
-    ).toEqual("foo <span></span> bar")
-
-    expect(
-      html(
-        <Trans
-          id="unknown"
           message={"foo <0>{0}</0> bar"}
           values={{
             0: "lol",
@@ -345,14 +330,15 @@ describe("Trans component", () => {
     expect(translation).toEqual("1,00 €")
   })
 
-  it("should preserve Date values for i18n interpolation", () => {
+  it("should preserve Date and bigint values for i18n interpolation", () => {
     const deadline = new Date("2014-12-06T17:40:00.000Z")
     const translation = html(
       <Trans
-        id="msg.date"
-        message="It starts on {deadline} <0>{name}</0>"
+        id="msg.scalars"
+        message="It starts on {deadline}, count {total} <0>{name}</0>"
         values={{
           deadline,
+          total: BigInt(1),
           name: "John",
         }}
         components={{
@@ -362,64 +348,24 @@ describe("Trans component", () => {
     )
 
     expect(translation).toEqual(
-      `It starts on ${deadline.toString()} <span>John</span>`,
+      `It starts on ${deadline.toString()}, count 1 <span>John</span>`,
     )
-  })
-
-  it("should preserve bigint values for i18n interpolation", () => {
-    const translation = html(
-      <Trans
-        id="msg.bigint"
-        message="Count {total}"
-        values={{
-          total: BigInt(1),
-        }}
-      />,
-    )
-
-    expect(translation).toEqual("Count 1")
-  })
-
-  it("should omit false values during Trans interpolation", () => {
-    const translation = html(
-      <Trans
-        id="msg.bool.false"
-        message="Flag {active}"
-        values={{
-          active: false,
-        }}
-      />,
-    )
-
-    expect(translation).toEqual("Flag ")
-  })
-
-  it("should omit true values during Trans interpolation", () => {
-    const translation = html(
-      <Trans
-        id="msg.bool.true"
-        message="Flag {active}"
-        values={{
-          active: true,
-        }}
-      />,
-    )
-
-    expect(translation).toEqual("Flag ")
   })
 
   it.each([
+    ["false", false],
+    ["true", true],
     ["null", null],
     ["undefined", undefined],
   ] as const)(
-    "should omit %s values during i18n interpolation",
-    (_label, optional) => {
+    "should omit %s values during Trans interpolation",
+    (_label, value) => {
       const translation = html(
         <Trans
           id="msg.empty"
-          message="Value {optional}"
+          message="Value {value}"
           values={{
-            optional,
+            value,
           }}
         />,
       )

--- a/packages/react/src/TransNoContext.tsx
+++ b/packages/react/src/TransNoContext.tsx
@@ -195,12 +195,8 @@ function isReactRenderableValue(value: unknown): value is ReactRenderableValue {
 
 function shouldWrapAsPlaceholder(
   value: TransValue,
-): value is Exclude<ReactRenderableValue, string | number | boolean> {
-  if (
-    typeof value === "string" ||
-    typeof value === "number" ||
-    typeof value === "boolean"
-  ) {
+): value is Exclude<ReactRenderableValue, string | number> {
+  if (typeof value === "string" || typeof value === "number") {
     return false
   }
 

--- a/packages/react/src/TransNoContext.tsx
+++ b/packages/react/src/TransNoContext.tsx
@@ -1,5 +1,6 @@
 import { formatElements } from "./format"
 import type { I18n, MessageOptions } from "@lingui/core"
+import { isValidElement } from "react"
 
 export type TransRenderProps = {
   id: string
@@ -146,10 +147,28 @@ const getInterpolationValuesAndComponents = (props: TransProps) => {
     if (typeof valueForKey === "string" || typeof valueForKey === "number") {
       return
     }
+    // Preserve non-React objects, such as Date instances, for ICU formatters.
+    if (!isReactNodeValue(valueForKey)) {
+      return
+    }
     const index = Object.keys(components).length
     // react components, arrays, falsy values, all should be processed as JSX children
     components[index] = <>{valueForKey}</>
     values[key] = `<${index}/>`
   })
   return { values, components }
+}
+
+function isReactNodeValue(value: unknown): value is React.ReactNode {
+  if (
+    value == null ||
+    typeof value === "boolean" ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    isValidElement(value)
+  ) {
+    return true
+  }
+
+  return Array.isArray(value) && value.every(isReactNodeValue)
 }

--- a/packages/react/src/TransNoContext.tsx
+++ b/packages/react/src/TransNoContext.tsx
@@ -5,7 +5,6 @@ import type {
   MessagePlaceholderValue,
   Values,
 } from "@lingui/core"
-import { isValidElement } from "react"
 
 export type TransRenderProps = {
   id: string
@@ -26,16 +25,10 @@ export type TransRenderCallbackOrComponent =
       render?: never
     }
 
-type ReactRenderableValue =
-  | React.ReactElement
-  | string
-  | number
-  | boolean
-  | null
-  | undefined
-  | readonly ReactRenderableValue[]
+type CoreInterpolationValue = string | number | bigint | Date
+type TransChildValue = Exclude<React.ReactNode, string | number>
 
-export type TransValue = MessagePlaceholderValue | ReactRenderableValue
+export type TransValue = CoreInterpolationValue | TransChildValue
 export type TransValues = Record<string, TransValue>
 type TransComponents = { [key: string]: React.ElementType | any }
 
@@ -169,12 +162,13 @@ const getInterpolationValuesAndComponents = (
       Related discussion: https://github.com/lingui/js-lingui/issues/183
     */
   Object.entries(props.values).forEach(([key, valueForKey]) => {
-    // Preserve scalar interpolation values so i18n formatting stays intact.
-    if (!shouldWrapAsPlaceholder(valueForKey)) {
+    if (isCoreInterpolationValue(valueForKey)) {
       values[key] = valueForKey
       return
     }
-    // React elements, arrays, and nullish values should be processed as JSX children
+
+    // `Trans` intentionally keeps React child semantics for these values
+    // instead of flowing them through core string interpolation.
     components[nextIndex] = <>{valueForKey}</>
     values[key] = `<${nextIndex}/>`
     nextIndex += 1
@@ -186,26 +180,13 @@ function getNextPlaceholderIndex(components: TransComponents): number {
   return Object.keys(components).length
 }
 
-function isReactRenderableValue(value: unknown): value is ReactRenderableValue {
-  if (
-    value == null ||
-    typeof value === "boolean" ||
+function isCoreInterpolationValue(
+  value: TransValue,
+): value is CoreInterpolationValue {
+  return (
     typeof value === "string" ||
     typeof value === "number" ||
-    isValidElement(value)
-  ) {
-    return true
-  }
-
-  return Array.isArray(value) && value.every(isReactRenderableValue)
-}
-
-function shouldWrapAsPlaceholder(
-  value: TransValue,
-): value is Exclude<ReactRenderableValue, string | number> {
-  if (typeof value === "string" || typeof value === "number") {
-    return false
-  }
-
-  return isReactRenderableValue(value)
+    typeof value === "bigint" ||
+    value instanceof Date
+  )
 }

--- a/packages/react/src/TransNoContext.tsx
+++ b/packages/react/src/TransNoContext.tsx
@@ -1,5 +1,5 @@
 import { formatElements } from "./format"
-import type { I18n, MessageOptions } from "@lingui/core"
+import type { I18n, MessageOptions, MessageValue, Values } from "@lingui/core"
 import { isValidElement } from "react"
 
 export type TransRenderProps = {
@@ -21,10 +21,22 @@ export type TransRenderCallbackOrComponent =
       render?: never
     }
 
+type JSXChildValue =
+  | React.ReactElement
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | readonly JSXChildValue[]
+
+export type TransValue = MessageValue | JSXChildValue
+export type TransValues = Record<string, TransValue>
+
 export type TransProps = {
   id: string
   message?: string
-  values?: Record<string, unknown>
+  values?: TransValues
   components?: { [key: string]: React.ElementType | any }
   formats?: MessageOptions["formats"]
   comment?: string
@@ -116,7 +128,12 @@ const RenderChildren = ({ children }: TransRenderProps) => {
   return children
 }
 
-const getInterpolationValuesAndComponents = (props: TransProps) => {
+const getInterpolationValuesAndComponents = (
+  props: TransProps,
+): {
+  values: Values | undefined
+  components: TransProps["components"]
+} => {
   if (!props.values) {
     return {
       values: undefined,
@@ -124,8 +141,9 @@ const getInterpolationValuesAndComponents = (props: TransProps) => {
     }
   }
 
-  const values = { ...props.values }
+  const values: Values = Object.create(null)
   const components = { ...props.components }
+  let nextIndex = Object.keys(components).length
   /*
       Replace values placeholders with <INDEX /> and add values to `components`.
       This makes them processed as JSX children and follow JSX semantics.
@@ -143,23 +161,20 @@ const getInterpolationValuesAndComponents = (props: TransProps) => {
       Related discussion: https://github.com/lingui/js-lingui/issues/183
     */
   Object.entries(props.values).forEach(([key, valueForKey]) => {
-    // simple scalars should be processed as values to be able to apply formatting
-    if (typeof valueForKey === "string" || typeof valueForKey === "number") {
+    // Preserve non-React values instead of converting them into JSX placeholders.
+    if (!isPlaceholderValue(valueForKey)) {
+      values[key] = valueForKey
       return
     }
-    // Preserve non-React values, such as Date instances, instead of treating them as JSX children
-    if (!isReactNodeValue(valueForKey)) {
-      return
-    }
-    const index = Object.keys(components).length
     // react components, arrays, falsy values, all should be processed as JSX children
-    components[index] = <>{valueForKey}</>
-    values[key] = `<${index}/>`
+    components[nextIndex] = <>{valueForKey}</>
+    values[key] = `<${nextIndex}/>`
+    nextIndex += 1
   })
   return { values, components }
 }
 
-function isReactNodeValue(value: unknown): value is React.ReactNode {
+function isJSXChildValue(value: unknown): value is JSXChildValue {
   if (
     value == null ||
     typeof value === "boolean" ||
@@ -170,5 +185,15 @@ function isReactNodeValue(value: unknown): value is React.ReactNode {
     return true
   }
 
-  return Array.isArray(value) && value.every(isReactNodeValue)
+  return Array.isArray(value) && value.every(isJSXChildValue)
+}
+
+function isPlaceholderValue(
+  value: TransValue,
+): value is Exclude<JSXChildValue, string | number> {
+  if (typeof value === "string" || typeof value === "number") {
+    return false
+  }
+
+  return isJSXChildValue(value)
 }

--- a/packages/react/src/TransNoContext.tsx
+++ b/packages/react/src/TransNoContext.tsx
@@ -30,7 +30,7 @@ type TransChildValue = Exclude<React.ReactNode, string | number>
 
 export type TransValue = CoreInterpolationValue | TransChildValue
 export type TransValues = Record<string, TransValue>
-type TransComponents = { [key: string]: React.ElementType | any }
+type TransComponents = Record<string, React.ReactElement>
 
 export type TransProps = {
   id: string

--- a/packages/react/src/TransNoContext.tsx
+++ b/packages/react/src/TransNoContext.tsx
@@ -1,10 +1,5 @@
 import { formatElements } from "./format"
-import type {
-  I18n,
-  MessageOptions,
-  MessagePlaceholderValue,
-  Values,
-} from "@lingui/core"
+import type { I18n, MessageOptions, Values } from "@lingui/core"
 
 export type TransRenderProps = {
   id: string

--- a/packages/react/src/TransNoContext.tsx
+++ b/packages/react/src/TransNoContext.tsx
@@ -1,5 +1,10 @@
 import { formatElements } from "./format"
-import type { I18n, MessageOptions, MessageValue, Values } from "@lingui/core"
+import type {
+  I18n,
+  MessageOptions,
+  MessagePlaceholderValue,
+  Values,
+} from "@lingui/core"
 import { isValidElement } from "react"
 
 export type TransRenderProps = {
@@ -30,7 +35,7 @@ type JSXChildValue =
   | undefined
   | readonly JSXChildValue[]
 
-export type TransValue = MessageValue | JSXChildValue
+export type TransValue = MessagePlaceholderValue | JSXChildValue
 export type TransValues = Record<string, TransValue>
 
 export type TransProps = {

--- a/packages/react/src/TransNoContext.tsx
+++ b/packages/react/src/TransNoContext.tsx
@@ -166,7 +166,7 @@ const getInterpolationValuesAndComponents = (
       values[key] = valueForKey
       return
     }
-    // react components, arrays, falsy values, all should be processed as JSX children
+    // React elements, arrays, and nullish values should be processed as JSX children
     components[nextIndex] = <>{valueForKey}</>
     values[key] = `<${nextIndex}/>`
     nextIndex += 1
@@ -191,7 +191,11 @@ function isJSXChildValue(value: unknown): value is JSXChildValue {
 function isPlaceholderValue(
   value: TransValue,
 ): value is Exclude<JSXChildValue, string | number> {
-  if (typeof value === "string" || typeof value === "number") {
+  if (
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
     return false
   }
 

--- a/packages/react/src/TransNoContext.tsx
+++ b/packages/react/src/TransNoContext.tsx
@@ -37,12 +37,13 @@ type ReactRenderableValue =
 
 export type TransValue = MessagePlaceholderValue | ReactRenderableValue
 export type TransValues = Record<string, TransValue>
+type TransComponents = { [key: string]: React.ElementType | any }
 
 export type TransProps = {
   id: string
   message?: string
   values?: TransValues
-  components?: { [key: string]: React.ElementType | any }
+  components?: TransComponents
   formats?: MessageOptions["formats"]
   comment?: string
 } & TransRenderCallbackOrComponent
@@ -137,7 +138,7 @@ const getInterpolationValuesAndComponents = (
   props: TransProps,
 ): {
   values: Values | undefined
-  components: TransProps["components"]
+  components: TransComponents | undefined
 } => {
   if (!props.values) {
     return {
@@ -147,8 +148,10 @@ const getInterpolationValuesAndComponents = (
   }
 
   const values: Values = Object.create(null)
-  const components = { ...props.components }
-  let nextIndex = Object.keys(components).length
+  const components: TransComponents = {
+    ...props.components,
+  }
+  let nextIndex = getNextPlaceholderIndex(components)
   /*
       Replace values placeholders with <INDEX /> and add values to `components`.
       This makes them processed as JSX children and follow JSX semantics.
@@ -177,6 +180,10 @@ const getInterpolationValuesAndComponents = (
     nextIndex += 1
   })
   return { values, components }
+}
+
+function getNextPlaceholderIndex(components: TransComponents): number {
+  return Object.keys(components).length
 }
 
 function isReactRenderableValue(value: unknown): value is ReactRenderableValue {

--- a/packages/react/src/TransNoContext.tsx
+++ b/packages/react/src/TransNoContext.tsx
@@ -147,7 +147,7 @@ const getInterpolationValuesAndComponents = (props: TransProps) => {
     if (typeof valueForKey === "string" || typeof valueForKey === "number") {
       return
     }
-    // Preserve non-React objects, such as Date instances, for ICU formatters.
+    // Preserve non-React values, such as Date instances, instead of treating them as JSX children
     if (!isReactNodeValue(valueForKey)) {
       return
     }

--- a/packages/react/src/TransNoContext.tsx
+++ b/packages/react/src/TransNoContext.tsx
@@ -26,16 +26,16 @@ export type TransRenderCallbackOrComponent =
       render?: never
     }
 
-type JSXChildValue =
+type ReactRenderableValue =
   | React.ReactElement
   | string
   | number
   | boolean
   | null
   | undefined
-  | readonly JSXChildValue[]
+  | readonly ReactRenderableValue[]
 
-export type TransValue = MessagePlaceholderValue | JSXChildValue
+export type TransValue = MessagePlaceholderValue | ReactRenderableValue
 export type TransValues = Record<string, TransValue>
 
 export type TransProps = {
@@ -166,8 +166,8 @@ const getInterpolationValuesAndComponents = (
       Related discussion: https://github.com/lingui/js-lingui/issues/183
     */
   Object.entries(props.values).forEach(([key, valueForKey]) => {
-    // Preserve non-React values instead of converting them into JSX placeholders.
-    if (!isPlaceholderValue(valueForKey)) {
+    // Preserve scalar interpolation values so i18n formatting stays intact.
+    if (!shouldWrapAsPlaceholder(valueForKey)) {
       values[key] = valueForKey
       return
     }
@@ -179,7 +179,7 @@ const getInterpolationValuesAndComponents = (
   return { values, components }
 }
 
-function isJSXChildValue(value: unknown): value is JSXChildValue {
+function isReactRenderableValue(value: unknown): value is ReactRenderableValue {
   if (
     value == null ||
     typeof value === "boolean" ||
@@ -190,12 +190,12 @@ function isJSXChildValue(value: unknown): value is JSXChildValue {
     return true
   }
 
-  return Array.isArray(value) && value.every(isJSXChildValue)
+  return Array.isArray(value) && value.every(isReactRenderableValue)
 }
 
-function isPlaceholderValue(
+function shouldWrapAsPlaceholder(
   value: TransValue,
-): value is Exclude<JSXChildValue, string | number> {
+): value is Exclude<ReactRenderableValue, string | number | boolean> {
   if (
     typeof value === "string" ||
     typeof value === "number" ||
@@ -204,5 +204,5 @@ function isPlaceholderValue(
     return false
   }
 
-  return isJSXChildValue(value)
+  return isReactRenderableValue(value)
 }


### PR DESCRIPTION
# Description

This PR narrows `Trans` interpolation values to supported scalar types and fixes the rendering logic to match that contract across `@lingui/core`, `@lingui/react`, and macro typings.

Before this change, some values were accepted by TypeScript but did not behave correctly at runtime in `Trans`. 

This PR makes the typing stricter

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

Fixes # (issue)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
