### PR TITLE
docs: add legacy docs mode for SEO-safe archived deployments

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -2,6 +2,25 @@ import type { Config } from "@docusaurus/types";
 import type * as Preset from "@docusaurus/preset-classic";
 import { themes } from "prism-react-renderer";
 
+const isLegacyDocs = process.env["LEGACY_DOCS"] === "true";
+
+const customAnnouncementBar = {
+  id: "lingui-6.0",
+  content: `✨ Lingui <strong>6.0</strong> is now available. <a href="/blog/2026/04/22/announcing-lingui-6.0">Read the release announcement</a> for what's new ✨`,
+  backgroundColor: "#0d9488",
+  textColor: "#ffffff",
+  isCloseable: true,
+};
+
+const legacyDocsAnnouncementBar = {
+  id: "lingui-legacy-docs",
+  content:
+    'This is archived documentation for older version of Lingui. For the latest Lingui docs, visit <a href="https://lingui.dev">lingui.dev</a>.',
+  backgroundColor: "#92400e",
+  textColor: "#ffffff",
+  isCloseable: false,
+};
+
 const config: Config = {
   title: "Lingui",
   tagline: "Internationalization Framework for Global Products",
@@ -23,13 +42,7 @@ const config: Config = {
       disableSwitch: false,
       respectPrefersColorScheme: true,
     },
-    announcementBar: {
-      id: "lingui-6.0",
-      content: `✨ Lingui <strong>6.0</strong> is now available. <a href="/blog/2026/04/22/announcing-lingui-6.0">Read the release announcement</a> for what's new ✨`,
-      backgroundColor: "#0d9488",
-      textColor: "#ffffff",
-      isCloseable: true,
-    },
+    announcementBar: isLegacyDocs ? legacyDocsAnnouncementBar : customAnnouncementBar,
     metadata: [
       {
         name: "title",
@@ -45,6 +58,12 @@ const config: Config = {
         content:
           "internationalization, localization, multilingual, translation, i18n, l10n, react, react native, vue, next.js, ICU, javascript, typescript, pseudolocalization, internationalization framework",
       },
+      ...(isLegacyDocs
+        ? [
+            { name: "robots", content: "noindex, nofollow, noarchive" },
+            { name: "googlebot", content: "noindex, nofollow, noarchive" },
+          ]
+        : []),
     ],
     navbar: {
       title: "",
@@ -136,10 +155,12 @@ const config: Config = {
           showReadingTime: true,
           editUrl: "https://github.com/lingui/js-lingui/tree/main/website/",
         },
-        sitemap: {
-          priority: 0.5,
-          filename: "sitemap.xml",
-        },
+        sitemap: isLegacyDocs
+          ? false
+          : {
+              priority: 0.5,
+              filename: "sitemap.xml",
+            },
         theme: {
           customCss: require.resolve("./src/css/custom.scss"),
         },


### PR DESCRIPTION
# Description

This PR introduces a `LEGACY_DOCS` mode for the Docusaurus website to support archived version deployments (e.g. `v5.lingui.dev`, `v4.lingui.dev`) in an SEO-safe way. When enabled, the site adds `noindex/nofollow` robots metadata, disables sitemap generation, and shows a clear announcement bar pointing users to the latest docs on `lingui.dev`.

The main-site behavior remains unchanged.

This PR is for future releases. I am going to port this change to the site in the `stable-4.x` and `stable-5.x` branches.

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Examples update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
