### PR TITLE
docs: improve SEO meta tags across the website

### DIFF
--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -1,5 +1,5 @@
 ---
-title: Internationalization Framework for Global Products
+title: JavaScript i18n Introduction & Core Concepts
 description: Lingui is a universal, clean and readable, lightweight and powerful internationalization (i18n) framework for global projects
 ---
 

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -30,20 +30,12 @@ const config: Config = {
       textColor: "#ffffff",
       isCloseable: true,
     },
+    image: "img/og-image.png",
     metadata: [
-      {
-        name: "title",
-        content: "Lingui - Internationalization Framework for Global Products",
-      },
       {
         name: "description",
         content:
           "Lingui is a modern internationalization framework for global products. It provides the best developer experience for managing translations and supports all major frameworks.",
-      },
-      {
-        name: "keywords",
-        content:
-          "internationalization, localization, multilingual, translation, i18n, l10n, react, react native, vue, next.js, ICU, javascript, typescript, pseudolocalization, internationalization framework",
       },
     ],
     navbar: {

--- a/website/src/components/header.tsx
+++ b/website/src/components/header.tsx
@@ -1,30 +1,13 @@
 import React from "react";
 import useBaseUrl from "@docusaurus/useBaseUrl";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
-import Head from "@docusaurus/Head";
 import { Button } from "./ui/button";
 
 export function Header(): React.ReactElement {
   const { siteConfig = { url: "", title: "", tagline: "" } } = useDocusaurusContext();
-  const ogImage = `${siteConfig.url}/img/og-image.png`;
 
   return (
     <header className="relative px-4 text-center sm:px-8">
-      <Head>
-        <title>{siteConfig.title}</title>
-        <meta property="og:image" content={ogImage} />
-        <meta property="og:title" content={siteConfig.title} />
-        <meta property="og:description" content={siteConfig.tagline} />
-        <meta property="og:image:width" content="1200" />
-        <meta property="og:image:height" content="630" />
-
-        <meta name="description" content={siteConfig.tagline} />
-        <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:title" content={siteConfig.title} />
-        <meta name="twitter:description" content={siteConfig.tagline} />
-        <meta name="twitter:image" content={ogImage} />
-      </Head>
-
       <div className="relative bottom-0 flex overflow-hidden rounded-b-3xl bg-gradient-to-b from-transparent to-red-500/5 p-0">
         <img
           src="/img/header/left-bg.svg"

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import Layout from "@theme/Layout";
-import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+import Head from "@docusaurus/Head";
 import { Features } from "../components/features";
 import { Header } from "../components/header";
 import { Users } from "../components/users";
@@ -10,11 +10,21 @@ import { PartnerBanner } from "../components/partner-banner";
 import { LinguiWorkflow } from "../components/lingui-workflow";
 import { SiteFooter } from "../components/site-footer";
 
-function Home() {
-  const { siteConfig } = useDocusaurusContext();
+const TITLE = "Lingui | Lightweight i18n Framework for React & JS";
+const DESCRIPTION =
+  "Build global products with Lingui, the lightweight JavaScript i18n framework. Features full React and RSC support, JSX rich-text, and powerful CLI tooling.";
 
+function Home() {
   return (
-    <Layout title={siteConfig.tagline}>
+    <Layout>
+      <Head>
+        <title>{TITLE}</title>
+        <meta name="description" content={DESCRIPTION} />
+        <meta property="og:title" content={TITLE} />
+        <meta property="og:description" content={DESCRIPTION} />
+        <meta name="twitter:title" content={TITLE} />
+        <meta name="twitter:description" content={DESCRIPTION} />
+      </Head>
       <main className="space-y-24">
         <Header />
         <PartnerBanner />


### PR DESCRIPTION
# Description

- Remove sitewide `meta name="title"` and keywords injected on every page via `themeConfig.metadata` (flagged as duplicate meta titles by SEO audit)
- Set `themeConfig.image` so all pages get `og:image/twitter:image`, previously missing on docs pages
- Fix homepage `<title>` being just "Lingui": drop the hardcoded title override in the hero component and define keyword-rich title and description in the page itself
- Retitle the introduction page to stop competing with the homepage for the same phrase

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Examples update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
