### PR TITLE
ci: pin npm to 11.10.0 to avoid promise-retry failure on Node 22.22.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Install latest npm CLI
         run: |
-          npm install -g npm@latest
+          npm install -g npm@11.10.0
           npm --version
 
       - name: Publishing packages


### PR DESCRIPTION
https://github.com/npm/cli/pull/9152