### PR TITLE
feat: support typed message IDs

### DIFF
--- a/packages/core/__typetests__/index.tst.ts
+++ b/packages/core/__typetests__/index.tst.ts
@@ -1,5 +1,9 @@
 import { i18n } from "@lingui/core"
+import type { MessageId } from "@lingui/core"
 import { expect } from "tstyche"
+
+// MessageId resolves to string when Register is not augmented
+expect<MessageId>().type.toBe<string>()
 
 expect(i18n._("message.id")).type.toBe<string>()
 expect(

--- a/packages/core/__typetests__/typed-ids/index.tst.ts
+++ b/packages/core/__typetests__/typed-ids/index.tst.ts
@@ -1,0 +1,39 @@
+import { i18n } from "@lingui/core"
+import type { MessageId, MessageDescriptor } from "@lingui/core"
+import { expect } from "tstyche"
+
+// MessageId resolves to the registered union
+expect<MessageId>().type.toBe<"welcome.title" | "welcome.body" | "greeting">()
+
+// i18n._() accepts valid IDs
+expect(i18n._("welcome.title")).type.toBe<string>()
+expect(i18n._("greeting")).type.toBe<string>()
+
+// i18n._() rejects invalid IDs
+expect(i18n._).type.not.toBeCallableWith("invalid.id")
+
+// i18n.t() accepts valid IDs
+expect(i18n.t("welcome.body")).type.toBe<string>()
+
+// i18n.t() rejects invalid IDs
+expect(i18n.t).type.not.toBeCallableWith("invalid.id")
+
+// MessageDescriptor requires a valid ID
+expect<MessageDescriptor>().type.toBeAssignableWith({
+  id: "welcome.title" as const,
+  message: "Welcome!",
+})
+
+// MessageDescriptor rejects an invalid ID
+expect<MessageDescriptor>().type.not.toBeAssignableWith({
+  id: "invalid.id",
+  message: "Nope",
+})
+
+// i18n._() accepts a MessageDescriptor with a valid ID
+expect(
+  i18n._({
+    id: "greeting",
+    message: "Hello!",
+  }),
+).type.toBe<string>()

--- a/packages/core/__typetests__/typed-ids/lingui.d.ts
+++ b/packages/core/__typetests__/typed-ids/lingui.d.ts
@@ -1,0 +1,7 @@
+import "@lingui/core"
+
+declare module "@lingui/core" {
+  interface Register {
+    messageIds: "welcome.title" | "welcome.body" | "greeting"
+  }
+}

--- a/packages/core/__typetests__/typed-ids/tsconfig.json
+++ b/packages/core/__typetests__/typed-ids/tsconfig.json
@@ -9,8 +9,7 @@
     "moduleResolution": "bundler",
     "target": "ES2022",
     "esModuleInterop": true,
-    "skipLibCheck": true,
-    "types": ["vitest/globals"]
+    "skipLibCheck": true
   },
-  "exclude": ["__typetests__/typed-ids"]
+  "include": ["./**/*.ts"]
 }

