### PR TITLE
fix: respect corePackage/jsxPackage setting in experimental extractor

### DIFF
--- a/packages/cli/src/extract-experimental/linguiEsbuildPlugin.ts
+++ b/packages/cli/src/extract-experimental/linguiEsbuildPlugin.ts
@@ -10,44 +10,57 @@ import { LinguiConfigNormalized } from "@lingui/conf"
 
 export const pluginLinguiMacro = (options: {
   linguiConfig: LinguiConfigNormalized
-}): Plugin => ({
-  name: "linguiMacro",
-  setup(build) {
-    build.onLoad({ filter: babelRe, namespace: "" }, async (args) => {
-      const filename = path.relative(process.cwd(), args.path)
+}): Plugin => {
+  const configuredPackages = [
+    ...new Set([
+      "@lingui/macro",
+      "@lingui/core/macro",
+      "@lingui/react/macro",
+      ...options.linguiConfig.macro.corePackage,
+      ...options.linguiConfig.macro.jsxPackage,
+    ]),
+  ].map((str) => str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+  const hasMacroRe = new RegExp(
+    `from\\s*(["'])(?:${configuredPackages.join("|")})\\1`,
+  )
 
-      const contents = await fs.promises.readFile(args.path, "utf8")
+  return {
+    name: "linguiMacro",
+    setup(build) {
+      build.onLoad({ filter: babelRe, namespace: "" }, async (args) => {
+        const filename = path.relative(process.cwd(), args.path)
 
-      const hasMacroRe = /from ["']@lingui(\/.+)?\/macro["']/g
+        const contents = await fs.promises.readFile(args.path, "utf8")
 
-      if (!hasMacroRe.test(contents)) {
-        // let esbuild process file as usual
-        return undefined
-      }
+        if (!hasMacroRe.test(contents)) {
+          // let esbuild process file as usual
+          return undefined
+        }
 
-      const result = await transformAsync(contents, {
-        babelrc: false,
-        configFile: false,
+        const result = await transformAsync(contents, {
+          babelrc: false,
+          configFile: false,
 
-        filename: filename,
+          filename: filename,
 
-        sourceMaps: "inline",
-        parserOpts: {
-          plugins: getBabelParserOptions(filename, {}),
-        },
+          sourceMaps: "inline",
+          parserOpts: {
+            plugins: getBabelParserOptions(filename, {}),
+          },
 
-        plugins: [
-          [
-            linguiMacroPlugin,
-            {
-              descriptorFields: "all",
-              linguiConfig: options.linguiConfig,
-            } satisfies LinguiPluginOpts,
+          plugins: [
+            [
+              linguiMacroPlugin,
+              {
+                descriptorFields: "all",
+                linguiConfig: options.linguiConfig,
+              } satisfies LinguiPluginOpts,
+            ],
           ],
-        ],
-      })
+        })
 
-      return { contents: result!.code!, loader: "tsx" }
-    })
-  },
-})
+        return { contents: result!.code!, loader: "tsx" }
+      })
+    },
+  }
+}

--- a/packages/cli/test/extractor-experimental-custom-macro/expected/index.page.en.po
+++ b/packages/cli/test/extractor-experimental-custom-macro/expected/index.page.en.po
@@ -1,0 +1,20 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2023-03-15 10:00+0000\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: en\n"
+
+#: fixtures/pages/index.page.tsx:5
+msgid "Goodbye from a custom macro package"
+msgstr "Goodbye from a custom macro package"
+
+#: fixtures/pages/index.page.tsx:3
+msgid "Hello from a custom macro package"
+msgstr "Hello from a custom macro package"
+
+#: fixtures/pages/index.page.tsx:9
+msgid "Rendered through a custom macro package"
+msgstr "Rendered through a custom macro package"

--- a/packages/cli/test/extractor-experimental-custom-macro/fixtures/pages/index.page.tsx
+++ b/packages/cli/test/extractor-experimental-custom-macro/fixtures/pages/index.page.tsx
@@ -1,0 +1,10 @@
+import { Trans, msg, t } from "#macros"
+
+const greeting = t`Hello from a custom macro package`
+
+const farewell = msg`Goodbye from a custom macro package`
+
+export function Page() {
+  console.log(greeting, farewell)
+  return <Trans>Rendered through a custom macro package</Trans>
+}

--- a/packages/cli/test/extractor-experimental-custom-macro/lingui.config.ts
+++ b/packages/cli/test/extractor-experimental-custom-macro/lingui.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from "@lingui/conf"
+
+export default defineConfig({
+  locales: ["en"],
+  sourceLocale: "en",
+
+  catalogs: [],
+  macro: {
+    // The macros are imported through the local `#macros` barrel rather than
+    // directly from `@lingui/*/macro`, so the barrel must be declared here.
+    corePackage: ["@lingui/core/macro", "#macros"],
+    jsxPackage: ["@lingui/react/macro", "#macros"],
+  },
+  experimental: {
+    extractor: {
+      entries: ["<rootDir>/fixtures/pages/**/*.page.{ts,tsx}"],
+      output: "<rootDir>/actual/{entryName}.{locale}",
+    },
+  },
+})

--- a/packages/cli/test/extractor-experimental-custom-macro/macros.ts
+++ b/packages/cli/test/extractor-experimental-custom-macro/macros.ts
@@ -1,0 +1,6 @@
+// A local barrel that re-exports the Lingui macros, imported by app code
+// through the `#macros` subpath. Files importing from here must still be picked
+// up by the experimental extractor when the package is listed in
+// `macro.corePackage` / `macro.jsxPackage`.
+export * from "@lingui/core/macro"
+export * from "@lingui/react/macro"

--- a/packages/cli/test/extractor-experimental-custom-macro/package.json
+++ b/packages/cli/test/extractor-experimental-custom-macro/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "extractor-experimental-custom-macro",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "imports": {
+    "#macros": "./macros.ts"
+  },
+  "dependencies": {
+    "@lingui/core": "*",
+    "@lingui/react": "*",
+    "@lingui/conf": "*"
+  }
+}

