### PR TITLE
perf(cli): speed up catalog merge key partitioning

### DIFF
--- a/packages/cli/src/api/catalog/mergeCatalog-performance.test.ts
+++ b/packages/cli/src/api/catalog/mergeCatalog-performance.test.ts
@@ -1,0 +1,79 @@
+import { performance } from "node:perf_hooks"
+import { describe, expect, test } from "vitest"
+
+import {
+  defaultMergeOptions,
+  makeNextMessage,
+  makePrevMessage,
+} from "../../tests.js"
+import { mergeCatalog } from "./mergeCatalog.js"
+import { CatalogType, ExtractedCatalogType } from "../types.js"
+
+function median(values: number[]) {
+  const sorted = [...values].sort((a, b) => a - b)
+
+  return sorted[Math.floor(sorted.length / 2)]!
+}
+
+function measure(fn: () => void, runs = 15) {
+  const times: number[] = []
+
+  // Warm-up for JIT
+  for (let i = 0; i < 20; i++) {
+    fn()
+  }
+
+  for (let i = 0; i < runs; i++) {
+    const start = performance.now()
+    fn()
+    const end = performance.now()
+
+    times.push(end - start)
+  }
+
+  return median(times)
+}
+
+function makePrevCatalog(size: number) {
+  return Object.fromEntries(
+    Array.from({ length: size }, (_, index) => [
+      `prev.${index}`,
+      makePrevMessage({ translation: `Translation ${index}` }),
+    ]),
+  ) as CatalogType
+}
+
+function makeNextCatalog(size: number) {
+  return Object.fromEntries(
+    Array.from({ length: size }, (_, index) => [
+      `next.${index}`,
+      makeNextMessage({ message: `Message ${index}` }),
+    ]),
+  ) as ExtractedCatalogType
+}
+
+describe("mergeCatalog performance", () => {
+  test("merge scales approximately linearly", () => {
+    const sizes = [1_000, 2_000, 4_000, 8_000]
+
+    const measurements = sizes.map((size) => {
+      const prevCatalog = makePrevCatalog(size)
+      const nextCatalog = makeNextCatalog(size)
+
+      return {
+        size,
+        timeMs: measure(() => {
+          mergeCatalog(prevCatalog, nextCatalog, false, defaultMergeOptions)
+        }),
+      }
+    })
+
+    const small = measurements[0]!
+    const large = measurements[measurements.length - 1]!
+    const inputGrowth = large.size / small.size
+    const timeGrowth = large.timeMs / small.timeMs
+
+    // Allow CI noise while still keeping the budget well below quadratic growth.
+    expect(timeGrowth).toBeLessThan(inputGrowth * 3)
+  })
+})

--- a/packages/cli/src/api/catalog/mergeCatalog.ts
+++ b/packages/cli/src/api/catalog/mergeCatalog.ts
@@ -11,7 +11,7 @@ export function mergeCatalog(
   const nextKeys = Object.keys(nextCatalog)
   const prevKeys = Object.keys(prevCatalog)
 
-  const hasKeysInBothCatalogs = prevKeys.length && nextKeys.length
+  const hasKeysInBothCatalogs = prevKeys.length > 0 && nextKeys.length > 0
   let newKeys: string[]
   let mergeKeys: string[]
   let obsoleteKeys: string[]

--- a/packages/cli/src/api/catalog/mergeCatalog.ts
+++ b/packages/cli/src/api/catalog/mergeCatalog.ts
@@ -11,9 +11,23 @@ export function mergeCatalog(
   const nextKeys = Object.keys(nextCatalog)
   const prevKeys = Object.keys(prevCatalog)
 
-  const newKeys = nextKeys.filter((key) => !prevKeys.includes(key))
-  const mergeKeys = nextKeys.filter((key) => prevKeys.includes(key))
-  const obsoleteKeys = prevKeys.filter((key) => !nextKeys.includes(key))
+  const hasKeysInBothCatalogs = prevKeys.length && nextKeys.length
+  let newKeys: string[]
+  let mergeKeys: string[]
+  let obsoleteKeys: string[]
+
+  if (hasKeysInBothCatalogs) {
+    const prevKeySet = new Set(prevKeys)
+    const nextKeySet = new Set(nextKeys)
+
+    newKeys = nextKeys.filter((key) => !prevKeySet.has(key))
+    mergeKeys = nextKeys.filter((key) => prevKeySet.has(key))
+    obsoleteKeys = prevKeys.filter((key) => !nextKeySet.has(key))
+  } else {
+    newKeys = nextKeys
+    mergeKeys = []
+    obsoleteKeys = prevKeys
+  }
 
   // Initialize new catalog with new keys
   const newMessages: CatalogType = Object.fromEntries(


### PR DESCRIPTION
# Description

In our project, we have around 20k messages in Lingui catalogs, and this change cuts our extraction time nearly in half.

`mergeCatalog` currently partitions catalog keys with repeated `Array.includes` checks:

```ts
const newKeys = nextKeys.filter((key) => !prevKeys.includes(key))
const mergeKeys = nextKeys.filter((key) => prevKeys.includes(key))
const obsoleteKeys = prevKeys.filter((key) => !nextKeys.includes(key))
```

For large catalogs, this becomes expensive because each `includes` call may scan the other key array. This PR uses `Set.has` when both catalogs contain keys, reducing key partitioning from `O(N * P)` repeated scans to `O(N + P)` Set construction and lookup work. It also keeps a fast path for empty catalogs, avoiding unnecessary Set creation during initial extraction or fully-obsolete cases.

### Operation Count Estimate

Let:

```txt
N = nextKeys.length
P = prevKeys.length
```

Current implementation:

```txt
newKeys:      N items * O(P) lookup in prevKeys
mergeKeys:   N items * O(P) lookup in prevKeys
obsoleteKeys: P items * O(N) lookup in nextKeys

total:       O(N * P)
```

Optimized version:

```txt
build Sets:  O(P + N)
newKeys:     N items * O(1) lookup in prevKeySet
mergeKeys:   N items * O(1) lookup in prevKeySet
obsoleteKeys: P items * O(1) lookup in nextKeySet

total:       O(N + P)
```

In our case, both the previous and next catalogs contain around 20k messages. With the current implementation, each extraction can require hundreds of millions of array comparison steps while partitioning catalog keys. With this change, the same step is reduced to roughly 100k Set build/lookups.

This keeps the behavior unchanged while making large catalog merges significantly cheaper.

One question about the checklist: since this change keeps the existing behavior covered by the current `mergeCatalog` tests and only changes the key partitioning strategy, would you like me to add a small performance check or benchmark test for this path?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