--- a/packages/core/macro/index.d.mts
+++ b/packages/core/macro/index.d.mts
@@ -1,4 +1,4 @@
-import type { I18n, MessageDescriptor } from "@lingui/core"
+import type { I18n, MessageDescriptor, MessageId } from "@lingui/core"
 
 export type ChoiceOptions = {
   /** Offset of value when calculating plural forms */
@@ -17,11 +17,11 @@ export type ChoiceOptions = {
 
 export type MacroMessageDescriptor = (
   | {
-      id: string
+      id: MessageId
       message?: string
     }
   | {
-      id?: string
+      id?: MessageId
       message: string
     }
 ) & {
@@ -126,7 +126,7 @@ export function t(i18n: I18n): {
  */
 export function plural(
   value: number | string | LabeledExpression<number | string>,
-  options: ChoiceOptions
+  options: ChoiceOptions,
 ): string
 
 /**
@@ -151,7 +151,7 @@ export function plural(
  */
 export function selectOrdinal(
   value: number | string | LabeledExpression<number | string>,
-  options: ChoiceOptions
+  options: ChoiceOptions,
 ): string
 
 type SelectOptions = {
@@ -182,7 +182,7 @@ type SelectOptions = {
  */
 export function select(
   value: string | LabeledExpression<string>,
-  choices: SelectOptions
+  choices: SelectOptions,
 ): string
 
 /**
@@ -203,7 +203,7 @@ export function select(
  * @param descriptor The message descriptor
  */
 export function defineMessage(
-  descriptor: MacroMessageDescriptor
+  descriptor: MacroMessageDescriptor,
 ): MessageDescriptor
 
 /**

--- a/packages/core/src/i18n.ts
+++ b/packages/core/src/i18n.ts
@@ -49,6 +49,7 @@ export type AllMessages = Record<Locale, Messages>
  * }
  * ```
  */
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type -- intentionally empty; users augment this via module augmentation
 export interface Register {}
 
 /**
@@ -254,9 +255,9 @@ export class I18n extends EventEmitter<Events> {
 > ${translation}
 
 That means you use raw catalog or your catalog doesn't have a translation for the message and fallback was used.
-ICU features such as interpolation and plurals will not work properly for that message. 
+ICU features such as interpolation and plurals will not work properly for that message.
 
-Please compile your catalog first. 
+Please compile your catalog first.
 `)
       }
     }

--- a/packages/core/src/i18n.ts
+++ b/packages/core/src/i18n.ts
@@ -33,8 +33,36 @@ export type Messages = Record<string, UncompiledMessage | CompiledMessage>
 
 export type AllMessages = Record<Locale, Messages>
 
+/**
+ * Register interface for module augmentation.
+ * Users can augment this interface to narrow MessageId to a specific union type.
+ *
+ * @example
+ * ```ts
+ * // src/lingui.d.ts
+ * import type enMessages from "./locales/en/messages.json";
+ *
+ * declare module "@lingui/core" {
+ *   interface Register {
+ *     messageIds: keyof typeof enMessages;
+ *   }
+ * }
+ * ```
+ */
+export interface Register {}
+
+/**
+ * Resolves to the registered message ID union, or falls back to `string`
+ * when no augmentation exists.
+ */
+export type MessageId = Register extends {
+  messageIds: infer TIds extends string
+}
+  ? TIds
+  : string
+
 export type MessageDescriptor = {
-  id: string
+  id: MessageId
   comment?: string
   message?: string
   values?: Record<string, unknown>
@@ -42,7 +70,7 @@ export type MessageDescriptor = {
 
 export type MissingMessageEvent = {
   locale: Locale
-  id: string
+  id: MessageId
 }
 
 type MissingHandler = string | ((locale: string, id: string) => string)
@@ -174,9 +202,9 @@ export class I18n extends EventEmitter<Events> {
 
   // method for translation and formatting
   _(descriptor: MessageDescriptor): string
-  _(id: string, values?: Values, options?: MessageOptions): string
+  _(id: MessageId, values?: Values, options?: MessageOptions): string
   _(
-    id: MessageDescriptor | string,
+    id: MessageDescriptor | MessageId,
     values?: Values,
     options?: MessageOptions,
   ): string {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,10 +3,12 @@ export { setupI18n, I18n } from "./i18n"
 export type {
   AllMessages,
   MessageDescriptor,
+  MessageId,
   Messages,
   Locale,
   Locales,
   MessageOptions,
+  Register,
 } from "./i18n"
 
 // Default i18n object

--- a/packages/react/macro/index.d.mts
+++ b/packages/react/macro/index.d.mts
@@ -4,9 +4,10 @@ import type {
   MacroMessageDescriptor,
   LabeledExpression,
 } from "@lingui/core/macro"
+import type { MessageId } from "@lingui/core"
 
 type CommonProps = TransRenderCallbackOrComponent & {
-  id?: string
+  id?: MessageId
   comment?: string
   context?: string
 }

--- a/packages/react/src/TransNoContext.tsx
+++ b/packages/react/src/TransNoContext.tsx
@@ -1,8 +1,8 @@
 import { formatElements } from "./format"
-import type { I18n, MessageOptions } from "@lingui/core"
+import type { I18n, MessageId, MessageOptions } from "@lingui/core"
 
 export type TransRenderProps = {
-  id: string
+  id: MessageId
   translation: React.ReactNode
   children: React.ReactNode
   message?: string | null
@@ -21,7 +21,7 @@ export type TransRenderCallbackOrComponent =
     }
 
 export type TransProps = {
-  id: string
+  id: MessageId
   message?: string
   values?: Record<string, unknown>
   components?: { [key: string]: React.ElementType | any }

--- a/tstyche.config.json
+++ b/tstyche.config.json
@@ -1,6 +1,4 @@
 {
   "$schema": "https://tstyche.org/schemas/config.json",
-  "testFileMatch": [
-    "packages/**/__typetests__/*.tst.*"
-  ]
+  "testFileMatch": ["packages/**/__typetests__/**/*.tst.*"]
 }

--- a/website/docs/guides/explicit-vs-generated-ids.md
+++ b/website/docs/guides/explicit-vs-generated-ids.md
@@ -58,6 +58,10 @@ Example:
 - **Readability:** explicit IDs often have meaningful names, making it easier for developers, translators, and content creators to understand their purpose within the codebase.
 - **Predictability:** since explicit IDs are manually assigned, they remain stable across different versions of your application, reducing the likelihood of breaking changes during updates.
 
+:::tip
+If you use explicit IDs, you can opt in to [Typed Message IDs](/guides/typed-message-ids.md) for autocomplete and compile-time validation of your message identifiers.
+:::
+
 The choice between these two strategies depends on your project requirements and priorities. However, it's important to note that Lingui provides the full range of benefits, especially with generated IDs.
 
 :::note

--- a/website/docs/guides/explicit-vs-generated-ids.md
+++ b/website/docs/guides/explicit-vs-generated-ids.md
@@ -59,7 +59,7 @@ Example:
 - **Predictability:** since explicit IDs are manually assigned, they remain stable across different versions of your application, reducing the likelihood of breaking changes during updates.
 
 :::tip
-If you use explicit IDs, you can opt in to [Typed Message IDs](/guides/typed-message-ids.md) for autocomplete and compile-time validation of your message identifiers.
+If you use explicit IDs, you can opt in to [Typed Message IDs](/guides/typed-message-ids) for autocomplete and compile-time validation of your message identifiers.
 :::
 
 The choice between these two strategies depends on your project requirements and priorities. However, it's important to note that Lingui provides the full range of benefits, especially with generated IDs.

--- a/website/docs/guides/typed-message-ids.md
+++ b/website/docs/guides/typed-message-ids.md
@@ -1,0 +1,50 @@
+---
+title: Typed Message IDs
+description: Learn how to opt in to type-safe message IDs for autocomplete and compile-time validation
+---
+
+# Typed Message IDs
+
+Lingui supports opt-in typed message IDs via TypeScript module augmentation. When enabled, all functions and components that accept a message `id` (i.e. `i18n._()`, `i18n.t()`, and `<Trans>`) will be narrowed to your specific set of known IDs, giving you autocomplete and compile-time errors for invalid IDs.
+
+Without augmentation, `id` remains `string` and existing behaviour is unchanged.
+
+## Setup
+
+Create a declaration file that augments the `Register` interface from `@lingui/core`:
+
+```ts title="src/lingui.d.ts"
+import type enMessages from "./locales/en/messages.json";
+
+declare module "@lingui/core" {
+  interface Register {
+    messageIds: keyof typeof enMessages;
+  }
+}
+```
+
+The `messageIds` key must resolve to a union of string literal types. When `Register` is augmented with `messageIds`, the `MessageId` type resolves to that union. When `Register` is empty (the default), `MessageId` falls back to `string`.
+
+## Usage
+
+Once set up, TypeScript will flag invalid IDs:
+
+```tsx
+import { t } from "@lingui/core/macro";
+import { Trans } from "@lingui/react";
+
+// ✅ Valid — "welcome.title" exists in your catalog
+const msg = t({ id: "welcome.title", message: "Welcome!" });
+
+// ❌ Type error — "welcme.title" is not a known message ID
+const bad = t({ id: "welcme.title", message: "Welcome!" });
+
+// ✅ Autocomplete works in JSX too
+<Trans id="welcome.title">Welcome!</Trans>
+```
+
+## Notes
+
+- This feature is **fully opt-in**. Without the `.d.ts` augmentation, all existing code continues to work with `string` IDs.
+- There is **no runtime impact**. The `Register` interface and `MessageId` type are erased at compile time.
+- You can point `messageIds` at any source that produces a string union, such as a compiled catalog JSON import, a hand-maintained union type, or a generated `.d.ts` file.

--- a/website/docs/guides/typed-message-ids.md
+++ b/website/docs/guides/typed-message-ids.md
@@ -7,7 +7,7 @@ description: Learn how to opt in to type-safe message IDs for autocomplete and c
 
 Lingui supports opt-in typed message IDs via TypeScript module augmentation. When enabled, all functions and components that accept a message `id` (i.e. `i18n._()`, `i18n.t()`, and `<Trans>`) will be narrowed to your specific set of known IDs, giving you autocomplete and compile-time errors for invalid IDs.
 
-Without augmentation, `id` remains `string` and existing behaviour is unchanged.
+Without augmentation, `id` remains `string` and existing behavior is unchanged.
 
 ## Setup
 
@@ -40,7 +40,7 @@ const msg = t({ id: "welcome.title", message: "Welcome!" });
 const bad = t({ id: "welcme.title", message: "Welcome!" });
 
 // ✅ Autocomplete works in JSX too
-<Trans id="welcome.title">Welcome!</Trans>
+<Trans id="welcome.title">Welcome!</Trans>;
 ```
 
 ## Notes

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -162,6 +162,11 @@ const sidebar = [
         items: [
           {
             type: "doc",
+            label: "Typed Message IDs",
+            id: "guides/typed-message-ids",
+          },
+          {
+            type: "doc",
             label: "Custom Extractor",
             id: "guides/custom-extractor",
           },


### PR DESCRIPTION
# Description

Adds support for optionally typed message IDs, for build systems where the message IDs are known ahead of time.



## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Examples update

Fixes #2478

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
