### PR TITLE
fix(react): use sync external store for i18n provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     },
     {
       "path": "./packages/react/dist/index.mjs",
-      "limit": "1.5 kB",
+      "limit": "2 kB",
       "ignore": [
         "react"
       ]

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -70,13 +70,15 @@
   },
   "dependencies": {
     "@lingui/babel-plugin-lingui-macro": "workspace:*",
-    "@lingui/core": "workspace:*"
+    "@lingui/core": "workspace:*",
+    "use-sync-external-store": "^1.6.0"
   },
   "devDependencies": {
     "@lingui/test-utils": "workspace:*",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",
     "@types/react": "^18.2.13",
+    "@types/use-sync-external-store": "^1.5.0",
     "eslint": "^9.39.3",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",

--- a/packages/react/src/I18nProvider.test.tsx
+++ b/packages/react/src/I18nProvider.test.tsx
@@ -4,6 +4,7 @@ import { act, render } from "@testing-library/react"
 import { I18nProvider, useLingui } from "./I18nProvider"
 import { I18n, setupI18n } from "@lingui/core"
 import { useMemo, useCallback } from "react"
+import type { TransRenderProps } from "./TransNoContext"
 
 describe("I18nProvider", () => {
   it(
@@ -133,7 +134,7 @@ describe("I18nProvider", () => {
   })
 
   it(
-    "given 'en' locale, if activate('cs') call happens before i18n.on-change subscription in useEffect(), " +
+    "given 'en' locale, if activate('cs') call happens before i18n.on-change subscription is established, " +
       "I18nProvider detects that it's stale and re-renders with the 'cs' locale value",
     () => {
       const i18n = setupI18n({
@@ -152,7 +153,7 @@ describe("I18nProvider", () => {
        * Note that we're doing exactly what the description says:
        * but to simulate the equivalent situation, we pass our own mock subscriber
        * to i18n.on("change", ...) and in it we call i18n.activate("cs") ourselves
-       * so that the condition in useEffect() is met and the component re-renders
+       * so that the stale snapshot condition is met and the component re-renders
        * */
       const mockSubscriber = vi.fn(() => {
         i18n.load("cs", {})
@@ -225,6 +226,79 @@ describe("I18nProvider", () => {
     })
 
     expect(getByText("Ahoj světe")).toBeTruthy()
+  })
+
+  it("updates translations when active locale messages change", () => {
+    const greetingId = "greeting"
+    const i18n = setupI18n({
+      locale: "en",
+      messages: {
+        en: {
+          [greetingId]: "Hello World",
+        },
+      },
+    })
+
+    const Component = () => {
+      const { _ } = useLingui()
+      return <div>{_(greetingId)}</div>
+    }
+
+    const { getByText } = render(
+      <I18nProvider i18n={i18n}>
+        <Component />
+      </I18nProvider>,
+    )
+
+    expect(getByText("Hello World")).toBeTruthy()
+
+    act(() => {
+      i18n.load("en", {
+        [greetingId]: "Hi World",
+      })
+    })
+
+    expect(getByText("Hi World")).toBeTruthy()
+  })
+
+  it("exposes defaultComponent through context and updates it when the prop changes", () => {
+    const i18n = setupI18n({
+      locale: "en",
+      messages: { en: {} },
+    })
+
+    const DefaultA: React.ComponentType<TransRenderProps> = () => (
+      <span>default-A</span>
+    )
+    const DefaultB: React.ComponentType<TransRenderProps> = () => (
+      <span>default-B</span>
+    )
+
+    const Consumer = () => {
+      const { defaultComponent: DefaultComponent } = useLingui()
+      return DefaultComponent ? (
+        <DefaultComponent id="x" translation="x">
+          x
+        </DefaultComponent>
+      ) : null
+    }
+
+    const { getByText, rerender } = render(
+      <I18nProvider i18n={i18n} defaultComponent={DefaultA}>
+        <Consumer />
+      </I18nProvider>,
+    )
+
+    expect(getByText("default-A")).toBeTruthy()
+
+    // Changing only `defaultComponent` (same i18n) must propagate to consumers.
+    rerender(
+      <I18nProvider i18n={i18n} defaultComponent={DefaultB}>
+        <Consumer />
+      </I18nProvider>,
+    )
+
+    expect(getByText("default-B")).toBeTruthy()
   })
 
   it("keeps memoized useLingui().i18n locale in sync on locale change", () => {

--- a/packages/react/src/I18nProvider.tsx
+++ b/packages/react/src/I18nProvider.tsx
@@ -1,18 +1,14 @@
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useRef,
-  useState,
-} from "react"
+import { createContext, useContext, useMemo } from "react"
+import { useSyncExternalStore } from "use-sync-external-store/shim"
 import type { I18n } from "@lingui/core"
 import type { TransRenderProps } from "./TransNoContext"
+
+export type I18nDefaultComponent = React.ComponentType<TransRenderProps>
 
 export type I18nContext = {
   i18n: I18n
   _: I18n["_"]
-  defaultComponent?: React.ComponentType<TransRenderProps>
+  defaultComponent?: I18nDefaultComponent
 }
 
 export type I18nProviderProps = Omit<I18nContext, "_"> & {
@@ -38,36 +34,65 @@ export function useLingui(): I18nContext {
   return useLinguiInternal()
 }
 
+/**
+ * We can't pass the `i18n` object directly through context, because even when
+ * locale or messages change, the i18n object keeps the same reference. Context
+ * providers compare reference identity, so we create a fresh wrapper object for
+ * each context update. See https://reactjs.org/docs/context.html#caveats.
+ *
+ * We wrap `i18n` in a Proxy to create a new reference on each context update.
+ * This ensures React correctly invalidates memoized values that depend on `i18n`.
+ */
+const getI18nContext = (
+  i18n: I18n,
+  defaultComponent?: I18nDefaultComponent,
+): I18nContext => ({
+  i18n: new Proxy(i18n, {}),
+  defaultComponent,
+  _: i18n.t.bind(i18n),
+})
+
+const createI18nStore = (
+  i18n: I18n,
+  defaultComponent?: I18nDefaultComponent,
+) => {
+  let latestLocale = i18n.locale
+  let context = getI18nContext(i18n, defaultComponent)
+
+  const updateContext = () => {
+    latestLocale = i18n.locale
+    context = getI18nContext(i18n, defaultComponent)
+  }
+
+  const getSnapshot = () => {
+    if (latestLocale !== i18n.locale) {
+      updateContext()
+    }
+
+    return context
+  }
+
+  const subscribe = (onStoreChange: () => void) =>
+    i18n.on("change", () => {
+      updateContext()
+      onStoreChange()
+    })
+
+  return {
+    getSnapshot,
+    subscribe,
+  }
+}
+
 export const I18nProvider = ({
   i18n,
   defaultComponent,
   children,
 }: I18nProviderProps) => {
-  const latestKnownLocale = useRef<string | null>(i18n.locale || null)
-  /**
-   * We can't pass `i18n` object directly through context, because even when locale
-   * or messages are changed, i18n object is still the same. Context provider compares
-   * reference identity and suggested workaround is to create a wrapper object every time
-   * we need to trigger re-render. See https://reactjs.org/docs/context.html#caveats.
-   *
-   * Due to this effect we also pass `defaultComponent` in the same context, instead
-   * of creating a separate Provider/Consumer pair.
-   *
-   * We can't use useMemo hook either, because we want to recalculate value manually.
-   *
-   * We wrap `i18n` in a Proxy to create a new reference on each context update.
-   * This ensures React correctly invalidates memoized values that depend on `i18n`.
-   */
-  const makeContext = useCallback(
-    () => ({
-      i18n: new Proxy(i18n, {}),
-      defaultComponent,
-      _: i18n.t.bind(i18n),
-    }),
+  const store = useMemo(
+    () => createI18nStore(i18n, defaultComponent),
     [i18n, defaultComponent],
   )
-
-  const [context, setContext] = useState<I18nContext>(makeContext)
 
   /**
    * Subscribe for locale/message changes
@@ -76,24 +101,13 @@ export const I18nProvider = ({
    * data (active locale, catalogs). When new messages are loaded or locale is changed
    * we need to trigger re-rendering of LinguiContext.Consumers.
    */
-  useEffect(() => {
-    const updateContext = () => {
-      latestKnownLocale.current = i18n.locale || null
-      setContext(makeContext())
-    }
-    const unsubscribe = i18n.on("change", updateContext)
+  const context = useSyncExternalStore(
+    store.subscribe,
+    store.getSnapshot,
+    store.getSnapshot,
+  )
 
-    /**
-     * unlikely, but if the locale changes before the onChange listener
-     * was added, we need to trigger a rerender
-     * */
-    if (latestKnownLocale.current !== i18n.locale) {
-      updateContext()
-    }
-    return unsubscribe
-  }, [i18n, makeContext])
-
-  if (latestKnownLocale.current === null) {
+  if (!context.i18n.locale) {
     process.env.NODE_ENV === "development" &&
       console.log(
         "I18nProvider rendered `null`. A call to `i18n.activate` needs to happen in order for translations to be activated and for the I18nProvider to render." +

--- a/packages/react/src/server.ts
+++ b/packages/react/src/server.ts
@@ -5,7 +5,7 @@
  * RSC uses static analysis to find any non-valid function calls in the import graph.
  * That means this entry point and its children must not have any Provider/Context calls.
  */
-import type { I18nContext } from "./I18nProvider"
+import type { I18nContext, I18nDefaultComponent } from "./I18nProvider"
 
 export { TransNoContext } from "./TransNoContext"
 export type {
@@ -48,10 +48,7 @@ const getLinguiCache = () => {
  * setI18n(i18n);
  * ```
  */
-export function setI18n(
-  i18n: I18n,
-  defaultComponent?: I18nContext["defaultComponent"],
-) {
+export function setI18n(i18n: I18n, defaultComponent?: I18nDefaultComponent) {
   getLinguiCache().current = {
     i18n,
     _: i18n._.bind(i18n),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1747,6 +1747,7 @@ __metadata:
     "@testing-library/dom": "npm:^10.4.1"
     "@testing-library/react": "npm:^16.3.2"
     "@types/react": "npm:^18.2.13"
+    "@types/use-sync-external-store": "npm:^1.5.0"
     eslint: "npm:^9.39.3"
     eslint-plugin-react: "npm:^7.37.5"
     eslint-plugin-react-hooks: "npm:^7.0.1"
@@ -1755,6 +1756,7 @@ __metadata:
     react-dom: "npm:^18.2.0"
     typescript: "catalog:"
     unbuild: "catalog:"
+    use-sync-external-store: "npm:^1.6.0"
     vitest: "catalog:"
   peerDependencies:
     babel-plugin-macros: 2 || 3
@@ -3503,6 +3505,13 @@ __metadata:
   version: 2.0.6
   resolution: "@types/statuses@npm:2.0.6"
   checksum: 10/dadfbb4f32a16d3106a8e2a957dab17b1ae99fc4788e1fd96aeaf82355e3b2b069d5ea0f5fb887efa830def033828955a5bbdfd35454ba2088822537aed9e5db
+  languageName: node
+  linkType: hard
+
+"@types/use-sync-external-store@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "@types/use-sync-external-store@npm:1.5.0"
+  checksum: 10/39e5be8dc2cca080b490f2f79fed4381ae7eebee3f981208e359856733eafb2479d229db07a552f6c99fe0b5c09b3e46a3e6a870e00a88b50f3e690e73d2649b
   languageName: node
   linkType: hard
 
@@ -14322,6 +14331,15 @@ __metadata:
   dependencies:
     punycode: "npm:^2.1.0"
   checksum: 10/b271ca7e3d46b7160222e3afa3e531505161c9a4e097febae9664e4b59912f4cbe94861361a4175edac3a03fee99d91e44b6a58c17a634bc5a664b19fc76fbcb
+  languageName: node
+  linkType: hard
+
+"use-sync-external-store@npm:^1.6.0":
+  version: 1.6.0
+  resolution: "use-sync-external-store@npm:1.6.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10/b40ad2847ba220695bff2d4ba4f4d60391c0fb4fb012faa7a4c18eb38b69181936f5edc55a522c4d20a788d1a879b73c3810952c9d0fd128d01cb3f22042c09e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

Restore `useSyncExternalStore`-based subscriptions in `@lingui/react` via the `use-sync-external-store` shim.

This brings back the approach from [lingui/js-lingui#1746](https://github.com/lingui/js-lingui/pull/1746) by @vonovak, which was reverted in [lingui/js-lingui#1755](https://github.com/lingui/js-lingui/pull/1755) because of [lingui/js-lingui#1754](https://github.com/lingui/js-lingui/issues/1754). The upstream shim issue has since been fixed in [react/react#25231](https://github.com/react/react/pull/25231), so the external-store subscription model can be restored.

React recommends `useSyncExternalStore` for libraries subscribing to external mutable state because it supports concurrent reads and avoids manually syncing store state through Effects:
https://react.dev/reference/react/useSyncExternalStore,
https://react.dev/learn/you-might-not-need-an-effect#subscribing-to-an-external-store.

Also updates the `@lingui/react` size limit to account for the shim as an intentional compatibility dependency. For React 18+ consumers, the shim delegates to React's built-in `useSyncExternalStore`, so this should not add a separate polyfill implementation to their runtime path.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

Fixes #1754

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
