### PR TITLE
fix: avoid throwing on object spreads in babel-plugin-extract-messages

### DIFF
--- a/packages/babel-plugin-extract-messages/src/index.ts
+++ b/packages/babel-plugin-extract-messages/src/index.ts
@@ -163,7 +163,10 @@ function extractFromObjectExpression(
 
   const textKeys = ["id", "message", "comment", "context"] as const
 
-  ;(exp.properties as ObjectProperty[]).forEach(({ key, value }, i) => {
+  exp.properties.forEach((prop, i) => {
+    if (prop.type !== "ObjectProperty") return
+    const { key, value } = prop
+
     const name = (key as Identifier).name
 
     if (name === "values" && t.isObjectExpression(value)) {

--- a/packages/babel-plugin-extract-messages/test/extract-messages.test.ts
+++ b/packages/babel-plugin-extract-messages/test/extract-messages.test.ts
@@ -254,6 +254,18 @@ import { Trans } from "@lingui/react";
         expect(messages.length).toBe(1)
       })
     })
+
+    it("Should handle descriptors with object spreads", () => {
+      const code = `
+      const spread = {};
+      i18n.t({ ...spread, id: "x", message: "translation" });
+      `
+      expectNoConsole(() => {
+        const messages = transformCode(code)
+        expect(messages).toHaveLength(1)
+        expect(messages[0]).toMatchObject({ id: "x", message: "translation" })
+      })
+    })
   })
 
   describe("StringLiteral", () => {


### PR DESCRIPTION
# Description

Fixes a bug in `@lingui/babel-plugin-extract-messages` which caused `extractFromObjectExpression()` to throw when it encountered an object spread:

```ts
const spread = {};
i18n.t({ ...spread, id: "x", message: "translation" });
```

Also introduces a regression test for this.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
