### PR TITLE
fix: provide peer deps for workspace build tools

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,5 +1,6 @@
 catalog:
   "@vitest/coverage-v8": 4.1.5
+  typescript: 5.9.3
   vitest: 4.1.5
   unbuild: 3.6.1
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "size-limit": "^11.1.6",
     "tstyche": "^4.0.0",
     "tsx": "^4.21.0",
-    "typescript": "^5.7.2",
+    "typescript": "catalog:",
     "typescript-eslint": "^8.56.1",
     "vitest": "catalog:"
   },

--- a/packages/babel-plugin-extract-messages/package.json
+++ b/packages/babel-plugin-extract-messages/package.json
@@ -48,6 +48,7 @@
     "@babel/types": "^7.20.7",
     "@lingui/babel-plugin-lingui-macro": "workspace:*",
     "@lingui/test-utils": "workspace:*",
+    "typescript": "catalog:",
     "unbuild": "catalog:",
     "vitest": "catalog:"
   },

--- a/packages/babel-plugin-lingui-macro/package.json
+++ b/packages/babel-plugin-lingui-macro/package.json
@@ -67,6 +67,7 @@
     "babel-plugin-macros": "^3.1.0",
     "babel-plugin-react-compiler": "^1.0.0",
     "prettier": "3.8.1",
+    "typescript": "catalog:",
     "unbuild": "catalog:",
     "vitest": "catalog:"
   },

--- a/packages/conf/package.json
+++ b/packages/conf/package.json
@@ -48,6 +48,7 @@
   "devDependencies": {
     "@lingui/test-utils": "workspace:*",
     "@types/normalize-path": "^3.0.0",
+    "typescript": "catalog:",
     "unbuild": "catalog:",
     "vitest": "catalog:"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -60,6 +60,7 @@
   },
   "devDependencies": {
     "@lingui/test-utils": "workspace:*",
+    "typescript": "catalog:",
     "unbuild": "catalog:",
     "vitest": "catalog:"
   },

--- a/packages/detect-locale/package.json
+++ b/packages/detect-locale/package.json
@@ -45,6 +45,7 @@
   ],
   "devDependencies": {
     "happy-dom": "^20.9.0",
+    "typescript": "catalog:",
     "unbuild": "catalog:",
     "vitest": "catalog:"
   },

--- a/packages/detect-locale/src/detectors/fromCookie.test.ts
+++ b/packages/detect-locale/src/detectors/fromCookie.test.ts
@@ -9,4 +9,13 @@ describe("fromCookie detector", () => {
     expect(fromCookie("CONSENT")).toEqual("YES+ES.es+V11")
     expect(fromCookie("SEARCH_SAMESITE")).toEqual("CgQI3JAB")
   })
+
+  it("should return null when the cookie is missing", () => {
+    Object.defineProperty(window.document, "cookie", {
+      writable: true,
+      value: "CONSENT=YES+ES.es+V11",
+    })
+
+    expect(fromCookie("SEARCH_SAMESITE")).toBeNull()
+  })
 })

--- a/packages/detect-locale/src/detectors/fromCookie.ts
+++ b/packages/detect-locale/src/detectors/fromCookie.ts
@@ -1,6 +1,6 @@
 import { LocaleString } from ".."
 import { getCookie } from "../utils/cookie-getter"
 
-export default function detectFromCookie(key: string): LocaleString {
+export default function detectFromCookie(key: string): LocaleString | null {
   return getCookie(key)
 }

--- a/packages/detect-locale/src/utils/cookie-getter.test.ts
+++ b/packages/detect-locale/src/utils/cookie-getter.test.ts
@@ -9,4 +9,13 @@ describe("getCookie", () => {
     expect(getCookie("CONSENT")).toEqual("YES+ES.es+V11")
     expect(getCookie("SEARCH_SAMESITE")).toEqual("CgQI3JAB")
   })
+
+  it("should return null when the cookie is missing", () => {
+    Object.defineProperty(window.document, "cookie", {
+      writable: true,
+      value: "CONSENT=YES+ES.es+V11",
+    })
+
+    expect(getCookie("SEARCH_SAMESITE")).toBeNull()
+  })
 })

