### PR TITLE
fix(po-format): remove duplicated references when lineNumbers is false

### DIFF
--- a/packages/format-po-gettext/src/po-gettext.test.ts
+++ b/packages/format-po-gettext/src/po-gettext.test.ts
@@ -538,6 +538,63 @@ msgstr[3] "# dní"
       expect(pofile).toMatchSnapshot()
     })
 
+    it("should deduplicate file references when merging duplicate entries without line numbers", () => {
+      const duplicateFormatter = createFormat({
+        mergePlurals: true,
+        origins: true,
+        lineNumbers: false,
+      })
+      const message1 = "{count, plural, one {one book} other {many books}}"
+      const message2 =
+        "{anotherCount, plural, one {one book} other {many books}}"
+
+      const id1 = generateMessageId(message1)
+      const id2 = generateMessageId(message2)
+
+      const catalog: CatalogType = {
+        [id1]: {
+          message: message1,
+          translation: message1,
+          origin: [["src/App.tsx", 60]],
+        },
+        [id2]: {
+          message: message2,
+          translation: message2,
+          origin: [["src/App.tsx", 66]],
+        },
+      }
+
+      const pofile = duplicateFormatter.serialize(
+        catalog,
+        defaultSerializeCtx,
+      ) as string
+
+      expect(pofile).toMatchInlineSnapshot(`
+        "msgid ""
+        msgstr ""
+        "POT-Creation-Date: 2018-08-27 10:00+0000\\n"
+        "MIME-Version: 1.0\\n"
+        "Content-Type: text/plain; charset=utf-8\\n"
+        "Content-Transfer-Encoding: 8bit\\n"
+        "X-Generator: @lingui/cli\\n"
+        "Language: en\\n"
+        "Project-Id-Version: \\n"
+        "Report-Msgid-Bugs-To: \\n"
+        "PO-Revision-Date: \\n"
+        "Last-Translator: \\n"
+        "Language-Team: \\n"
+        "Plural-Forms: \\n"
+
+        #. js-lingui:icu=%7B%24var%2C+plural%2C+one+%7Bone+book%7D+other+%7Bmany+books%7D%7D&pluralize_on=count%2CanotherCount
+        #: src/App.tsx
+        msgid "one book"
+        msgid_plural "many books"
+        msgstr[0] "one book"
+        msgstr[1] "many books"
+        "
+      `)
+    })
+
     it("should keep all non-plurals entries intact", () => {
       const duplicateFormatter = createFormat({
         mergePlurals: true,

--- a/packages/format-po-gettext/src/po-gettext.ts
+++ b/packages/format-po-gettext/src/po-gettext.ts
@@ -354,8 +354,10 @@ function mergeDuplicatePluralEntries(
         ctxPrefix,
       )
 
-      // Merge references
-      mergedItem.references = duplicateItems.flatMap((item) => item.references)
+      // Merge references, preserving only unique file paths.
+      mergedItem.references = [
+        ...new Set(duplicateItems.flatMap((item) => item.references)),
+      ]
 
       mergedItems.push(mergedItem)
     }

--- a/packages/format-po/src/po.test.ts
+++ b/packages/format-po/src/po.test.ts
@@ -484,6 +484,43 @@ describe("pofile format", () => {
     `)
   })
 
+  it("should deduplicate file references when lineNumbers option is false", () => {
+    const format = createFormatter({ origins: true, lineNumbers: false })
+
+    const catalog: CatalogType = {
+      withDuplicateOrigins: {
+        translation: "Message with duplicate origins",
+        origin: [
+          ["src/App.js", 4],
+          ["src/App.js", 20],
+          ["src/Component.js", 2],
+          ["src/App.js", 55],
+          ["src/Component.js", 8],
+        ],
+      },
+    }
+
+    const actual = format.serialize(catalog, defaultSerializeCtx)
+
+    expect(actual).toMatchInlineSnapshot(`
+      "msgid ""
+      msgstr ""
+      "POT-Creation-Date: 2018-08-27 10:00+0000\\n"
+      "MIME-Version: 1.0\\n"
+      "Content-Type: text/plain; charset=utf-8\\n"
+      "Content-Transfer-Encoding: 8bit\\n"
+      "X-Generator: @lingui/cli\\n"
+      "Language: en\\n"
+
+      #. js-lingui-explicit-id
+      #: src/App.js
+      #: src/Component.js
+      msgid "withDuplicateOrigins"
+      msgstr "Message with duplicate origins"
+      "
+    `)
+  })
+
   it("should include custom header attributes", () => {
     const format = createFormatter({
       customHeaderAttributes: { "X-Custom-Attribute": "custom-value" },

--- a/packages/format-po/src/po.ts
+++ b/packages/format-po/src/po.ts
@@ -218,7 +218,7 @@ const serialize = (
 
     if (options.origins !== false) {
       if (message.origin && options.lineNumbers === false) {
-        item.references = message.origin.map(([path]) => path)
+        item.references = [...new Set(message.origin.map(([path]) => path))]
       } else {
         item.references = message.origin ? message.origin.map(joinOrigin) : []
       }


### PR DESCRIPTION
# Description

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

When `lineNumbers: false` is used, extracted PO catalogs currently keep duplicate `#:` reference lines if the same message appears multiple times in the same file. That creates unnecessary diff noise in source control even though the line numbers have already been intentionally removed.

This PR reduces that churn by deduplicating file-only references while preserving their original order.

Changes:
  - deduplicate references in `@lingui/format-po` when `lineNumbers: false`
  - deduplicate references in `@lingui/format-po-gettext` for the `mergePlurals: true` path, where merged plural entries could reintroduce duplicate file-only references
  - add regression tests for both cases

This keeps the existing behavior unchanged when line numbers are enabled, and only removes repeated file references once multiple locations have collapsed to the same path.

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

Fixes https://github.com/lingui/js-lingui/issues/2405

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
