### PR TITLE
fix: don't warn about missing id when a spread is present

### DIFF
--- a/packages/babel-plugin-extract-messages/src/index.ts
+++ b/packages/babel-plugin-extract-messages/src/index.ts
@@ -252,6 +252,15 @@ export default function ({ types: t }: { types: BabelTypes }): PluginObj {
     const props = extractFromObjectExpression(t, path.node, ctx.file.hub)
 
     if (!props.id) {
+      // The id may be provided by a spread element (e.g. `i18n._({ ...msg })`),
+      // which can't be resolved statically. Skip silently instead of warning.
+      const hasSpread = path.node.properties.some((prop) =>
+        t.isSpreadElement(prop),
+      )
+      if (hasSpread) {
+        return
+      }
+
       console.warn(
         path.buildCodeFrameError("Missing message ID, skipping.").message,
       )

--- a/packages/babel-plugin-extract-messages/test/extract-messages.test.ts
+++ b/packages/babel-plugin-extract-messages/test/extract-messages.test.ts
@@ -324,6 +324,20 @@ import { MyTrans } from "@my/lingui"
         expect(messages[0]).toMatchObject({ id: "x", message: "translation" })
       })
     })
+
+    it("Should not warn when id could be provided via spread", () => {
+      const code = `
+      const lookup = { x: {}, generic: {} };
+      i18n._({
+        ...(lookup.x ?? lookup.generic),
+        values: { val: "test" },
+      });
+      `
+      expectNoConsole(() => {
+        const messages = transformCode(code)
+        expect(messages).toHaveLength(0)
+      })
+    })
   })
 
   describe("StringLiteral", () => {


### PR DESCRIPTION
# Description

Code like below currently triggers a "Missing message ID, skipping" warning on `lingui extract`, even though it works and is a decent workaround to use placeholders in lazy lookups:

```ts
const lookup = {
  x: msg`x {val}`,
  generic: msg`generic {val}`,
}

function X() {
  const { i18n } = useI18n()
  return i18n._({
    ...(lookup.x ?? lookup.generic),
    values: { val: 'test' },
  })
}
```

I'd like to propose that we stop reporting missing IDs when a spread is also present in the object passed to the `i18n._` call.

If this is accepted I'll happily provide patches for the experimental extractor along with the SWC extractor.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
