### PR TITLE
chore(dependabot): group monthly dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 3
     groups:
       github-actions:
         patterns:
@@ -17,6 +19,8 @@ updates:
       - "/packages/*"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 3
     exclude-paths:
       - "test/**"
       - "examples/**"
@@ -38,6 +42,8 @@ updates:
     directory: "/website"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 3
     ignore:
       - dependency-name: "*"
         update-types:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,5 +4,50 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     commit-message:
       prefix: "ci"
+
+  - package-ecosystem: "npm"
+    directories:
+      - "/"
+      - "/packages/*"
+    schedule:
+      interval: "monthly"
+    exclude-paths:
+      - "test/**"
+      - "examples/**"
+      - "website/**"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+    groups:
+      root-and-package-dev-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+    commit-message:
+      prefix: "chore"
+
+  - package-ecosystem: "npm"
+    directory: "/website"
+    schedule:
+      interval: "monthly"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+    groups:
+      website-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    commit-message:
+      prefix: "chore"


### PR DESCRIPTION
# Description

This updates Dependabot to run monthly grouped updates while preserving security update coverage.

- Website npm updates group both dependencies and devDependencies, minor/patch only.
- Root and package npm updates group devDependencies, minor/patch only.
- npm major updates are ignored.
- GitHub Actions updates are grouped into one monthly PR.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

Fixes # N/A

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)

Validation performed:

- Parsed `.github/dependabot.yml` as YAML locally.
- Ran `git diff --check`.
