### PR TITLE
fix: don't warn about idPrefixLeader in config

### DIFF
--- a/packages/conf/src/makeConfig.ts
+++ b/packages/conf/src/makeConfig.ts
@@ -83,6 +83,7 @@ export const exampleConfig = {
   ...defaultConfig,
   macro: {
     ...defaultConfig.macro,
+    idPrefixLeader: ".",
     jsxPlaceholderAttribute: "_t",
     jsxPlaceholderDefaults: multipleValidOptions(
       {},


### PR DESCRIPTION
# Description

@lingui/conf was complaining about `idPrefixLeader` not being a valid macro option. This PR fixes that.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
