### PR TITLE
chore: update vanilla js example to lingui v6

### DIFF
--- a/examples/js/package.json
+++ b/examples/js/package.json
@@ -12,13 +12,13 @@
     "extract": "lingui extract --clean"
   },
   "dependencies": {
-    "@lingui/core": "^5.0.0-next.3"
+    "@lingui/core": "^6.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.12",
     "@babel/preset-env": "^7.20.2",
-    "@lingui/babel-plugin-lingui-macro": "^5.0.0-next.3",
-    "@lingui/cli": "^5.0.0-next.3",
+    "@lingui/babel-plugin-lingui-macro": "^6.0.0",
+    "@lingui/cli": "^6.0.0",
     "jest": "^29.5.0"
   }
 }


### PR DESCRIPTION
## Problem

The vanilla JavaScript example still referenced Lingui v5 prerelease packages, while issue #2526 tracks moving examples to Lingui v6.

## Solution

Updated the vanilla JavaScript example's Lingui runtime, CLI, and Babel macro plugin dependencies to the v6 line used by the already-migrated examples.

## Testing

Inspected the example package.json and compared the dependency pattern with the v6 Next.js/Babel example through the GitHub web UI. I could not run package installation or tests because this run is limited to Chrome-only browser edits.