### PR TITLE
fix: disappearing placeholder comments in partial extract

### DIFF
--- a/packages/cli/test/extract-partial-consistency/existing/en.po
+++ b/packages/cli/test/extract-partial-consistency/existing/en.po
@@ -19,8 +19,8 @@ msgstr ""
 #~ msgstr "This message has custom id"
 
 #. js-lingui-explicit-id
-#: fixtures/file-a.ts:22
-#: fixtures/file-a.ts:23
+#: fixtures/file-a.ts:24
+#: fixtures/file-a.ts:25
 msgid "addToCart"
 msgstr "Add To Cart with change ignored"
 
@@ -46,6 +46,11 @@ msgstr "Hello world"
 #: fixtures/file-a.ts:16
 msgid "Message in descriptor"
 msgstr "Message in descriptor"
+
+#. placeholder {0}: Date.now()
+#: fixtures/file-a.ts:20
+msgid "Message with unlabeled placeholder {0}"
+msgstr "Message with unlabeled placeholder {0}"
 
 #. js-lingui-explicit-id
 #: fixtures/file-b.tsx:15

--- a/packages/cli/test/extract-partial-consistency/expected/en.po
+++ b/packages/cli/test/extract-partial-consistency/expected/en.po
@@ -19,8 +19,8 @@ msgstr ""
 #~ msgstr "This message has custom id"
 
 #. js-lingui-explicit-id
-#: fixtures/file-a.ts:22
-#: fixtures/file-a.ts:23
+#: fixtures/file-a.ts:24
+#: fixtures/file-a.ts:25
 msgid "addToCart"
 msgstr "Add To Cart with change ignored"
 
@@ -46,6 +46,11 @@ msgstr "Hello world"
 #: fixtures/file-a.ts:16
 msgid "Message in descriptor"
 msgstr "Message in descriptor"
+
+#. placeholder {0}: Date.now()
+#: fixtures/file-a.ts:20
+msgid "Message with unlabeled placeholder {0}"
+msgstr "Message with unlabeled placeholder {0}"
 
 #. js-lingui-explicit-id
 #: fixtures/file-b.tsx:15

--- a/packages/cli/test/extract-partial-consistency/fixtures/file-a.ts
+++ b/packages/cli/test/extract-partial-consistency/fixtures/file-a.ts
@@ -17,6 +17,8 @@ const msgDescriptor = defineMessage({
   message: "Message in descriptor",
 })
 
+t`Message with unlabeled placeholder ${Date.now()}`
+
 i18n._(msgDescriptor)
 
 i18n._("addToCart")

--- a/packages/format-po/src/__snapshots__/po.test.ts.snap
+++ b/packages/format-po/src/__snapshots__/po.test.ts.snap
@@ -67,6 +67,11 @@ msgstr "Static message {0}"
 #. placeholder {0}: profile.name
 msgid "static4"
 msgstr "Static message {0}"
+
+#. placeholder: {0} = getValue()
+#. js-lingui-explicit-id
+msgid "static5"
+msgstr "Static message {0}"
 "
 `;
 

--- a/packages/format-po/src/po.test.ts
+++ b/packages/format-po/src/po.test.ts
@@ -582,6 +582,14 @@ describe("pofile format", () => {
             0: ["userName", "user.name", "profile.name", "authorName"],
           },
         },
+
+        // Should not erase existing comments if message does not have placeholder
+        // https://github.com/lingui/js-lingui/issues/2542
+        static5: {
+          message: "Static message {0}",
+          comments: ["placeholder: {0} = getValue()"],
+          translation: "Static message {0}",
+        },
       }
 
       const actual = format.serialize(catalog, defaultSerializeCtx)

--- a/packages/format-po/src/po.ts
+++ b/packages/format-po/src/po.ts
@@ -175,7 +175,7 @@ const serialize = (
       item.msgid = id
     }
 
-    if (options.printPlaceholdersInComments !== false) {
+    if (options.printPlaceholdersInComments !== false && message.placeholders) {
       item.extractedComments = item.extractedComments.filter(
         (comment) => !comment.startsWith("placeholder "),
       )


### PR DESCRIPTION
# Description

Fixes: https://github.com/lingui/js-lingui/issues/2542

Steps to reproduce could be simplified, than in original issue: 

1. Have to files `a.tsx` and `b.tsx`
2. Both of them has some unlabeled placeholders eq: `{todoItems.length}`
3. Extract partially `lingui extract b.tsx`

**Actual Result:** 

Messages from `a.tsx` and `b.tsx` would be in catalog, but for `a` all placeholder messages would be erased. 

**Expected Result:**

Messages from `a.tsx` and `b.tsx` kept as is. 


Serialization and deserialization to PO file is lossy, means we lost some data. When we do partial extract (from specific files, not the whole codebase), part of the catalog entries are generated from the source code, rest of them are taken from catalog deserialization. 

The serialiazation function actually check if there are comments starting from "placeholder: ..." and if they are - erasing them, to not duplicate placeholder comments during serialization.

I changed this function in the way, that if there is not placeholders passed to it, it doesn't modify a comments of an entry. 

Unit tests for formatter and integration test for extractor added. 

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
