### PR TITLE
chore(dependabot): limit package updates to dev dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,8 @@ updates:
       - "test/**"
       - "examples/**"
       - "website/**"
+    allow:
+      - dependency-type: "development"
     ignore:
       - dependency-name: "*"
         update-types:


### PR DESCRIPTION
# Description

Limit Dependabot npm updates for the root and package workspaces to devDependencies only.

@andrii-bodnar  Sorry, I missed this field in the previous PR: [lingui/js-lingui#2595](https://github.com/lingui/js-lingui/pull/2595).

This avoids routine version update PRs for production dependencies outside the website package.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

Fixes # N/A

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
