### PR TITLE
fix(core): add bigint to MessagePlaceholder type

### DIFF
--- a/packages/core/macro/index.d.ts
+++ b/packages/core/macro/index.d.ts
@@ -59,7 +59,8 @@ export type LabeledExpression<T> = Record<string, T>
 export type MessagePlaceholder =
   | string
   | number
-  | LabeledExpression<string | number>
+  | bigint
+  | LabeledExpression<string | number | bigint>
 
 /**
  * Translates a template string using the global I18n instance


### PR DESCRIPTION
## Problem

Libraries like Zod type validation bounds as `number | bigint` (e.g. `ZodTooSmallIssue.minimum: number | bigint`). Passing these values directly in `t` template literals causes a TypeScript error:

```
error TS2345: Argument of type 'number | bigint' is not assignable 
to parameter of type 'MessagePlaceholder'.
  Type 'bigint' is not assignable to type 'MessagePlaceholder'.
```

## Solution

Add `bigint` to the `MessagePlaceholder` type in `@lingui/core/macro`:

```diff
 export type MessagePlaceholder =
   | string
   | number
+  | bigint
-  | LabeledExpression<string | number>
+  | LabeledExpression<string | number | bigint>
```

This is consistent with `i18n._()` which already accepts `Values = Record<string, unknown>`.

## Workaround users currently need

```ts
// Zod validation bounds
t`Min. ${Number(min)} characters`  // wrapping in Number()
```

With this fix:
```ts
t`Min. ${min} characters`  // works directly
```