### PR TITLE
feat: define strings with generated ids using `/* i18n-s */` comments

### DIFF
--- a/packages/babel-plugin-extract-messages/package.json
+++ b/packages/babel-plugin-extract-messages/package.json
@@ -43,7 +43,8 @@
     "node": ">=22.19.0"
   },
   "dependencies": {
-    "@lingui/conf": "workspace:*"
+    "@lingui/conf": "workspace:*",
+    "@lingui/message-utils": "workspace:*"
   },
   "devDependencies": {
     "@babel/core": "^7.29.0",

--- a/packages/babel-plugin-extract-messages/src/index.ts
+++ b/packages/babel-plugin-extract-messages/src/index.ts
@@ -14,6 +14,7 @@ import {
   getConfig as loadConfig,
   type LinguiConfigNormalized,
 } from "@lingui/conf"
+import { generateMessageId } from "@lingui/message-utils/generateMessageId"
 
 type BabelTypes = typeof BabelTypesNamespace
 
@@ -202,12 +203,21 @@ function hasIgnoreComment(node: Node): boolean {
   return hasComment(node, "lingui-extract-ignore")
 }
 
-function hasI18nComment(node: Node): boolean {
-  return !!node.leadingComments?.some((comm) => {
-    const trimmed = comm.value.trim()
+const I18N_COMMENT_MARKS = ["i18n", "* i18n", "*i18n"] as const
+const I18N_STRING_COMMENT_MARKS = ["i18n-s", "* i18n-s", "*i18n-s"] as const
 
-    return trimmed === "i18n" || trimmed === "* i18n" || trimmed === "*i18n"
-  })
+function hasMarkComment(node: Node, marks: readonly string[]): boolean {
+  return !!node.leadingComments?.some((comm) =>
+    marks.includes(comm.value.trim()),
+  )
+}
+
+function hasI18nComment(node: Node): boolean {
+  return hasMarkComment(node, I18N_COMMENT_MARKS)
+}
+
+function hasI18nStringComment(node: Node): boolean {
+  return hasMarkComment(node, I18N_STRING_COMMENT_MARKS)
 }
 
 function getLinguiConfig(ctx: PluginPass): LinguiConfigNormalized {
@@ -349,7 +359,10 @@ export default function ({ types: t }: { types: BabelTypes }): PluginObj {
         // i18n._(/**i18n*/ {descriptor})
         // skipping this as it is processed
         // by ObjectExpression visitor
-        if (hasI18nComment(firstArgument.node)) {
+        if (
+          hasI18nComment(firstArgument.node) ||
+          hasI18nStringComment(firstArgument.node)
+        ) {
           return
         }
 
@@ -395,20 +408,25 @@ export default function ({ types: t }: { types: BabelTypes }): PluginObj {
       },
 
       StringLiteral(path, ctx) {
-        if (!hasI18nComment(path.node)) {
+        const isExplicitId = hasI18nComment(path.node)
+        const isStringMessage = hasI18nStringComment(path.node)
+
+        if (!isExplicitId && !isStringMessage) {
           return
         }
 
-        const props = {
-          id: path.node.value,
-        }
+        const message = path.node.value
 
-        if (!props.id) {
+        if (!message) {
           console.warn(
             path.buildCodeFrameError("Empty StringLiteral, skipping.").message,
           )
           return
         }
+
+        const props = isStringMessage
+          ? { id: generateMessageId(message), message }
+          : { id: message }
 
         collectMessage(path, props, ctx)
       },

--- a/packages/babel-plugin-extract-messages/test/extract-messages.test.ts
+++ b/packages/babel-plugin-extract-messages/test/extract-messages.test.ts
@@ -7,6 +7,7 @@ import linguiMacroPlugin, {
   type LinguiPluginOpts,
 } from "@lingui/babel-plugin-lingui-macro"
 import { getConfig } from "@lingui/conf"
+import { generateMessageId } from "@lingui/message-utils/generateMessageId"
 
 const transform = (filename: string) => {
   const rootDir = path.join(__dirname, "fixtures")
@@ -350,6 +351,48 @@ import { MyTrans } from "@my/lingui"
         expect(console.warn).toBeCalledWith(
           expect.stringContaining(`Empty StringLiteral`),
         )
+      })
+    })
+
+    it("Should extract from marked StringLiteral with generated id (i18n-s)", () => {
+      const code = `const t = /* i18n-s */'Message'`
+
+      expectNoConsole(() => {
+        const messages = transformCode(code)
+
+        expect(messages[0]).toMatchObject({
+          id: generateMessageId("Message"),
+          message: "Message",
+        })
+      })
+    })
+
+    it("Should support /*i18n-s*/ and /** i18n-s */ and /**i18n-s*/ mark formats", () => {
+      expectNoConsole(() => {
+        const blockFormat = transformCode(
+          `const a = /*i18n-s*/ 'Old format'`,
+        )
+        expect(blockFormat).toHaveLength(1)
+        expect(blockFormat[0]).toMatchObject({
+          id: generateMessageId("Old format"),
+          message: "Old format",
+        })
+
+        const jsdocFormat = transformCode(
+          `const b = /** i18n-s */ 'New format'`,
+        )
+        expect(jsdocFormat).toHaveLength(1)
+        expect(jsdocFormat[0]).toMatchObject({
+          id: generateMessageId("New format"),
+          message: "New format",
+        })
+
+        const noSpaces = transformCode(`const c = /**i18n-s*/ 'No spaces'`)
+        expect(noSpaces).toHaveLength(1)
+        expect(noSpaces[0]).toMatchObject({
+          id: generateMessageId("No spaces"),
+          message: "No spaces",
+        })
       })
     })
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1925,6 +1925,7 @@ __metadata:
     "@babel/types": "npm:^7.29.0"
     "@lingui/babel-plugin-lingui-macro": "workspace:*"
     "@lingui/conf": "workspace:*"
+    "@lingui/message-utils": "workspace:*"
     "@lingui/test-utils": "workspace:*"
     typescript: "catalog:"
     unbuild: "catalog:"


### PR DESCRIPTION
# Description

Adds a new `/* i18n-s */` comment marker for extracting bare string literals with **generated message IDs**.

This is the first step in the epic to allow using Lingui in pure JS scripts, without macros at all. The next step is introduce a function that accepts the string and the variables, and converts the string to the generated id on the fly, an example of such function is here: https://github.com/lingui/js-lingui/discussions/2468#discussioncomment-17289094 

A use case for this is different scripts that should be in purge JS or TS without macro usage. There are many of them in my project, in addition to the main app, that supports macros pretty well. Just need to add support for translating strings to such scripts, to not use in them completely another translation package, but reuse the same approach.

Lingui already supports explicit message marking via `/* i18n */` on string literals, where the literal value becomes the message ID and the PO formatter flags it as `js-lingui-explicit-id`. There was no comment-based equivalent for the default generated-ID workflow — users had to use macros (`msg`, `defineMessage`, etc.) instead.

With `/* i18n-s */`, a plain string can be marked for extraction while keeping standard generated-ID behavior:

```js
const label = /* i18n-s */ 'Save'
// → id: generateMessageId("Save"), message: "Save"
```

This produces a regular catalog entry (no `js-lingui-explicit-id` flag), consistent with macro-extracted messages. The existing `/* i18n */` behavior is unchanged.

Implementation is in `@lingui/babel-plugin-extract-messages`: comment detection was refactored into a shared helper with separate mark sets for explicit (`i18n`) and string (`i18n-s`) annotations. The `StringLiteral` visitor branches on comment type — `i18n-s` uses `generateMessageId()` from `@lingui/message-utils`. All standard comment formats are supported (`/* i18n-s */`, `/*i18n-s*/`, `/** i18n-s */`, `/**i18n-s*/`).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

Fixes #2468 (first part)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)