--- a/packages/detect-locale/src/utils/cookie-getter.ts
+++ b/packages/detect-locale/src/utils/cookie-getter.ts
@@ -1,6 +1,6 @@
-export function getCookie(key: string): string {
+export function getCookie(key: string): string | null {
   if (!key) {
-    return
+    return null
   }
 
   // To prevent the for loop in the first place assign an empty array
@@ -8,7 +8,7 @@ export function getCookie(key: string): string {
   const cookies = globalThis.document.cookie
     ? globalThis.document.cookie.split("; ")
     : []
-  const jar = {}
+  const jar: Record<string, string> = {}
   for (let i = 0; i < cookies.length; i++) {
     const parts = cookies[i].split("=")
     let value = parts.slice(1).join("=")
@@ -29,5 +29,5 @@ export function getCookie(key: string): string {
     }
   }
 
-  return key ? jar[key] : jar
+  return jar[key] ?? null
 }

--- a/packages/extractor-vue/package.json
+++ b/packages/extractor-vue/package.json
@@ -49,6 +49,7 @@
   "devDependencies": {
     "@lingui/babel-plugin-extract-messages": "workspace:*",
     "@lingui/core": "workspace:*",
+    "typescript": "catalog:",
     "unbuild": "catalog:",
     "vitest": "catalog:"
   },

--- a/packages/format-csv/package.json
+++ b/packages/format-csv/package.json
@@ -44,6 +44,7 @@
     "papaparse": "^5.4.0"
   },
   "devDependencies": {
+    "typescript": "catalog:",
     "unbuild": "catalog:",
     "vitest": "catalog:"
   },

--- a/packages/format-json/package.json
+++ b/packages/format-json/package.json
@@ -43,6 +43,7 @@
     "@lingui/conf": "workspace:*"
   },
   "devDependencies": {
+    "typescript": "catalog:",
     "unbuild": "catalog:",
     "vitest": "catalog:"
   },

--- a/packages/format-po-gettext/package.json
+++ b/packages/format-po-gettext/package.json
@@ -49,6 +49,7 @@
   },
   "devDependencies": {
     "@lingui/test-utils": "workspace:*",
+    "typescript": "catalog:",
     "unbuild": "catalog:",
     "vitest": "catalog:"
   },

--- a/packages/format-po/package.json
+++ b/packages/format-po/package.json
@@ -47,6 +47,7 @@
     "pofile": "^1.1.4"
   },
   "devDependencies": {
+    "typescript": "catalog:",
     "unbuild": "catalog:",
     "vitest": "catalog:"
   },

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -53,6 +53,7 @@
   "devDependencies": {
     "@lingui/format-json": "workspace:*",
     "jiti": "^2.6.1",
+    "typescript": "catalog:",
     "unbuild": "catalog:",
     "vitest": "catalog:",
     "webpack": "^5.76.1"

--- a/packages/message-utils/package.json
+++ b/packages/message-utils/package.json
@@ -49,6 +49,7 @@
   },
   "devDependencies": {
     "@lingui/test-utils": "workspace:*",
+    "typescript": "catalog:",
     "unbuild": "catalog:",
     "vitest": "catalog:"
   },

--- a/packages/metro-transformer/package.json
+++ b/packages/metro-transformer/package.json
@@ -61,6 +61,7 @@
     "memoize-one": "^6.0.0"
   },
   "devDependencies": {
+    "typescript": "catalog:",
     "unbuild": "catalog:",
     "vitest": "catalog:"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -83,6 +83,7 @@
     "happy-dom": "^20.9.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "typescript": "catalog:",
     "unbuild": "catalog:",
     "vitest": "catalog:"
   }