--- a/packages/cli/test/index.test.ts
+++ b/packages/cli/test/index.test.ts
@@ -429,6 +429,39 @@ describe("E2E Extractor Test", () => {
 
       compareFolders(actualPath, expectedPath)
     })
+
+    it("should extract messages imported from a configured custom macro package", async () => {
+      const { rootDir, actualPath, expectedPath } = await prepare(
+        "extractor-experimental-custom-macro",
+      )
+
+      await mockConsole(async (console) => {
+        const config = getConfig({ cwd: rootDir })
+
+        const result = await extractExperimentalCommand(config, {
+          workersOptions: {
+            poolSize: 0,
+          },
+        })
+
+        expect(getConsoleMockCalls(console.error)).toBeFalsy()
+        expect(result).toBeTruthy()
+        expect(replaceDuration(getConsoleMockCalls(console.log)))
+          .toMatchInlineSnapshot(`
+            You have using an experimental feature
+            Experimental features are not covered by semver, and may cause unexpected or broken application behavior. Use at your own risk.
+
+            Catalog statistics for fixtures/pages/index.page.tsx:
+            ┌─────────────┬─────────────┬─────────┐
+            │ Language    │ Total count │ Missing │
+            ├─────────────┼─────────────┼─────────┤
+            │ en (source) │      3      │    -    │
+            └─────────────┴─────────────┴─────────┘
+          `)
+      })
+
+      compareFolders(actualPath, expectedPath)
+    })
   })
 
   it("should extract consistently with files argument", async () => {


### PR DESCRIPTION
# Description

This PR updates the experimental extractor (`lingui extract-experimental`) to respect the `macro.corePackage` / `macro.jsxPackage` settings.

Up until now it only considers files that import directly from `@lingui/*/macro` for extraction using a hardcoded regex (`/from ["']@lingui(\/.+)?\/macro["']/`).

## Fix

The pre-filter is now built from the configured macro packages (`macro.corePackage` + `macro.jsxPackage`) in addition to the built-in `@lingui/*/macro` entrypoints (kept for backwards compatibility, so the default config and the legacy `@lingui/macro` package keep working even when a project overrides `corePackage`/`jsxPackage`). The regex is also built once per plugin instance instead of per file, which removes a latent `RegExp`-with-`/g` + `.test()` `lastIndex` statefulness bug.

## Tests

Added an integration test `should extract messages imported from a configured custom macro package` with a new fixture (`packages/cli/test/extractor-experimental-custom-macro`) that imports `t`, `msg` and `<Trans>` through a `#macros` subpath barrel declared in `macro.corePackage` / `macro.jsxPackage`, and asserts all three messages are extracted. The test fails on `main` (no messages extracted) and passes with this change. Existing `extractor-experimental` tests continue to pass, covering the backwards-compatible default behavior.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
