### PR TITLE
feat: add optional configurable JSX placeholder naming

### DIFF
--- a/packages/babel-plugin-lingui-macro/src/index.ts
+++ b/packages/babel-plugin-lingui-macro/src/index.ts
@@ -232,7 +232,9 @@ export default function ({
           path.traverse(
             {
               JSXElement(path, state) {
-                const linguiConfig = state.get("linguiConfig") as LinguiConfigNormalized
+                const linguiConfig = state.get(
+                  "linguiConfig",
+                ) as LinguiConfigNormalized
 
                 const macro = new MacroJSX(
                   { types: t },

--- a/packages/babel-plugin-lingui-macro/src/index.ts
+++ b/packages/babel-plugin-lingui-macro/src/index.ts
@@ -232,6 +232,8 @@ export default function ({
           path.traverse(
             {
               JSXElement(path, state) {
+                const linguiConfig = state.get("linguiConfig") as LinguiConfigNormalized
+
                 const macro = new MacroJSX(
                   { types: t },
                   {
@@ -244,6 +246,10 @@ export default function ({
                     ),
                     isLinguiIdentifier: (node: Identifier, macro) =>
                       isLinguiIdentifier(path, node, macro),
+                    jsxPlaceholderAttribute:
+                      linguiConfig.macro?.jsxPlaceholderAttribute,
+                    jsxPlaceholderDefaults:
+                      linguiConfig.macro?.jsxPlaceholderDefaults,
                   },
                 )
 

--- a/packages/babel-plugin-lingui-macro/src/macroJsx.ts
+++ b/packages/babel-plugin-lingui-macro/src/macroJsx.ts
@@ -49,6 +49,9 @@ function maybeNodeValue(node: Node): { text: string; loc: SourceLocation } {
 export type MacroJsxContext = MacroJsContext & {
   elementIndex: () => number
   transImportName: string
+  elementsTracking: Map<string, JSXElement>
+  jsxPlaceholderAttribute?: string
+  jsxPlaceholderDefaults?: Record<string, string>
 }
 
 export type MacroJsxOpts = {
@@ -56,6 +59,8 @@ export type MacroJsxOpts = {
   stripMessageProp: boolean
   transImportName: string
   isLinguiIdentifier: (node: Identifier, macro: JsMacroName) => boolean
+  jsxPlaceholderAttribute?: string
+  jsxPlaceholderDefaults?: Record<string, string>
 }
 
 const choiceComponentAttributesWhitelist = [
@@ -86,6 +91,9 @@ export class MacroJSX {
       ),
       transImportName: opts.transImportName,
       elementIndex: makeCounter(),
+      elementsTracking: new Map(),
+      jsxPlaceholderAttribute: opts.jsxPlaceholderAttribute,
+      jsxPlaceholderDefaults: opts.jsxPlaceholderDefaults,
     }
   }
 
@@ -351,18 +359,85 @@ export class MacroJSX {
   }
 
   tokenizeElement = (path: NodePath<JSXElement>): ElementToken => {
-    // !!! Important: Calculate element index before traversing children.
-    // That way outside elements are numbered before inner elements. (...and it looks pretty).
-    const name = this.ctx.elementIndex()
+    const {
+      jsxPlaceholderAttribute,
+      jsxPlaceholderDefaults,
+      elementsTracking,
+    } = this.ctx
+
+    let node = path.node
+    let name: string | undefined = undefined
+
+    if (jsxPlaceholderAttribute) {
+      const { attributes } = node.openingElement
+      const attrIndex = attributes.findIndex(
+        (attr) =>
+          attr.type === "JSXAttribute" &&
+          attr.name.name === jsxPlaceholderAttribute,
+      )
+
+      if (attrIndex !== -1) {
+        const attr = attributes[attrIndex] as JSXAttribute
+        if (attr.value && attr.value.type === "StringLiteral") {
+          name = attr.value.value
+        }
+
+        const newAttributes = [...attributes]
+        newAttributes.splice(attrIndex, 1)
+
+        node = {
+          ...node,
+          openingElement: {
+            ...node.openingElement,
+            attributes: newAttributes,
+          },
+        }
+      }
+    }
+
+    if (!name && jsxPlaceholderDefaults) {
+      const tagName = node.openingElement.name
+      if (tagName.type === "JSXIdentifier") {
+        name = jsxPlaceholderDefaults[tagName.name]
+      }
+    }
+
+    if (!name) {
+      name = String(this.ctx.elementIndex())
+      elementsTracking.set(name, node)
+    } else {
+      const existingElement = elementsTracking.get(name)
+
+      if (existingElement) {
+        const existingAttrs = existingElement.openingElement.attributes
+        const openingAttrs = node.openingElement.attributes
+        if (
+          existingAttrs.length !== openingAttrs.length ||
+          !existingAttrs.every((a) =>
+            openingAttrs.some((b) => this.types.isNodesEquivalent(a, b)),
+          )
+        ) {
+          const eg = `(e.g. \`<element ${jsxPlaceholderAttribute || '_t'}="newName" />\`)`
+          const msg = `Multiple distinct JSX elements with the same placeholder name (\`${name}\`). `
+            + (jsxPlaceholderAttribute
+              ? `Differentiate them by adding/modifying the \`${jsxPlaceholderAttribute}\` attribute ${eg}.`
+              : `Differentiate them by setting \`macro.jsxPlaceholderAttribute\` in the lingui config and then adding the attribute to your JSX elements ${eg}.`
+            )
+          throw path.buildCodeFrameError(msg)
+        }
+      } else {
+        elementsTracking.set(name, node)
+      }
+    }
 
     return {
       type: "element",
       name,
       value: {
-        ...path.node,
+        ...node,
         children: [],
         openingElement: {
-          ...path.node.openingElement,
+          ...node.openingElement,
           selfClosing: true,
         },
       },

--- a/packages/babel-plugin-lingui-macro/src/macroJsx.ts
+++ b/packages/babel-plugin-lingui-macro/src/macroJsx.ts
@@ -378,9 +378,16 @@ export class MacroJSX {
 
       if (attrIndex !== -1) {
         const attr = attributes[attrIndex] as JSXAttribute
-        if (attr.value && attr.value.type === "StringLiteral") {
-          name = attr.value.value
+        if (
+          !attr.value ||
+          attr.value.type !== "StringLiteral" ||
+          !attr.value.value
+        ) {
+          throw path.buildCodeFrameError(
+            `The \`${jsxPlaceholderAttribute}\` attribute must be a non-empty string literal.`,
+          )
         }
+        name = attr.value.value
 
         const newAttributes = [...attributes]
         newAttributes.splice(attrIndex, 1)
@@ -406,12 +413,26 @@ export class MacroJSX {
       name = String(this.ctx.elementIndex())
       elementsTracking.set(name, node)
     } else {
+      if (/^\d+$/.test(name)) {
+        throw path.buildCodeFrameError(
+          `Placeholder name \`${name}\` is not allowed because it conflicts with auto-generated numeric placeholders. Use a non-numeric name instead.`,
+        )
+      }
+      if (!/^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(name)) {
+        throw path.buildCodeFrameError(
+          `Placeholder name \`${name}\` is not a valid identifier. Only valid JS identifers are allowed; /^[a-zA-Z_$][a-zA-Z0-9_$]*$/`,
+        )
+      }
+
       const existingElement = elementsTracking.get(name)
 
       if (existingElement) {
+        const existingTag = existingElement.openingElement.name
+        const currentTag = node.openingElement.name
         const existingAttrs = existingElement.openingElement.attributes
         const openingAttrs = node.openingElement.attributes
         if (
+          !this.types.isNodesEquivalent(existingTag, currentTag) ||
           existingAttrs.length !== openingAttrs.length ||
           !existingAttrs.every((a) =>
             openingAttrs.some((b) => this.types.isNodesEquivalent(a, b)),

--- a/packages/babel-plugin-lingui-macro/src/macroJsx.ts
+++ b/packages/babel-plugin-lingui-macro/src/macroJsx.ts
@@ -431,12 +431,26 @@ export class MacroJSX {
         const currentTag = node.openingElement.name
         const existingAttrs = existingElement.openingElement.attributes
         const openingAttrs = node.openingElement.attributes
+
+        const hasSpreads = existingAttrs.some(
+          (a) => a.type === "JSXSpreadAttribute",
+        )
+
+        // When spreads are present, attribute order matters for React
+        // semantics so we compare positionally. Otherwise, order-insensitive.
+        const attrsEqual =
+          existingAttrs.length === openingAttrs.length &&
+          (hasSpreads
+            ? existingAttrs.every((a, i) =>
+                this.types.isNodesEquivalent(a, openingAttrs[i]),
+              )
+            : existingAttrs.every((a) =>
+                openingAttrs.some((b) => this.types.isNodesEquivalent(a, b)),
+              ))
+
         if (
           !this.types.isNodesEquivalent(existingTag, currentTag) ||
-          existingAttrs.length !== openingAttrs.length ||
-          !existingAttrs.every((a) =>
-            openingAttrs.some((b) => this.types.isNodesEquivalent(a, b)),
-          )
+          !attrsEqual
         ) {
           const eg = `(e.g. \`<element ${jsxPlaceholderAttribute || '_t'}="newName" />\`)`
           const msg = `Multiple distinct JSX elements with the same placeholder name (\`${name}\`). `

--- a/packages/babel-plugin-lingui-macro/src/macroJsx.ts
+++ b/packages/babel-plugin-lingui-macro/src/macroJsx.ts
@@ -452,12 +452,12 @@ export class MacroJSX {
           !this.types.isNodesEquivalent(existingTag, currentTag) ||
           !attrsEqual
         ) {
-          const eg = `(e.g. \`<element ${jsxPlaceholderAttribute || '_t'}="newName" />\`)`
-          const msg = `Multiple distinct JSX elements with the same placeholder name (\`${name}\`). `
-            + (jsxPlaceholderAttribute
+          const eg = `(e.g. \`<element ${jsxPlaceholderAttribute || "_t"}="newName" />\`)`
+          const msg =
+            `Multiple distinct JSX elements with the same placeholder name (\`${name}\`). ` +
+            (jsxPlaceholderAttribute
               ? `Differentiate them by adding/modifying the \`${jsxPlaceholderAttribute}\` attribute ${eg}.`
-              : `Differentiate them by setting \`macro.jsxPlaceholderAttribute\` in the lingui config and then adding the attribute to your JSX elements ${eg}.`
-            )
+              : `Differentiate them by setting \`macro.jsxPlaceholderAttribute\` in the lingui config and then adding the attribute to your JSX elements ${eg}.`)
           throw path.buildCodeFrameError(msg)
         }
       } else {

--- a/packages/babel-plugin-lingui-macro/src/macroJsx.ts
+++ b/packages/babel-plugin-lingui-macro/src/macroJsx.ts
@@ -418,9 +418,9 @@ export class MacroJSX {
           `Placeholder name \`${name}\` is not allowed because it conflicts with auto-generated numeric placeholders. Use a non-numeric name instead.`,
         )
       }
-      if (!/^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(name)) {
+      if (!/^[a-zA-Z_]([\w.-]*\w)?$/.test(name)) {
         throw path.buildCodeFrameError(
-          `Placeholder name \`${name}\` is not a valid identifier. Only valid JS identifers are allowed; /^[a-zA-Z_$][a-zA-Z0-9_$]*$/`,
+          `Placeholder name \`${name}\` is not valid. Names must start and end with a letter/digit/underscore, but may contain \`.-\` in between.`,
         )
       }
 

--- a/packages/babel-plugin-lingui-macro/src/messageDescriptorUtils.ts
+++ b/packages/babel-plugin-lingui-macro/src/messageDescriptorUtils.ts
@@ -139,7 +139,12 @@ function createIdProperty(message: string, context?: string) {
 
 function createValuesProperty(key: string, values: Record<string, Expression>) {
   const valuesObject = Object.keys(values).map((key) =>
-    types.objectProperty(types.identifier(key), values[key]),
+    types.objectProperty(
+      types.isValidIdentifier(key) || /^\d+$/.test(key)
+        ? types.identifier(key)
+        : types.stringLiteral(key),
+      values[key],
+    ),
   )
 
   if (!valuesObject.length) return

--- a/packages/babel-plugin-lingui-macro/test/__snapshots__/jsx-placeholder.test.ts.snap
+++ b/packages/babel-plugin-lingui-macro/test/__snapshots__/jsx-placeholder.test.ts.snap
@@ -122,6 +122,23 @@ import { Trans as _Trans } from "@lingui/react";
 
 `;
 
+exports[`Deduplication: Same name on different element types throws an error 1`] = `
+[SyntaxError: <cwd>/<filename>jsx: Unsupported macro usage. Please check the examples at https://lingui.dev/ref/macro#examples-of-js-macros.
+ If you think this is a bug, fill in an issue at https://github.com/lingui/js-lingui/issues
+
+ Error: Multiple distinct JSX elements with the same placeholder name (\`same\`). Differentiate them by adding/modifying the \`_t\` attribute (e.g. \`<element _t="newName" />\`).
+  1 |
+  2 |         import { Trans } from '@lingui/react/macro';
+> 3 |         <Trans><em _t="same">A</em> and <strong _t="same">B</strong></Trans>
+    |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  4 |       
+  1 |
+  2 |         import { Trans } from '@lingui/react/macro';
+> 3 |         <Trans><em _t="same">A</em> and <strong _t="same">B</strong></Trans>
+    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  4 |       ]
+`;
+
 exports[`Mixing explicit _t together with jsxPlaceholderDefaults 1`] = `
 import { Trans } from "@lingui/react/macro";
 <Trans>
@@ -200,4 +217,72 @@ import { Trans as _Trans } from "@lingui/react";
   }
 />;
 
+`;
+
+exports[`Throws on empty _t attribute value 1`] = `
+[SyntaxError: <cwd>/<filename>jsx: Unsupported macro usage. Please check the examples at https://lingui.dev/ref/macro#examples-of-js-macros.
+ If you think this is a bug, fill in an issue at https://github.com/lingui/js-lingui/issues
+
+ Error: The \`_t\` attribute must be a non-empty string literal.
+  1 |
+  2 |         import { Trans } from '@lingui/react/macro';
+> 3 |         <Trans><a _t="" href="/">click</a></Trans>
+    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  4 |       
+  1 |
+  2 |         import { Trans } from '@lingui/react/macro';
+> 3 |         <Trans><a _t="" href="/">click</a></Trans>
+    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  4 |       ]
+`;
+
+exports[`Throws on invalid identifier placeholder name 1`] = `
+[SyntaxError: <cwd>/<filename>jsx: Unsupported macro usage. Please check the examples at https://lingui.dev/ref/macro#examples-of-js-macros.
+ If you think this is a bug, fill in an issue at https://github.com/lingui/js-lingui/issues
+
+ Error: Placeholder name \`foo-bar\` is not a valid identifier. Only valid JS identifers are allowed; /^[a-zA-Z_$][a-zA-Z0-9_$]*$/
+  1 |
+  2 |         import { Trans } from '@lingui/react/macro';
+> 3 |         <Trans><a _t="foo-bar" href="/">click</a></Trans>
+    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  4 |       
+  1 |
+  2 |         import { Trans } from '@lingui/react/macro';
+> 3 |         <Trans><a _t="foo-bar" href="/">click</a></Trans>
+    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  4 |       ]
+`;
+
+exports[`Throws on non-string _t attribute value 1`] = `
+[SyntaxError: <cwd>/<filename>jsx: Unsupported macro usage. Please check the examples at https://lingui.dev/ref/macro#examples-of-js-macros.
+ If you think this is a bug, fill in an issue at https://github.com/lingui/js-lingui/issues
+
+ Error: The \`_t\` attribute must be a non-empty string literal.
+  2 |         import { Trans } from '@lingui/react/macro';
+  3 |         const name = "link";
+> 4 |         <Trans><a _t={name} href="/">click</a></Trans>
+    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  5 |       
+  2 |         import { Trans } from '@lingui/react/macro';
+  3 |         const name = "link";
+> 4 |         <Trans><a _t={name} href="/">click</a></Trans>
+    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  5 |       ]
+`;
+
+exports[`Throws on numeric placeholder name 1`] = `
+[SyntaxError: <cwd>/<filename>jsx: Unsupported macro usage. Please check the examples at https://lingui.dev/ref/macro#examples-of-js-macros.
+ If you think this is a bug, fill in an issue at https://github.com/lingui/js-lingui/issues
+
+ Error: Placeholder name \`0\` is not allowed because it conflicts with auto-generated numeric placeholders. Use a non-numeric name instead.
+  1 |
+  2 |         import { Trans } from '@lingui/react/macro';
+> 3 |         <Trans><a _t="0" href="/">click</a></Trans>
+    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  4 |       
+  1 |
+  2 |         import { Trans } from '@lingui/react/macro';
+> 3 |         <Trans><a _t="0" href="/">click</a></Trans>
+    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  4 |       ]
 `;

--- a/packages/babel-plugin-lingui-macro/test/__snapshots__/jsx-placeholder.test.ts.snap
+++ b/packages/babel-plugin-lingui-macro/test/__snapshots__/jsx-placeholder.test.ts.snap
@@ -1,5 +1,57 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`Allows dotted placeholder name 1`] = `
+import { Trans } from "@lingui/react/macro";
+<Trans>
+  <a _t="ns.link" href="/">
+    click
+  </a>
+</Trans>;
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { Trans as _Trans } from "@lingui/react";
+<_Trans
+  {
+    /*i18n*/
+    ...{
+      id: "_0hJpt",
+      message: "<ns.link>click</ns.link>",
+      components: {
+        "ns.link": <a href="/" />,
+      },
+    }
+  }
+/>;
+
+`;
+
+exports[`Allows hyphenated placeholder name 1`] = `
+import { Trans } from "@lingui/react/macro";
+<Trans>
+  <a _t="foo-bar" href="/">
+    click
+  </a>
+</Trans>;
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { Trans as _Trans } from "@lingui/react";
+<_Trans
+  {
+    /*i18n*/
+    ...{
+      id: "IeIam7",
+      message: "<foo-bar>click</foo-bar>",
+      components: {
+        "foo-bar": <a href="/" />,
+      },
+    }
+  }
+/>;
+
+`;
+
 exports[`Deduplication: Different spreads throw an error 1`] = `
 [SyntaxError: <cwd>/<filename>jsx: Unsupported macro usage. Please check the examples at https://lingui.dev/ref/macro#examples-of-js-macros.
  If you think this is a bug, fill in an issue at https://github.com/lingui/js-lingui/issues
@@ -304,23 +356,6 @@ exports[`Throws on empty _t attribute value 1`] = `
   4 |       ]
 `;
 
-exports[`Throws on invalid identifier placeholder name 1`] = `
-[SyntaxError: <cwd>/<filename>jsx: Unsupported macro usage. Please check the examples at https://lingui.dev/ref/macro#examples-of-js-macros.
- If you think this is a bug, fill in an issue at https://github.com/lingui/js-lingui/issues
-
- Error: Placeholder name \`foo-bar\` is not a valid identifier. Only valid JS identifers are allowed; /^[a-zA-Z_$][a-zA-Z0-9_$]*$/
-  1 |
-  2 |         import { Trans } from '@lingui/react/macro';
-> 3 |         <Trans><a _t="foo-bar" href="/">click</a></Trans>
-    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  4 |       
-  1 |
-  2 |         import { Trans } from '@lingui/react/macro';
-> 3 |         <Trans><a _t="foo-bar" href="/">click</a></Trans>
-    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  4 |       ]
-`;
-
 exports[`Throws on non-string _t attribute value 1`] = `
 [SyntaxError: <cwd>/<filename>jsx: Unsupported macro usage. Please check the examples at https://lingui.dev/ref/macro#examples-of-js-macros.
  If you think this is a bug, fill in an issue at https://github.com/lingui/js-lingui/issues
@@ -352,5 +387,39 @@ exports[`Throws on numeric placeholder name 1`] = `
   2 |         import { Trans } from '@lingui/react/macro';
 > 3 |         <Trans><a _t="0" href="/">click</a></Trans>
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  4 |       ]
+`;
+
+exports[`Throws on placeholder name ending with dot 1`] = `
+[SyntaxError: <cwd>/<filename>jsx: Unsupported macro usage. Please check the examples at https://lingui.dev/ref/macro#examples-of-js-macros.
+ If you think this is a bug, fill in an issue at https://github.com/lingui/js-lingui/issues
+
+ Error: Placeholder name \`foo.\` is not valid. Names must start and end with a letter/digit/underscore, but may contain \`.-\` in between.
+  1 |
+  2 |         import { Trans } from '@lingui/react/macro';
+> 3 |         <Trans><a _t="foo." href="/">click</a></Trans>
+    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  4 |       
+  1 |
+  2 |         import { Trans } from '@lingui/react/macro';
+> 3 |         <Trans><a _t="foo." href="/">click</a></Trans>
+    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  4 |       ]
+`;
+
+exports[`Throws on placeholder name starting with hyphen 1`] = `
+[SyntaxError: <cwd>/<filename>jsx: Unsupported macro usage. Please check the examples at https://lingui.dev/ref/macro#examples-of-js-macros.
+ If you think this is a bug, fill in an issue at https://github.com/lingui/js-lingui/issues
+
+ Error: Placeholder name \`-foo\` is not valid. Names must start and end with a letter/digit/underscore, but may contain \`.-\` in between.
+  1 |
+  2 |         import { Trans } from '@lingui/react/macro';
+> 3 |         <Trans><a _t="-foo" href="/">click</a></Trans>
+    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  4 |       
+  1 |
+  2 |         import { Trans } from '@lingui/react/macro';
+> 3 |         <Trans><a _t="-foo" href="/">click</a></Trans>
+    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   4 |       ]
 `;

--- a/packages/babel-plugin-lingui-macro/test/__snapshots__/jsx-placeholder.test.ts.snap
+++ b/packages/babel-plugin-lingui-macro/test/__snapshots__/jsx-placeholder.test.ts.snap
@@ -1,5 +1,22 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`Deduplication: Different spreads throw an error 1`] = `
+[SyntaxError: <cwd>/<filename>jsx: Unsupported macro usage. Please check the examples at https://lingui.dev/ref/macro#examples-of-js-macros.
+ If you think this is a bug, fill in an issue at https://github.com/lingui/js-lingui/issues
+
+ Error: Multiple distinct JSX elements with the same placeholder name (\`link\`). Differentiate them by adding/modifying the \`_t\` attribute (e.g. \`<element _t="newName" />\`).
+  3 |         const p1 = { href: "/a" };
+  4 |         const p2 = { href: "/b" };
+> 5 |         <Trans><a _t="link" {...p1}>A</a> and <a _t="link" {...p2}>B</a></Trans>
+    |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  6 |       
+  3 |         const p1 = { href: "/a" };
+  4 |         const p2 = { href: "/b" };
+> 5 |         <Trans><a _t="link" {...p1}>A</a> and <a _t="link" {...p2}>B</a></Trans>
+    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  6 |       ]
+`;
+
 exports[`Deduplication: Explicit names with different attributes throw an error 1`] = `
 [SyntaxError: <cwd>/<filename>jsx: Unsupported macro usage. Please check the examples at https://lingui.dev/ref/macro#examples-of-js-macros.
  If you think this is a bug, fill in an issue at https://github.com/lingui/js-lingui/issues
@@ -73,6 +90,40 @@ import { Trans as _Trans } from "@lingui/react";
 
 `;
 
+exports[`Deduplication: Identical spreads are reused 1`] = `
+import { Trans } from "@lingui/react/macro";
+const props = { href: "/a" };
+<Trans>
+  <a _t="link" {...props}>
+    A
+  </a>{" "}
+  and{" "}
+  <a _t="link" {...props}>
+    B
+  </a>
+</Trans>;
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { Trans as _Trans } from "@lingui/react";
+const props = {
+  href: "/a",
+};
+<_Trans
+  {
+    /*i18n*/
+    ...{
+      id: "OdVP6t",
+      message: "<link>A</link> and <link>B</link>",
+      components: {
+        link: <a {...props} />,
+      },
+    }
+  }
+/>;
+
+`;
+
 exports[`Deduplication: Implicit names with distinct attributes throw an error 1`] = `
 [SyntaxError: <cwd>/<filename>jsx: Unsupported macro usage. Please check the examples at https://lingui.dev/ref/macro#examples-of-js-macros.
  If you think this is a bug, fill in an issue at https://github.com/lingui/js-lingui/issues
@@ -137,6 +188,23 @@ exports[`Deduplication: Same name on different element types throws an error 1`]
 > 3 |         <Trans><em _t="same">A</em> and <strong _t="same">B</strong></Trans>
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   4 |       ]
+`;
+
+exports[`Deduplication: Same spread with different attribute order throws an error 1`] = `
+[SyntaxError: <cwd>/<filename>jsx: Unsupported macro usage. Please check the examples at https://lingui.dev/ref/macro#examples-of-js-macros.
+ If you think this is a bug, fill in an issue at https://github.com/lingui/js-lingui/issues
+
+ Error: Multiple distinct JSX elements with the same placeholder name (\`link\`). Differentiate them by adding/modifying the \`_t\` attribute (e.g. \`<element _t="newName" />\`).
+  2 |         import { Trans } from '@lingui/react/macro';
+  3 |         const props = { href: "/b" };
+> 4 |         <Trans><a _t="link" {...props} href="/a">A</a> and <a _t="link" href="/a" {...props}>B</a></Trans>
+    |                                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  5 |       
+  2 |         import { Trans } from '@lingui/react/macro';
+  3 |         const props = { href: "/b" };
+> 4 |         <Trans><a _t="link" {...props} href="/a">A</a> and <a _t="link" href="/a" {...props}>B</a></Trans>
+    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  5 |       ]
 `;
 
 exports[`Mixing explicit _t together with jsxPlaceholderDefaults 1`] = `

--- a/packages/babel-plugin-lingui-macro/test/__snapshots__/jsx-placeholder.test.ts.snap
+++ b/packages/babel-plugin-lingui-macro/test/__snapshots__/jsx-placeholder.test.ts.snap
@@ -1,0 +1,203 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Deduplication: Explicit names with different attributes throw an error 1`] = `
+[SyntaxError: <cwd>/<filename>jsx: Unsupported macro usage. Please check the examples at https://lingui.dev/ref/macro#examples-of-js-macros.
+ If you think this is a bug, fill in an issue at https://github.com/lingui/js-lingui/issues
+
+ Error: Multiple distinct JSX elements with the same placeholder name (\`link\`). Differentiate them by adding/modifying the \`_t\` attribute (e.g. \`<element _t="newName" />\`).
+  1 |
+  2 |         import { Trans } from '@lingui/react/macro';
+> 3 |         <Trans>Hello <a _t="link" href="/a">link 1</a>, normal, <a _t="link" href="/b">link 2</a>.</Trans>
+    |                                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  4 |       
+  1 |
+  2 |         import { Trans } from '@lingui/react/macro';
+> 3 |         <Trans>Hello <a _t="link" href="/a">link 1</a>, normal, <a _t="link" href="/b">link 2</a>.</Trans>
+    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  4 |       ]
+`;
+
+exports[`Deduplication: Identical elements are reused 1`] = `
+import { Trans } from "@lingui/react/macro";
+<Trans>
+  Hello <em>emphasis</em>, normal, <em>more emphasis</em>.
+</Trans>;
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { Trans as _Trans } from "@lingui/react";
+<_Trans
+  {
+    /*i18n*/
+    ...{
+      id: "idxihm",
+      message: "Hello <em>emphasis</em>, normal, <em>more emphasis</em>.",
+      components: {
+        em: <em />,
+      },
+    }
+  }
+/>;
+
+`;
+
+exports[`Deduplication: Identical elements with different prop order are reused 1`] = `
+import { Trans } from "@lingui/react/macro";
+<Trans>
+  Hello{" "}
+  <a _t="link" href="/a" class="foo">
+    link 1
+  </a>
+  , normal,{" "}
+  <a _t="link" class="foo" href="/a">
+    link 1 copy
+  </a>
+  .
+</Trans>;
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { Trans as _Trans } from "@lingui/react";
+<_Trans
+  {
+    /*i18n*/
+    ...{
+      id: "9en3MH",
+      message: "Hello <link>link 1</link>, normal, <link>link 1 copy</link>.",
+      components: {
+        link: <a class="foo" href="/a" />,
+      },
+    }
+  }
+/>;
+
+`;
+
+exports[`Deduplication: Implicit names with distinct attributes throw an error 1`] = `
+[SyntaxError: <cwd>/<filename>jsx: Unsupported macro usage. Please check the examples at https://lingui.dev/ref/macro#examples-of-js-macros.
+ If you think this is a bug, fill in an issue at https://github.com/lingui/js-lingui/issues
+
+ Error: Multiple distinct JSX elements with the same placeholder name (\`a\`). Differentiate them by setting \`macro.jsxPlaceholderAttribute\` in the lingui config and then adding the attribute to your JSX elements (e.g. \`<element _t="newName" />\`).
+  1 |
+  2 |         import { Trans } from '@lingui/react/macro';
+> 3 |         <Trans>Hello <a href="/a">link 1</a>, normal, <a href="/b">link 2</a>.</Trans>
+    |                                                       ^^^^^^^^^^^^^^^^^^^^^^^
+  4 |       
+  1 |
+  2 |         import { Trans } from '@lingui/react/macro';
+> 3 |         <Trans>Hello <a href="/a">link 1</a>, normal, <a href="/b">link 2</a>.</Trans>
+    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  4 |       ]
+`;
+
+exports[`Deduplication: Same explicit placeholder with identical attributes does not throw 1`] = `
+import { Trans } from "@lingui/react/macro";
+<Trans>
+  Hello{" "}
+  <a _t="link" href="/a">
+    link 1
+  </a>
+  , normal,{" "}
+  <a _t="link" href="/a">
+    link 1 copy
+  </a>
+  .
+</Trans>;
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { Trans as _Trans } from "@lingui/react";
+<_Trans
+  {
+    /*i18n*/
+    ...{
+      id: "9en3MH",
+      message: "Hello <link>link 1</link>, normal, <link>link 1 copy</link>.",
+      components: {
+        link: <a href="/a" />,
+      },
+    }
+  }
+/>;
+
+`;
+
+exports[`Mixing explicit _t together with jsxPlaceholderDefaults 1`] = `
+import { Trans } from "@lingui/react/macro";
+<Trans>
+  Hello <a href="/a">link 1</a>, normal,{" "}
+  <a _t="link2" href="/b">
+    link 2
+  </a>
+  .
+</Trans>;
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { Trans as _Trans } from "@lingui/react";
+<_Trans
+  {
+    /*i18n*/
+    ...{
+      id: "yU9TUm",
+      message: "Hello <link>link 1</link>, normal, <link2>link 2</link2>.",
+      components: {
+        link: <a href="/a" />,
+        link2: <a href="/b" />,
+      },
+    }
+  }
+/>;
+
+`;
+
+exports[`Placeholder attribute is stripped from AST 1`] = `
+import { Trans } from "@lingui/react/macro";
+<Trans>
+  <a _t="link" href="/about">
+    About
+  </a>
+</Trans>;
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { Trans as _Trans } from "@lingui/react";
+<_Trans
+  {
+    /*i18n*/
+    ...{
+      id: "Ym2S6K",
+      message: "<link>About</link>",
+      components: {
+        link: <a href="/about" />,
+      },
+    }
+  }
+/>;
+
+`;
+
+exports[`Respects jsxPlaceholderDefaults 1`] = `
+import { Trans } from "@lingui/react/macro";
+<Trans>
+  Here's a <a>link</a> and <em>emphasis</em>.
+</Trans>;
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { Trans as _Trans } from "@lingui/react";
+<_Trans
+  {
+    /*i18n*/
+    ...{
+      id: "Jg_WOt",
+      message: "Here's a <link>link</link> and <em>emphasis</em>.",
+      components: {
+        link: <a />,
+        em: <em />,
+      },
+    }
+  }
+/>;
+
+`;

--- a/packages/babel-plugin-lingui-macro/test/jsx-placeholder.test.ts
+++ b/packages/babel-plugin-lingui-macro/test/jsx-placeholder.test.ts
@@ -157,5 +157,96 @@ import { Trans } from "@lingui/react/macro";
         ),
       },
     },
+    {
+      name: "Deduplication: Same name on different element types throws an error",
+      code: `
+        import { Trans } from '@lingui/react/macro';
+        <Trans><em _t="same">A</em> and <strong _t="same">B</strong></Trans>
+      `,
+      shouldThrow: true,
+      macroOpts: {
+        linguiConfig: makeConfig(
+          {
+            macro: {
+              jsxPlaceholderAttribute: "_t",
+            },
+          },
+          { skipValidation: true },
+        ),
+      },
+    },
+    {
+      name: "Throws on non-string _t attribute value",
+      code: `
+        import { Trans } from '@lingui/react/macro';
+        const name = "link";
+        <Trans><a _t={name} href="/">click</a></Trans>
+      `,
+      shouldThrow: true,
+      macroOpts: {
+        linguiConfig: makeConfig(
+          {
+            macro: {
+              jsxPlaceholderAttribute: "_t",
+            },
+          },
+          { skipValidation: true },
+        ),
+      },
+    },
+    {
+      name: "Throws on empty _t attribute value",
+      code: `
+        import { Trans } from '@lingui/react/macro';
+        <Trans><a _t="" href="/">click</a></Trans>
+      `,
+      shouldThrow: true,
+      macroOpts: {
+        linguiConfig: makeConfig(
+          {
+            macro: {
+              jsxPlaceholderAttribute: "_t",
+            },
+          },
+          { skipValidation: true },
+        ),
+      },
+    },
+    {
+      name: "Throws on numeric placeholder name",
+      code: `
+        import { Trans } from '@lingui/react/macro';
+        <Trans><a _t="0" href="/">click</a></Trans>
+      `,
+      shouldThrow: true,
+      macroOpts: {
+        linguiConfig: makeConfig(
+          {
+            macro: {
+              jsxPlaceholderAttribute: "_t",
+            },
+          },
+          { skipValidation: true },
+        ),
+      },
+    },
+    {
+      name: "Throws on invalid identifier placeholder name",
+      code: `
+        import { Trans } from '@lingui/react/macro';
+        <Trans><a _t="foo-bar" href="/">click</a></Trans>
+      `,
+      shouldThrow: true,
+      macroOpts: {
+        linguiConfig: makeConfig(
+          {
+            macro: {
+              jsxPlaceholderAttribute: "_t",
+            },
+          },
+          { skipValidation: true },
+        ),
+      },
+    },
   ],
 })

--- a/packages/babel-plugin-lingui-macro/test/jsx-placeholder.test.ts
+++ b/packages/babel-plugin-lingui-macro/test/jsx-placeholder.test.ts
@@ -231,10 +231,62 @@ import { Trans } from "@lingui/react/macro";
       },
     },
     {
-      name: "Throws on invalid identifier placeholder name",
+      name: "Allows hyphenated placeholder name",
       code: `
         import { Trans } from '@lingui/react/macro';
         <Trans><a _t="foo-bar" href="/">click</a></Trans>
+      `,
+      macroOpts: {
+        linguiConfig: makeConfig(
+          {
+            macro: {
+              jsxPlaceholderAttribute: "_t",
+            },
+          },
+          { skipValidation: true },
+        ),
+      },
+    },
+    {
+      name: "Allows dotted placeholder name",
+      code: `
+        import { Trans } from '@lingui/react/macro';
+        <Trans><a _t="ns.link" href="/">click</a></Trans>
+      `,
+      macroOpts: {
+        linguiConfig: makeConfig(
+          {
+            macro: {
+              jsxPlaceholderAttribute: "_t",
+            },
+          },
+          { skipValidation: true },
+        ),
+      },
+    },
+    {
+      name: "Throws on placeholder name starting with hyphen",
+      code: `
+        import { Trans } from '@lingui/react/macro';
+        <Trans><a _t="-foo" href="/">click</a></Trans>
+      `,
+      shouldThrow: true,
+      macroOpts: {
+        linguiConfig: makeConfig(
+          {
+            macro: {
+              jsxPlaceholderAttribute: "_t",
+            },
+          },
+          { skipValidation: true },
+        ),
+      },
+    },
+    {
+      name: "Throws on placeholder name ending with dot",
+      code: `
+        import { Trans } from '@lingui/react/macro';
+        <Trans><a _t="foo." href="/">click</a></Trans>
       `,
       shouldThrow: true,
       macroOpts: {

--- a/packages/babel-plugin-lingui-macro/test/jsx-placeholder.test.ts
+++ b/packages/babel-plugin-lingui-macro/test/jsx-placeholder.test.ts
@@ -248,5 +248,62 @@ import { Trans } from "@lingui/react/macro";
         ),
       },
     },
+    {
+      name: "Deduplication: Identical spreads are reused",
+      code: `
+        import { Trans } from '@lingui/react/macro';
+        const props = { href: "/a" };
+        <Trans><a _t="link" {...props}>A</a> and <a _t="link" {...props}>B</a></Trans>
+      `,
+      macroOpts: {
+        linguiConfig: makeConfig(
+          {
+            macro: {
+              jsxPlaceholderAttribute: "_t",
+            },
+          },
+          { skipValidation: true },
+        ),
+      },
+    },
+    {
+      name: "Deduplication: Different spreads throw an error",
+      code: `
+        import { Trans } from '@lingui/react/macro';
+        const p1 = { href: "/a" };
+        const p2 = { href: "/b" };
+        <Trans><a _t="link" {...p1}>A</a> and <a _t="link" {...p2}>B</a></Trans>
+      `,
+      shouldThrow: true,
+      macroOpts: {
+        linguiConfig: makeConfig(
+          {
+            macro: {
+              jsxPlaceholderAttribute: "_t",
+            },
+          },
+          { skipValidation: true },
+        ),
+      },
+    },
+    {
+      name: "Deduplication: Same spread with different attribute order throws an error",
+      code: `
+        import { Trans } from '@lingui/react/macro';
+        const props = { href: "/b" };
+        <Trans><a _t="link" {...props} href="/a">A</a> and <a _t="link" href="/a" {...props}>B</a></Trans>
+      `,
+      shouldThrow: true,
+      macroOpts: {
+        linguiConfig: makeConfig(
+          {
+            macro: {
+              jsxPlaceholderAttribute: "_t",
+            },
+          },
+          { skipValidation: true },
+        ),
+      },
+    },
   ],
 })

--- a/packages/babel-plugin-lingui-macro/test/jsx-placeholder.test.ts
+++ b/packages/babel-plugin-lingui-macro/test/jsx-placeholder.test.ts
@@ -1,0 +1,137 @@
+import { macroTester } from "./macroTester"
+import { makeConfig } from "@lingui/conf"
+
+macroTester({
+  cases: [
+    {
+      name: "Placeholder attribute is stripped from AST",
+      code: `
+        import { Trans } from '@lingui/react/macro';
+        <Trans>
+          <a _t="link" href="/about">About</a>
+        </Trans>
+      `,
+      macroOpts: {
+        linguiConfig: makeConfig({
+          macro: {
+            jsxPlaceholderAttribute: "_t",
+          }
+        })
+      }
+    },
+    {
+      name: "Respects jsxPlaceholderDefaults",
+      code: `
+        import { Trans } from '@lingui/react/macro';
+        <Trans>
+          Here's a <a>link</a> and <em>emphasis</em>.
+        </Trans>
+      `,
+      macroOpts: {
+        linguiConfig: makeConfig({
+          macro: {
+            jsxPlaceholderDefaults: {
+              a: "link",
+              em: "em"
+            }
+          }
+        })
+      }
+    },
+    {
+      name: "Mixing explicit _t together with jsxPlaceholderDefaults",
+      code: `
+        import { Trans } from '@lingui/react/macro';
+        <Trans>
+          Hello <a href="/a">link 1</a>, normal, <a _t="link2" href="/b">link 2</a>.
+        </Trans>
+      `,
+      macroOpts: {
+        linguiConfig: makeConfig({
+          macro: {
+            jsxPlaceholderAttribute: "_t",
+            jsxPlaceholderDefaults: {
+              a: "link",
+            }
+          }
+        })
+      }
+    },
+    {
+      name: "Deduplication: Identical elements are reused",
+      code: `
+        import { Trans } from '@lingui/react/macro';
+        <Trans>Hello <em>emphasis</em>, normal, <em>more emphasis</em>.</Trans>
+      `,
+      macroOpts: {
+        linguiConfig: makeConfig({
+          macro: {
+            jsxPlaceholderDefaults: {
+              em: "em",
+            }
+          }
+        })
+      }
+    },
+    {
+      name: "Deduplication: Same explicit placeholder with identical attributes does not throw",
+      code: `
+        import { Trans } from '@lingui/react/macro';
+        <Trans>Hello <a _t="link" href="/a">link 1</a>, normal, <a _t="link" href="/a">link 1 copy</a>.</Trans>
+      `,
+      macroOpts: {
+        linguiConfig: makeConfig({
+          macro: {
+            jsxPlaceholderAttribute: "_t",
+          }
+        })
+      }
+    },
+    {
+      name: "Deduplication: Identical elements with different prop order are reused",
+      code: `
+import { Trans } from "@lingui/react/macro";
+<Trans>Hello <a _t="link" href="/a" class="foo">link 1</a>, normal, <a _t="link" class="foo" href="/a">link 1 copy</a>.</Trans>;
+      `,
+      macroOpts: {
+        linguiConfig: makeConfig({
+          macro: {
+            jsxPlaceholderAttribute: "_t",
+          }
+        })
+      }
+    },
+    {
+      name: "Deduplication: Implicit names with distinct attributes throw an error",
+      code: `
+        import { Trans } from '@lingui/react/macro';
+        <Trans>Hello <a href="/a">link 1</a>, normal, <a href="/b">link 2</a>.</Trans>
+      `,
+      shouldThrow: true,
+      macroOpts: {
+        linguiConfig: makeConfig({
+          macro: {
+            jsxPlaceholderDefaults: {
+              a: "a",
+            }
+          }
+        })
+      }
+    },
+    {
+      name: "Deduplication: Explicit names with different attributes throw an error",
+      code: `
+        import { Trans } from '@lingui/react/macro';
+        <Trans>Hello <a _t="link" href="/a">link 1</a>, normal, <a _t="link" href="/b">link 2</a>.</Trans>
+      `,
+      shouldThrow: true,
+      macroOpts: {
+        linguiConfig: makeConfig({
+          macro: {
+            jsxPlaceholderAttribute: "_t",
+          }
+        })
+      }
+    },
+  ]
+})

--- a/packages/babel-plugin-lingui-macro/test/jsx-placeholder.test.ts
+++ b/packages/babel-plugin-lingui-macro/test/jsx-placeholder.test.ts
@@ -12,12 +12,15 @@ macroTester({
         </Trans>
       `,
       macroOpts: {
-        linguiConfig: makeConfig({
-          macro: {
-            jsxPlaceholderAttribute: "_t",
-          }
-        })
-      }
+        linguiConfig: makeConfig(
+          {
+            macro: {
+              jsxPlaceholderAttribute: "_t",
+            },
+          },
+          { skipValidation: true },
+        ),
+      },
     },
     {
       name: "Respects jsxPlaceholderDefaults",
@@ -28,15 +31,18 @@ macroTester({
         </Trans>
       `,
       macroOpts: {
-        linguiConfig: makeConfig({
-          macro: {
-            jsxPlaceholderDefaults: {
-              a: "link",
-              em: "em"
-            }
-          }
-        })
-      }
+        linguiConfig: makeConfig(
+          {
+            macro: {
+              jsxPlaceholderDefaults: {
+                a: "link",
+                em: "em",
+              },
+            },
+          },
+          { skipValidation: true },
+        ),
+      },
     },
     {
       name: "Mixing explicit _t together with jsxPlaceholderDefaults",
@@ -47,15 +53,18 @@ macroTester({
         </Trans>
       `,
       macroOpts: {
-        linguiConfig: makeConfig({
-          macro: {
-            jsxPlaceholderAttribute: "_t",
-            jsxPlaceholderDefaults: {
-              a: "link",
-            }
-          }
-        })
-      }
+        linguiConfig: makeConfig(
+          {
+            macro: {
+              jsxPlaceholderAttribute: "_t",
+              jsxPlaceholderDefaults: {
+                a: "link",
+              },
+            },
+          },
+          { skipValidation: true },
+        ),
+      },
     },
     {
       name: "Deduplication: Identical elements are reused",
@@ -64,14 +73,17 @@ macroTester({
         <Trans>Hello <em>emphasis</em>, normal, <em>more emphasis</em>.</Trans>
       `,
       macroOpts: {
-        linguiConfig: makeConfig({
-          macro: {
-            jsxPlaceholderDefaults: {
-              em: "em",
-            }
-          }
-        })
-      }
+        linguiConfig: makeConfig(
+          {
+            macro: {
+              jsxPlaceholderDefaults: {
+                em: "em",
+              },
+            },
+          },
+          { skipValidation: true },
+        ),
+      },
     },
     {
       name: "Deduplication: Same explicit placeholder with identical attributes does not throw",
@@ -80,12 +92,15 @@ macroTester({
         <Trans>Hello <a _t="link" href="/a">link 1</a>, normal, <a _t="link" href="/a">link 1 copy</a>.</Trans>
       `,
       macroOpts: {
-        linguiConfig: makeConfig({
-          macro: {
-            jsxPlaceholderAttribute: "_t",
-          }
-        })
-      }
+        linguiConfig: makeConfig(
+          {
+            macro: {
+              jsxPlaceholderAttribute: "_t",
+            },
+          },
+          { skipValidation: true },
+        ),
+      },
     },
     {
       name: "Deduplication: Identical elements with different prop order are reused",
@@ -94,12 +109,15 @@ import { Trans } from "@lingui/react/macro";
 <Trans>Hello <a _t="link" href="/a" class="foo">link 1</a>, normal, <a _t="link" class="foo" href="/a">link 1 copy</a>.</Trans>;
       `,
       macroOpts: {
-        linguiConfig: makeConfig({
-          macro: {
-            jsxPlaceholderAttribute: "_t",
-          }
-        })
-      }
+        linguiConfig: makeConfig(
+          {
+            macro: {
+              jsxPlaceholderAttribute: "_t",
+            },
+          },
+          { skipValidation: true },
+        ),
+      },
     },
     {
       name: "Deduplication: Implicit names with distinct attributes throw an error",
@@ -109,14 +127,17 @@ import { Trans } from "@lingui/react/macro";
       `,
       shouldThrow: true,
       macroOpts: {
-        linguiConfig: makeConfig({
-          macro: {
-            jsxPlaceholderDefaults: {
-              a: "a",
-            }
-          }
-        })
-      }
+        linguiConfig: makeConfig(
+          {
+            macro: {
+              jsxPlaceholderDefaults: {
+                a: "a",
+              },
+            },
+          },
+          { skipValidation: true },
+        ),
+      },
     },
     {
       name: "Deduplication: Explicit names with different attributes throw an error",
@@ -126,12 +147,15 @@ import { Trans } from "@lingui/react/macro";
       `,
       shouldThrow: true,
       macroOpts: {
-        linguiConfig: makeConfig({
-          macro: {
-            jsxPlaceholderAttribute: "_t",
-          }
-        })
-      }
+        linguiConfig: makeConfig(
+          {
+            macro: {
+              jsxPlaceholderAttribute: "_t",
+            },
+          },
+          { skipValidation: true },
+        ),
+      },
     },
-  ]
+  ],
 })

--- a/packages/babel-plugin-lingui-macro/test/macroTester.ts
+++ b/packages/babel-plugin-lingui-macro/test/macroTester.ts
@@ -5,6 +5,7 @@ import path from "path"
 import fs from "fs"
 import { macro } from "../src/macro"
 import Module from "node:module"
+import { stripVTControlCharacters } from "node:util"
 
 export type TestCase = TestCaseInline | TestCaseFixture
 
@@ -126,7 +127,9 @@ export function macroTester(opts: MacroTesterOptions) {
                 )
               } catch (e: any) {
                 if (e && e.message) {
-                  e.message = e.message.replace(process.cwd(), "<cwd>")
+                  e.message = stripVTControlCharacters(
+                    e.message.replace(process.cwd(), "<cwd>"),
+                  )
                 }
                 throw e
               }

--- a/packages/babel-plugin-lingui-macro/test/macroTester.ts
+++ b/packages/babel-plugin-lingui-macro/test/macroTester.ts
@@ -31,6 +31,7 @@ type TestCaseCommon = {
   macroOpts?: LinguiPluginOpts
   only?: boolean
   skip?: boolean
+  shouldThrow?: boolean
   /**
    * Will not execute test using babel-macro-plugin
    */
@@ -111,6 +112,28 @@ export function macroTester(opts: MacroTesterOptions) {
 
           expect(await clean(actualPlugin)).toEqual(await clean(expected))
         } else {
+          if (testCase.shouldThrow) {
+            expect(() => {
+              try {
+                transformSync(
+                  testCase.code,
+                  getDefaultBabelOptions(
+                    "plugin",
+                    macroOpts,
+                    useTypescriptPreset,
+                    useReactCompiler,
+                  ),
+                )
+              } catch (e: any) {
+                if (e && e.message) {
+                  e.message = e.message.replace(process.cwd(), "<cwd>")
+                }
+                throw e
+              }
+            }).toThrowErrorMatchingSnapshot()
+            return
+          }
+
           const actualPlugin = transformSync(
             testCase.code,
             getDefaultBabelOptions(

--- a/packages/babel-plugin-lingui-macro/test/macroTester.ts
+++ b/packages/babel-plugin-lingui-macro/test/macroTester.ts
@@ -128,7 +128,10 @@ export function macroTester(opts: MacroTesterOptions) {
               } catch (e: any) {
                 if (e && e.message) {
                   e.message = stripVTControlCharacters(
-                    e.message.replace(process.cwd(), "<cwd>"),
+                    e.message
+                      .replace(process.cwd(), "<cwd>")
+                      // normalize path on Windows
+                      .replace("<cwd>\\", "<cwd>/"),
                   )
                 }
                 throw e

--- a/packages/conf/src/makeConfig.ts
+++ b/packages/conf/src/makeConfig.ts
@@ -81,6 +81,14 @@ export const defaultConfig = {
 
 export const exampleConfig = {
   ...defaultConfig,
+  macro: {
+    ...defaultConfig.macro,
+    jsxPlaceholderAttribute: "_t",
+    jsxPlaceholderDefaults: multipleValidOptions(
+      {},
+      { a: "link", em: "em", strong: "b" },
+    ),
+  },
   format: multipleValidOptions({}, {}),
   extractors: multipleValidOptions([], ["babel"], [Object]),
   runtimeConfigModule: multipleValidOptions(

--- a/packages/conf/src/types.ts
+++ b/packages/conf/src/types.ts
@@ -351,7 +351,7 @@ export type LinguiConfig = {
      * // lingui.config
      * {
      *   macro: {
-     *     jsxPackage: ["@lingui/myMacro"];
+     *     jsxPackage: ["@lingui/myMacro"]
      *   }
      * }
      *
@@ -364,6 +364,48 @@ export type LinguiConfig = {
      * @default ["@lingui/react/macro"]
      */
     jsxPackage?: string[]
+    /**
+     * The JSX attribute name used to assign explicit placeholder names to JSX elements inside `<Trans>`.
+     *
+     * When set, the macro will read this attribute from JSX elements to use as the placeholder name
+     * in the message string, and strip the attribute from the output.
+     *
+     * ```tsx
+     * // lingui.config
+     * {
+     *   macro: {
+     *     jsxPlaceholderAttribute: "_t" 
+     *   }
+     * }
+     *
+     * // source
+     * <Trans>Click <a _t="link" href="/">here</a></Trans>
+     *
+     * // extracted message: "Click <link>here</link>"
+     * ```
+     */
+    jsxPlaceholderAttribute?: string
+    /**
+     * A mapping of JSX element tag names to default placeholder names.
+     *
+     * When a JSX element inside `<Trans>` matches a key in this map and does not have an explicit
+     * placeholder attribute, the corresponding value is used as the placeholder name.
+     *
+     * ```tsx
+     * // lingui.config
+     * {
+     *   macro: {
+     *     jsxPlaceholderDefaults: { a: "link", em: "em" } 
+     *   }
+     * }
+     *
+     * // source
+     * <Trans>Click <a href="/">here</a> and <em>this</em></Trans>
+     *
+     * // extracted message: "Click <link>here</link> and <em>this</em>"
+     * ```
+     */
+    jsxPlaceholderDefaults?: Record<string, string>
   }
   experimental?: {
     extractor?: ExperimentalExtractorOptions

--- a/packages/conf/src/types.ts
+++ b/packages/conf/src/types.ts
@@ -374,7 +374,7 @@ export type LinguiConfig = {
      * // lingui.config
      * {
      *   macro: {
-     *     jsxPlaceholderAttribute: "_t" 
+     *     jsxPlaceholderAttribute: "_t"
      *   }
      * }
      *
@@ -395,7 +395,7 @@ export type LinguiConfig = {
      * // lingui.config
      * {
      *   macro: {
-     *     jsxPlaceholderDefaults: { a: "link", em: "em" } 
+     *     jsxPlaceholderDefaults: { a: "link", em: "em" }
      *   }
      * }
      *

--- a/website/docs/ref/conf.md
+++ b/website/docs/ref/conf.md
@@ -528,7 +528,7 @@ Allows customizing the Core Macro package name that the Lingui macro detects.
 // lingui.config
 {
   macro: {
-    corePackage: ["@lingui/myMacro"];
+    corePackage: ["@lingui/myMacro"],
   }
 }
 
@@ -550,7 +550,7 @@ Allows customizing the JSX Macro package name that the Lingui macro detects.
 // lingui.config
 {
   macro: {
-    jsxPackage: ["@lingui/myMacro"];
+    jsxPackage: ["@lingui/myMacro"],
   }
 }
 
@@ -561,3 +561,71 @@ import { Trans } from "@lingui/myMacro";
 ```
 
 This setting mostly useful for external framework integrations.
+
+## macro.jsxPlaceholderAttribute
+
+Default value: `undefined`
+
+The JSX attribute name used to assign explicit placeholder names to JSX elements inside `<Trans>`. When set, the macro reads this attribute from JSX elements to use as the placeholder name in the message string, and strips the attribute from the output.
+
+```jsx
+// lingui.config
+{
+  macro: {
+    jsxPlaceholderAttribute: "_t",
+  }
+}
+
+// source
+<Trans>
+  Click <a _t="link" href="/">here</a>
+</Trans>;
+
+// extracted message: "Click <link>here</link>"
+```
+
+Without this option, JSX elements are assigned auto-generated numeric placeholders (e.g. `<0>here</0>`), which are less readable for translators and may cause issues if the element order changes.
+
+:::note TypeScript Usage
+In React/TypeScript projects, you need to declare the custom attribute so that TypeScript doesn't report an error. Add the following to a `.d.ts` file included in your project:
+
+```ts
+import "react"
+
+declare module "react" {
+  interface Attributes {
+    _t?: string // replace with your `jsxPlaceholderAttribute` value
+  }
+}
+```
+
+:::
+
+## macro.jsxPlaceholderDefaults
+
+Default value: `undefined`
+
+A mapping of JSX element tag names to default placeholder names. When a JSX element inside `<Trans>` matches a key in this map and does not have an explicit placeholder attribute (see [`macro.jsxPlaceholderAttribute`](#macrojsxplaceholderattribute)), the corresponding value is used as the placeholder name.
+
+```jsx
+// lingui.config
+{
+  macro: {
+    jsxPlaceholderAttribute: "_t",
+    jsxPlaceholderDefaults: {
+      a: "link",
+      em: "emphasis",
+      strong: "bold",
+    },
+  }
+}
+
+// source
+<Trans>
+  Click <a href="/">here</a> and <em>this</em>
+</Trans>;
+
+// extracted message: "Click <link>here</link> and <emphasis>this</emphasis>"
+```
+
+Explicit attributes (via `jsxPlaceholderAttribute`) take priority over defaults.

--- a/website/docs/ref/conf.md
+++ b/website/docs/ref/conf.md
@@ -590,11 +590,11 @@ Without this option, JSX elements are assigned auto-generated numeric placeholde
 In React/TypeScript projects, you need to declare the custom attribute so that TypeScript doesn't report an error. Add the following to a `.d.ts` file included in your project:
 
 ```ts
-import "react"
+import "react";
 
 declare module "react" {
   interface Attributes {
-    _t?: string // replace with your `jsxPlaceholderAttribute` value
+    _t?: string; // replace with your `jsxPlaceholderAttribute` value
   }
 }
 ```


### PR DESCRIPTION
# Description

Add a new feature that allows developers to customize the identifiers of JSX placeholders generated by the `<Trans>` macro. This results in placeholder identifiers in extracted messages that are more stable, human-readable, and contextual, instead of the default arbitrary numeric indices (e.g., replacing `<0>` with `<em>` or `<link>`).

It is accomplished via two new optional configuration options (via `lingui.config.js` in the `macro` options):
1. `jsxPlaceholderAttribute`: Allows defining a custom prop name (e.g., `_t`) that can be used on components to set an explicit placeholder name locally.
2. `jsxPlaceholderDefaults`: Allows providing a record of tag names to placeholder names, enabling global default renaming for specific JSX components.

SWC implementation at https://github.com/lingui/swc-plugin/pull/207

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Examples update

Fixes #1188

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate) - _will do before merging_

## Usage

#### lingui.config.js
```ts
import { defineConfig } from '@lingui/cli'

export default defineConfig({
  sourceLocale: 'en',
  locales: ['en', 'sv'],
  macro: {
    jsxPlaceholderAttribute: '_t',
    jsxPlaceholderDefaults: {
      a: 'a',
      b: 'b',
      br: 'br',
    },
  },
})
```

#### globals.d.ts or similarly imported definitions file
```ts
import 'react'

declare module 'react' {
  interface Attributes {
    _t?: string
  }
}
```

#### source-file.tsx
```tsx
import { Trans } from '@lingui/react/macro'

function App() {
  return <Trans>Translated <a href="/">link</a> with some <div _t="div">additional</div> markup.</Trans>
}
```

## Disclaimer

Much of this PR was generated by Copilot using the Gemini 3.1 Pro (Preview) model with training/sharing disabled.

<details>
<summary>Initial prompt used</summary>

## Plan: Implement JSX named placeholders

Add opt-in support for named JSX placeholders through Lingui configuration (`jsxPlaceholderAttribute` and `jsxPlaceholderDefaults`), replacing numeric indices in extracted messages for better maintainability and readability. Include smart element deduplication that reuses element names if their props are identical, otherwise with direct suffix appended for duplicated names.

**Steps**
1. **Extend LinguiConfig**: Update type definition in types.ts to include `jsxPlaceholderAttribute?: string` and `jsxPlaceholderDefaults?: Record<string, string>` in the `macro` object.
2. **Update Validation Configuration**: Add these new properties to `exampleConfig` in makeConfig.ts so `jest-validate` will accept them. Let `defaultConfig` omit them (or set them to `undefined` / empty object).
3. **Pass Config to Macro**: In index.ts, extract the new options from the `linguiConfig` macro passing them to the `MacroJSX` instantiation inside `MacroJsxOpts`. 
4. **Update MacroJsxOpts Interface**: Expand `MacroJsxOpts` in macroJsx.ts to accept `jsxPlaceholderAttribute` and `jsxPlaceholderDefaults`.
5. **Add State for Placeholder Names**: Introduce a tracked collection in `macroJsx.ts` (scoped to `MacroJsxContext` per message evaluation) to track used placeholder names and their original JSX node props.
6. **Modify `tokenizeElement`**: In macroJsx.ts, parse out the requested name:
   - Check the JSX node's attributes for an exact match to `jsxPlaceholderAttribute`.
   - If found, use its string literal value as the requested placeholder name, and **remove the attribute** from the node's AST.
   - If not found, check `jsxPlaceholderDefaults` using the literal tag name.
   - If neither are present, fallback to the current behavior `this.ctx.elementIndex()`.
   - Apply deduplication: Check if the base name is already used.
     - Look up previously stored element by that name.
     - **Reuse rule:** Evaluate whether the previously stored node and the current node have **identical props** (either both have no additional props, or their existing props are structurally equal). If equal, reuse the exact same key without incrementing.
     - **Collision rule:** If the props differ (e.g. they both have different `href` props), generate a new key by directly appending an incremental numeric suffix to the original name (starting at 2, e.g. `a` -> `a2`, `a3`), avoiding an underscore separator. Store it and assign the newly suffixed name to the current element.
7. **Create Tests**: Add a test fixture testing scenarios with `_t` attribute, tag-name defaults, deep nesting, prop deduplication (including equal props and differing props), and direct suffix logic.

**Relevant files**
- packages/conf/src/types.ts — Add properties to `LinguiConfig.macro` type.
- packages/conf/src/makeConfig.ts — Update `exampleConfig` for validator compatibility.
- packages/babel-plugin-lingui-macro/src/index.ts — Route configuration from `macroContext` to `MacroJSX`.
- packages/babel-plugin-lingui-macro/src/macroJsx.ts — Implement name lookup, AST attribute pruning, and the prop equality / direct-suffix (`x2`) element duplication rules.

**Verification**
1. Validate `pnpm test` in babel-plugin-lingui-macro.
2. Compare emitted ICU format visually to directly match the test cases:
   - Identical elements (same props or exactly no props) reuse the same name.
   - Distinct elements with same tag/name emit `<a>...</a>` and `<a2>...</a2>`.

**Decisions**
- The configuration attribute is explicitly stripped from the extracted component output to avoid unused React props and potential runtime warnings.
- Deduplication relies on checking equality of props (or both having zero props) to map them to the same component index.
- Duplicate names follow direct appending mapping e.g., `x`, `x2`, `x3`.

</details>
