### PR TITLE
chore: harden GitHub actions supply chain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/docs-suite.yml
+++ b/.github/workflows/docs-suite.yml
@@ -7,6 +7,9 @@ on:
     paths:
       - website/**
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs-suite.yml
+++ b/.github/workflows/docs-suite.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 'lts/*'
 

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main-suite.yml
+++ b/.github/workflows/main-suite.yml
@@ -9,6 +9,9 @@ on:
       - main
       - next
 
+permissions:
+  contents: read
+
 jobs:
   test:
     timeout-minutes: 20

--- a/.github/workflows/main-suite.yml
+++ b/.github/workflows/main-suite.yml
@@ -25,10 +25,10 @@ jobs:
 
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node }}
           cache: 'yarn'
@@ -49,12 +49,12 @@ jobs:
     needs: test
     name: validate (node 22, ubuntu-latest)
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .nvmrc
           cache: 'yarn'
@@ -82,6 +82,6 @@ jobs:
         run: yarn test:e2e
 
       - name: Check coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         with:
           verbose: true

--- a/.github/workflows/main-suite.yml
+++ b/.github/workflows/main-suite.yml
@@ -82,6 +82,6 @@ jobs:
         run: yarn test:e2e
 
       - name: Check coverage
-        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           verbose: true

--- a/.github/workflows/next-sync.yml
+++ b/.github/workflows/next-sync.yml
@@ -12,16 +12,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 'lts/*'
 
       - name: Opening pull request
         id: pull
-        uses: tretuna/sync-branches@1.4.0
+        uses: tretuna/sync-branches@ea58ab6e406fd3ad016a064b31270bbb41127f41 # 1.4.0
         with:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           FROM_BRANCH: "main"

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -3,6 +3,9 @@ name: release-docs
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -19,6 +22,8 @@ jobs:
 
       - name: Install dependencies
         working-directory: website
+        env:
+          YARN_ENABLE_HARDENED_MODE: "1"
         run: yarn install
 
       - name: Build

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 'lts/*'
 
@@ -36,7 +36,7 @@ jobs:
           npx vercel --public --yes --prod --token ${{ secrets.NOW_TOKEN }} --name lingui-docs build
 
       - name: Update Algolia index
-        uses: darrenjennings/algolia-docsearch-action@v0.2.0
+        uses: darrenjennings/algolia-docsearch-action@e3b8c5540e90a964b655be6ca73c1ee1aeba2719 # v0.2.0
         with:
           algolia_application_id: ${{ vars.ALGOLIA_APP_ID }}
           algolia_api_key: ${{ secrets.ALGOLIA_WRITE_API_KEY }}

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -9,6 +9,9 @@ on:
       - main
       - next
 
+permissions:
+  contents: read
+
 jobs:
   release-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -17,12 +17,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 'lts/*'
           cache: 'yarn'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,8 @@ jobs:
           scope: '@lingui'
 
       - name: Install dependencies if needed
+        env:
+          YARN_ENABLE_HARDENED_MODE: "1"
         run: yarn install
 
       - name: Build packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,12 +20,12 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .nvmrc
           cache: 'yarn'

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -14,9 +14,9 @@ jobs:
       CI_JOB_NUMBER: 1
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: andresz1/size-limit-action@v1.8.0
+      - uses: andresz1/size-limit-action@94bc357df29c36c8f8d50ea497c3e225c3c95d1d # v1.8.0
         with:
           build_script: release:build
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-cldr-data.yml
+++ b/.github/workflows/update-cldr-data.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: "8.2"
           tools: composer
@@ -32,7 +32,7 @@ jobs:
           export-plural-rules --output=gettext-plurals.json json
 
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
 
       - run: npx prettier --write packages/format-po-gettext/gettext-plurals.json
 
@@ -49,7 +49,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.diff.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           commit-message: "chore: update CLDR plural rules"
           title: "chore: update CLDR plural rules"

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -17,12 +17,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .nvmrc
           cache: 'yarn'
@@ -41,7 +41,7 @@ jobs:
         run: yarn lint:all
 
       - name: Prepare Lingui-Bot git account
-        uses: oleksiyrudenko/gha-git-credentials@v2-latest
+        uses: oleksiyrudenko/gha-git-credentials@8bb1fe6d543b2233ef1856cd3b0181f5abbd4d6a # v2.1.2
         with:
           name: 'Lingui Bot'
           email: 'linguibot@gmail.com'


### PR DESCRIPTION
# Description

Hardens the GitHub Actions supply chain by pinning workflow actions to full commit SHAs while keeping the resolved versions as inline comments. Also limits default `GITHUB_TOKEN` permissions in read-only workflows, enables Yarn Hardened Mode for manual release install steps, and adds Dependabot coverage for monthly GitHub Actions updates.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
