### PR TITLE
fix(cli): declare files arguments

### DIFF
--- a/packages/cli/src/lingui-extract.ts
+++ b/packages/cli/src/lingui-extract.ts
@@ -188,6 +188,10 @@ if (import.meta.main) {
     )
     .option("--verbose", "Verbose output")
     .option("--watch", "Enables Watch Mode")
+    .argument(
+      "[files...]",
+      "Filter source paths to extract messages only from specific files",
+    )
     .parse(process.argv)
 
   const options = program.opts<CliArgs>()


### PR DESCRIPTION
# Description

After update commander in the #2429 running the extract command with specific files was broken.
[commander 13.0.0](https://github.com/tj/commander.js/releases/tag/v13.0.0) introduced breaking changes, specifically 

> Breaking: excess command-arguments cause an error by default

migrations tips were skipped and as a result - error from commander
for example, when running from a git hook or manually for a specific file

```sh
$ npx lingui extract src/App.tsx
error: too many arguments. Expected 0 arguments but got 1.
```

I made changes following migration tips. It fixes the error and now shows files arguments in the help message

before:

```
Usage: lingui-extract [options]

Options: ...
```

after:

```
Usage: lingui-extract [options] [files...]

Arguments:
  files                     Filter source paths to extract messages only from specific files

Options: ...
```

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
