### PR TITLE
docs: refine generated IDs documentation

### DIFF
--- a/website/docs/guides/explicit-vs-generated-ids.md
+++ b/website/docs/guides/explicit-vs-generated-ids.md
@@ -50,6 +50,7 @@ Example:
 - **Avoiding duplicates:** duplicate messages are merged together automatically. Translators will not have to translate the same phrases again and again. This could lead to cost savings, especially if translators charge by word count.
 - **Smaller bundle:** Lingui generates short IDs such as `MbT6FE` which are typically shorter than manually crafted IDs like `index.header.title`. This results in a smaller bundle size, optimizing your application's performance.
 - **Preventing ID collisions:** as your application scales, explicit IDs can potentially lead to conflicts. Lingui's generated IDs help avoid such collisions.
+- **Readability is a non-issue:** even though generated IDs aren't human-readable, you would hardly see them. Translators work with the source string in the catalog, while the IDs remain behind the scenes.
 
 ### Benefits of Explicit IDs
 
@@ -63,17 +64,6 @@ If you use explicit IDs, you can opt in to [Typed Message IDs](/guides/typed-mes
 :::
 
 The choice between these two strategies depends on your project requirements and priorities. However, it's important to note that Lingui provides the full range of benefits, especially with generated IDs.
-
-:::note
-You don't have to worry about the readability of the IDs because you would hardly see them. When extracted into a PO file, translators would see the source string and its corresponding translation, while the IDs remain behind the scenes:
-
-```gettext
-#: src/App.tsx:1
-msgid "Lingui example"
-msgstr "Lingui przyklad"
-```
-
-:::
 
 ## Context
 
@@ -178,6 +168,10 @@ import { msg } from "@lingui/core/macro";
 
 msg`Hello World`;
 ```
+
+:::tip
+Enforce generated IDs with the Lingui [ESLint Plugin](/ref/eslint-plugin) rule [`require-implicit-id`](https://github.com/lingui/eslint-plugin/blob/main/docs/rules/require-implicit-id.md).
+:::
 
 ## Using Explicit IDs
 


### PR DESCRIPTION
# Description

Improves consistency and reduces clutter in the "Explicit vs Generated IDs" guide:

- Add ESLint rule recommendation for generated IDs — the guide now points to the [require-implicit-id](https://github.com/lingui/eslint-plugin/blob/main/docs/rules/require-implicit-id.md) rule in the "Using Generated IDs" section, mirroring the existing `require-explicit-id` tip in the "Using Explicit IDs" section. Both approaches now consistently document their enforcement rule.
- Move the readability point into the benefits comparison — replaced the standalone note (and its PO/gettext example) with a concise "Readability is a non-issue" bullet under Benefits of Generated IDs, where the readability trade-off is actually discussed. This declutters the usage section and keeps the comparison balanced.
## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Examples update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