--- a/packages/remote-loader/package.json
+++ b/packages/remote-loader/package.json
@@ -51,6 +51,7 @@
     "@lingui/message-utils": "workspace:*"
   },
   "devDependencies": {
+    "typescript": "catalog:",
     "unbuild": "catalog:"
   },
   "unbuild": {

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -67,11 +67,14 @@
     }
   },
   "devDependencies": {
+    "@babel/core": "7.29.0",
     "@lingui/babel-plugin-lingui-macro": "workspace:^",
     "@lingui/core": "workspace:^",
     "@lingui/format-json": "workspace:^",
     "@lingui/react": "workspace:^",
     "@rolldown/plugin-babel": "^0.2.2",
+    "rolldown": "1.0.0-rc.17",
+    "typescript": "catalog:",
     "unbuild": "catalog:",
     "vite": "^8.0.3",
     "vite-plugin-babel-macros": "^1.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,7 +23,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:^7.17.7, @babel/core@npm:^7.20.12, @babel/core@npm:^7.21.0, @babel/core@npm:^7.24.4":
+"@babel/core@npm:7.29.0, @babel/core@npm:^7.17.7, @babel/core@npm:^7.20.12, @babel/core@npm:^7.21.0, @babel/core@npm:^7.24.4":
   version: 7.29.0
   resolution: "@babel/core@npm:7.29.0"
   dependencies:
@@ -1513,6 +1513,7 @@ __metadata:
     "@babel/types": "npm:^7.20.7"
     "@lingui/babel-plugin-lingui-macro": "workspace:*"
     "@lingui/test-utils": "workspace:*"
+    typescript: "catalog:"
     unbuild: "catalog:"
     vitest: "catalog:"
   languageName: unknown
@@ -1532,6 +1533,7 @@ __metadata:
     babel-plugin-macros: "npm:^3.1.0"
     babel-plugin-react-compiler: "npm:^1.0.0"
     prettier: "npm:3.8.1"
+    typescript: "catalog:"
     unbuild: "catalog:"
     vitest: "catalog:"
   languageName: unknown
@@ -1586,6 +1588,7 @@ __metadata:
     jiti: "npm:^2.5.1"
     lilconfig: "npm:^3.1.3"
     normalize-path: "npm:^3.0.0"
+    typescript: "catalog:"
     unbuild: "catalog:"
     vitest: "catalog:"
   languageName: unknown
@@ -1598,6 +1601,7 @@ __metadata:
     "@lingui/babel-plugin-lingui-macro": "workspace:*"
     "@lingui/message-utils": "workspace:*"
     "@lingui/test-utils": "workspace:*"
+    typescript: "catalog:"
     unbuild: "catalog:"
     vitest: "catalog:"
   peerDependencies:
@@ -1613,6 +1617,7 @@ __metadata:
   resolution: "@lingui/detect-locale@workspace:packages/detect-locale"
   dependencies:
     happy-dom: "npm:^20.9.0"
+    typescript: "catalog:"
     unbuild: "catalog:"
     vitest: "catalog:"
   languageName: unknown
@@ -1627,6 +1632,7 @@ __metadata:
     "@lingui/conf": "workspace:*"
     "@lingui/core": "workspace:*"
     "@vue/compiler-sfc": "npm:^3.2.47"
+    typescript: "catalog:"
     unbuild: "catalog:"
     vitest: "catalog:"
   languageName: unknown
@@ -1638,6 +1644,7 @@ __metadata:
   dependencies:
     "@lingui/conf": "workspace:*"
     papaparse: "npm:^5.4.0"
+    typescript: "catalog:"
     unbuild: "catalog:"
     vitest: "catalog:"
   languageName: unknown
@@ -1648,6 +1655,7 @@ __metadata:
   resolution: "@lingui/format-json@workspace:packages/format-json"
   dependencies:
     "@lingui/conf": "workspace:*"
+    typescript: "catalog:"
     unbuild: "catalog:"
     vitest: "catalog:"
   languageName: unknown
@@ -1663,6 +1671,7 @@ __metadata:
     "@lingui/test-utils": "workspace:*"
     "@messageformat/parser": "npm:^5.0.0"
     pofile: "npm:^1.1.4"
+    typescript: "catalog:"
     unbuild: "catalog:"
     vitest: "catalog:"
   languageName: unknown
@@ -1675,6 +1684,7 @@ __metadata:
     "@lingui/conf": "workspace:*"
     "@lingui/message-utils": "workspace:*"
     pofile: "npm:^1.1.4"
+    typescript: "catalog:"
     unbuild: "catalog:"
     vitest: "catalog:"
   languageName: unknown
@@ -1688,6 +1698,7 @@ __metadata:
     "@lingui/conf": "workspace:*"
     "@lingui/format-json": "workspace:*"
     jiti: "npm:^2.6.1"
+    typescript: "catalog:"
     unbuild: "catalog:"
     vitest: "catalog:"
     webpack: "npm:^5.76.1"
@@ -1707,6 +1718,7 @@ __metadata:
     "@messageformat/date-skeleton": "npm:^1.1.0"
     "@messageformat/parser": "npm:^5.0.0"
     js-sha256: "npm:^0.10.1"
+    typescript: "catalog:"
     unbuild: "catalog:"
     vitest: "catalog:"
   languageName: unknown
@@ -1719,6 +1731,7 @@ __metadata:
     "@lingui/cli": "workspace:*"
     "@lingui/conf": "workspace:*"
     memoize-one: "npm:^6.0.0"
+    typescript: "catalog:"
     unbuild: "catalog:"
     vitest: "catalog:"
   peerDependencies:
@@ -1752,6 +1765,7 @@ __metadata:
     happy-dom: "npm:^20.9.0"
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
+    typescript: "catalog:"
     unbuild: "catalog:"
     vitest: "catalog:"
   peerDependencies:
@@ -1768,6 +1782,7 @@ __metadata:
   resolution: "@lingui/remote-loader@workspace:packages/remote-loader"
   dependencies:
     "@lingui/message-utils": "workspace:*"
+    typescript: "catalog:"
     unbuild: "catalog:"
   languageName: unknown
   linkType: soft
@@ -1784,6 +1799,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@lingui/vite-plugin@workspace:packages/vite-plugin"
   dependencies:
+    "@babel/core": "npm:7.29.0"
     "@lingui/babel-plugin-lingui-macro": "workspace:^"
     "@lingui/cli": "workspace:*"
     "@lingui/conf": "workspace:*"
@@ -1791,6 +1807,8 @@ __metadata:
     "@lingui/format-json": "workspace:^"
     "@lingui/react": "workspace:^"
     "@rolldown/plugin-babel": "npm:^0.2.2"
+    rolldown: "npm:1.0.0-rc.17"
+    typescript: "catalog:"
     unbuild: "catalog:"
     vite: "npm:^8.0.3"
     vite-plugin-babel-macros: "npm:^1.0.6"
@@ -8585,7 +8603,7 @@ __metadata:
     size-limit: "npm:^11.1.6"
     tstyche: "npm:^4.0.0"
     tsx: "npm:^4.21.0"
-    typescript: "npm:^5.7.2"
+    typescript: "catalog:"
     typescript-eslint: "npm:^8.56.1"
     vitest: "catalog:"
   languageName: unknown
@@ -13608,23 +13626,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:>=3 < 6, typescript@npm:^5.7.2":
-  version: 5.7.2
-  resolution: "typescript@npm:5.7.2"
+"typescript@npm:5.9.3, typescript@npm:>=3 < 6":
+  version: 5.9.3
+  resolution: "typescript@npm:5.9.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/4caa3904df69db9d4a8bedc31bafc1e19ffb7b24fbde2997a1633ae1398d0de5bdbf8daf602ccf3b23faddf1aeeb9b795223a2ed9c9a4fdcaf07bfde114a401a
+  checksum: 10/c089d9d3da2729fd4ac517f9b0e0485914c4b3c26f80dc0cffcb5de1719a17951e92425d55db59515c1a7ddab65808466debb864d0d56dcf43f27007d0709594
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A>=3 < 6#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.7.2#optional!builtin<compat/typescript>":
-  version: 5.7.2
-  resolution: "typescript@patch:typescript@npm%3A5.7.2#optional!builtin<compat/typescript>::version=5.7.2&hash=5786d5"
+"typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A>=3 < 6#optional!builtin<compat/typescript>":
+  version: 5.9.3
+  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/d75ca10141afc64fd3474b41a8b082b640555bed388d237558aed64e5827ddadb48f90932c7f4205883f18f5bcab8b6a739a2cfac95855604b0dfeb34bc2f3eb
+  checksum: 10/696e1b017bc2635f4e0c94eb4435357701008e2f272f553d06e35b494b8ddc60aa221145e286c28ace0c89ee32827a28c2040e3a69bdc108b1a5dc8fb40b72e3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

This MR fixes Yarn peer dependency warnings reported during `yarn install`.

`unbuild@3.6.1` declares `typescript` as an optional peer dependency, but every package that uses `unbuild` must still provide it for Yarn peer validation. The MR adds `typescript` through the shared catalog and wires it into the workspaces that run `unbuild`.

It also adds the missing development peer providers for `@rolldown/plugin-babel` in `@lingui/vite-plugin`: `@babel/core` and `rolldown`.

While upgrading TypeScript to the latest available 5.x version (`5.9.3`), TypeScript surfaced an existing typing issue in `@lingui/detect-locale`: `getCookie` can return no value when the cookie key is empty or missing, but its types claimed it always returns `string`. The fix makes this explicit by returning `null` and updates `fromCookie` to return `LocaleString | null`.

This type fix is potentially breaking for TypeScript users because the previous public type was narrower than the real runtime behavior. However, the new type reflects the actual "not found" case and helps users handle a possible runtime absence instead of assuming a locale string is always present.

## Before

```text
❯ yarn install 
➤ YN0088: A new stable version of Yarn is available: 4.15.0!
➤ YN0088: Upgrade now by running yarn set version 4.15.0

➤ YN0000: · Yarn 4.14.1
➤ YN0000: ┌ Resolution step
➤ YN0000: └ Completed
➤ YN0000: ┌ Post-resolution validation
➤ YN0002: │ @lingui/babel-plugin-extract-messages@workspace:packages/babel-plugin-extract-messages doesn't provide typescript (paa4c54), requested by unbuild.
➤ YN0002: │ @lingui/babel-plugin-lingui-macro@workspace:packages/babel-plugin-lingui-macro doesn't provide typescript (p0f713a), requested by unbuild.
➤ YN0002: │ @lingui/conf@workspace:packages/conf doesn't provide typescript (pa9c453), requested by unbuild.
➤ YN0002: │ @lingui/core@workspace:packages/core [407d5] doesn't provide typescript (pa5d72e), requested by unbuild.
➤ YN0002: │ @lingui/core@workspace:packages/core doesn't provide typescript (pd13b51), requested by unbuild.
➤ YN0002: │ @lingui/detect-locale@workspace:packages/detect-locale doesn't provide typescript (p019dc8), requested by unbuild.
➤ YN0002: │ @lingui/extractor-vue@workspace:packages/extractor-vue doesn't provide typescript (p3c72b9), requested by unbuild.
➤ YN0002: │ @lingui/format-csv@workspace:packages/format-csv doesn't provide typescript (pe30c31), requested by unbuild.
➤ YN0002: │ @lingui/format-json@workspace:packages/format-json doesn't provide typescript (pe987ac), requested by unbuild.
➤ YN0002: │ @lingui/format-po-gettext@workspace:packages/format-po-gettext doesn't provide typescript (pf40939), requested by unbuild.
➤ YN0002: │ @lingui/format-po@workspace:packages/format-po doesn't provide typescript (p26b5fe), requested by unbuild.
➤ YN0002: │ @lingui/loader@workspace:packages/loader doesn't provide typescript (pd9a140), requested by unbuild.
➤ YN0002: │ @lingui/message-utils@workspace:packages/message-utils doesn't provide typescript (p3c410a), requested by unbuild.
➤ YN0002: │ @lingui/metro-transformer@workspace:packages/metro-transformer doesn't provide typescript (p56698d), requested by unbuild.
➤ YN0002: │ @lingui/react@workspace:packages/react [14f17] doesn't provide typescript (p027645), requested by unbuild.
➤ YN0002: │ @lingui/react@workspace:packages/react doesn't provide typescript (p0f88a1), requested by unbuild.
➤ YN0002: │ @lingui/remote-loader@workspace:packages/remote-loader doesn't provide typescript (p991880), requested by unbuild.
➤ YN0002: │ @lingui/vite-plugin@workspace:packages/vite-plugin doesn't provide @babel/core (pa94844), requested by @rolldown/plugin-babel.
➤ YN0002: │ @lingui/vite-plugin@workspace:packages/vite-plugin doesn't provide rolldown (pf8f47d), requested by @rolldown/plugin-babel.
➤ YN0002: │ @lingui/vite-plugin@workspace:packages/vite-plugin doesn't provide typescript (pe20f5a), requested by unbuild.
➤ YN0086: │ Some peer dependencies are incorrectly met by your project; run yarn explain peer-requirements <hash> for details, where <hash> is the six-letter p-prefixed code.
➤ YN0000: └ Completed
➤ YN0000: ┌ Fetch step
➤ YN0000: └ Completed
➤ YN0000: ┌ Link step
➤ YN0000: └ Completed
➤ YN0000: · Done with warnings in 0s 415ms
```

## After

```text
❯ yarn install 
➤ YN0000: · Yarn 4.14.1
➤ YN0000: ┌ Resolution step
➤ YN0000: └ Completed
➤ YN0000: ┌ Fetch step
➤ YN0000: └ Completed
➤ YN0000: ┌ Link step
➤ YN0000: └ Completed
➤ YN0000: · Done in 0s 397ms
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

Fixes #

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)

## Validation

- `yarn install --immutable`
- `yarn lint:types`
- `yarn vitest --run packages/detect-locale/src/utils/cookie-getter.test.ts packages/detect-locale/src/detectors/fromCookie.test.ts`
