### PR TITLE
fix(react): fallback to Object.create when Proxy is unavailable

### DIFF
--- a/packages/react/src/I18nProvider.test.tsx
+++ b/packages/react/src/I18nProvider.test.tsx
@@ -262,4 +262,54 @@ describe("I18nProvider", () => {
 
     expect(getByTestId("locale").textContent).toBe("cs")
   })
+
+  it("works on engines without Proxy support (fallback to Object.create)", () => {
+    // Simulate an engine without Proxy (embedded WebViews, older smart-TV
+    // browsers). Proxy cannot be polyfilled, so the provider must not
+    // depend on it unconditionally. Assertions observe values through a
+    // probe component rather than DOM queries, because the test DOM
+    // implementation itself needs Proxy for querySelectorAll.
+    const OriginalProxy = globalThis.Proxy
+    const observedLocales: string[] = []
+
+    delete (globalThis as any).Proxy
+    try {
+      const i18n = setupI18n({
+        locale: "en",
+        messages: {
+          en: {},
+          cs: {},
+        },
+      })
+
+      const ComponentWithMemoizedI18n = () => {
+        const { i18n } = useLingui()
+
+        const getLocale = useCallback(
+          (i18nInstance: I18n) => i18nInstance.locale,
+          [],
+        )
+        const currentLocale = useMemo(() => getLocale(i18n), [getLocale, i18n])
+
+        observedLocales.push(currentLocale)
+        return null
+      }
+
+      render(
+        <I18nProvider i18n={i18n}>
+          <ComponentWithMemoizedI18n />
+        </I18nProvider>,
+      )
+
+      act(() => {
+        i18n.activate("cs")
+      })
+    } finally {
+      globalThis.Proxy = OriginalProxy
+    }
+
+    // the context still exposes a fresh i18n reference on each update, so
+    // memoized values keyed on `i18n` are correctly invalidated
+    expect(observedLocales).toEqual(["en", "cs"])
+  })
 })

--- a/packages/react/src/I18nProvider.tsx
+++ b/packages/react/src/I18nProvider.tsx
@@ -57,10 +57,15 @@ export const I18nProvider = ({
    *
    * We wrap `i18n` in a Proxy to create a new reference on each context update.
    * This ensures React correctly invalidates memoized values that depend on `i18n`.
+   * On engines without Proxy support (e.g. embedded WebViews, older smart-TV
+   * browsers), we fallback to `Object.create` — reads still delegate to the
+   * i18n instance and the reference is fresh; Proxy cannot be polyfilled, so
+   * without the fallback the provider would crash on mount.
    */
   const makeContext = useCallback(
     () => ({
-      i18n: new Proxy(i18n, {}),
+      i18n:
+        typeof Proxy === "function" ? new Proxy(i18n, {}) : Object.create(i18n),
       defaultComponent,
       _: i18n.t.bind(i18n),
     }),


### PR DESCRIPTION
# Description

`I18nProvider` wraps `i18n` in an empty-handler `Proxy` solely to create a fresh reference on each context update, so that memoized values keyed on `i18n` invalidate correctly. On engines without `Proxy` (embedded WebViews, older smart-TV browsers) this crashes the provider on mount with `ReferenceError: Proxy is not defined` — and `Proxy` cannot be polyfilled, so affected apps have no userland workaround.

This PR uses a fallback to `Object.create(i18n)` when `Proxy` is missing: the reference is still fresh on every update and property reads still delegate to the i18n instance, so the memo-invalidation contract is preserved. Engines with `Proxy` support are byte-for-byte unaffected.

Includes a regression test that simulates a Proxy-less engine (deletes `globalThis.Proxy` around render/update) and verifies memoized values keyed on `i18n` still update on locale change. The test fails with `ReferenceError: Proxy is not defined` against the previous implementation.

Fixes #2609

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
