### PR TITLE
fix(cli): preserve bracketed names in catalog globs

### DIFF
--- a/packages/cli/src/api/catalog.test.ts
+++ b/packages/cli/src/api/catalog.test.ts
@@ -66,6 +66,34 @@ describe("Catalog", () => {
     mockFs.restore()
   })
 
+  describe("sourcePaths", () => {
+    it("should use current include and exclude patterns", () => {
+      const catalog = new Catalog(
+        {
+          name: "messages",
+          path: "locales/{locale}",
+          include: [fixture("collect/componentA/")],
+          exclude: [],
+          format,
+        },
+        mockConfig(),
+      )
+
+      expect(
+        catalog.sourcePaths.map((file) => path.basename(file)).sort(),
+      ).toEqual(["componentA.js", "index.js"])
+
+      const replacement = fixture("collect/componentB.js")
+      catalog.include = [replacement]
+      expect(catalog.sourcePaths.map((file) => path.basename(file))).toEqual([
+        "componentB.js",
+      ])
+
+      catalog.exclude.push(replacement)
+      expect(catalog.sourcePaths).toEqual([])
+    })
+  })
+
   describe("make", () => {
     it("should collect and write catalogs", async () => {
       const localeDir = await copyFixture(fixture("locales", "initial"))

--- a/packages/cli/src/api/catalog.ts
+++ b/packages/cli/src/api/catalog.ts
@@ -70,6 +70,17 @@ export type CatalogProps = {
   format: FormatterWrapper
 }
 
+type CatalogGlobPatterns = {
+  path: string
+  include: Array<string>
+  exclude: Array<string>
+}
+
+type CatalogPattern = {
+  value: string
+  glob: string
+}
+
 export class Catalog {
   name?: string
   path: string
@@ -77,15 +88,26 @@ export class Catalog {
   exclude: Array<string>
   format: FormatterWrapper
   templateFile: string
+  #includePatterns: Array<CatalogPattern>
+  #excludePatterns: Array<CatalogPattern>
 
   constructor(
     { name, path, include, templatePath, format, exclude = [] }: CatalogProps,
     public config: LinguiConfigNormalized,
+    globPatterns: CatalogGlobPatterns = { path, include, exclude },
   ) {
     this.name = name
     this.path = normalizeRelativePath(path)
     this.include = include.map(normalizeRelativePath)
     this.exclude = [this.localeDir, ...exclude.map(normalizeRelativePath)]
+    this.#includePatterns = createCatalogPatterns(
+      this.include,
+      globPatterns.include.map(normalizeRelativePath),
+    )
+    this.#excludePatterns = createCatalogPatterns(this.exclude, [
+      getLocaleDir(normalizeRelativePath(globPatterns.path)),
+      ...globPatterns.exclude.map(normalizeRelativePath),
+    ])
     this.format = format
     this.templateFile =
       templatePath ||
@@ -339,8 +361,18 @@ export class Catalog {
     return await this.format.read(this.templateFile, undefined)
   }
 
+  /** @internal */
+  get sourcePatterns() {
+    return {
+      include: resolveCatalogPatterns(this.include, this.#includePatterns),
+      exclude: resolveCatalogPatterns(this.exclude, this.#excludePatterns),
+    }
+  }
+
   get sourcePaths() {
-    const includeGlobs = this.include.map((includePath) => {
+    const sourcePatterns = this.sourcePatterns
+    const includeGlobs = this.include.map((includePath, index) => {
+      const includeGlob = sourcePatterns.include[index]!
       const isDir = isDirectory(includePath)
       /**
        * glob library results from absolute patterns such as /foo/* are mounted onto the root setting using path.join.
@@ -350,27 +382,48 @@ export class Catalog {
         ? normalize(
             path.resolve(
               process.cwd(),
-              includePath === "/" ? "" : includePath,
+              includePath === "/" ? "" : includeGlob,
               "**/*.*",
             ),
           )
-        : includePath
+        : includeGlob
     })
 
-    return globSync(includeGlobs, { exclude: this.exclude })
+    return globSync(includeGlobs, { exclude: sourcePatterns.exclude })
   }
 
   get localeDir() {
-    const localePatternIndex = this.path.indexOf(LOCALE)
-    if (localePatternIndex === -1) {
-      throw Error(`Invalid catalog path: ${LOCALE} variable is missing`)
-    }
-    return this.path.substring(0, localePatternIndex)
+    return getLocaleDir(this.path)
   }
 
   get locales() {
     return this.config.locales
   }
+}
+
+function createCatalogPatterns(values: Array<string>, globs: Array<string>) {
+  return values.map((value, index) => ({
+    value,
+    glob: globs[index] ?? value,
+  }))
+}
+
+function resolveCatalogPatterns(
+  values: Array<string>,
+  patterns: Array<CatalogPattern>,
+) {
+  return values.map((value, index) => {
+    const pattern = patterns[index]
+    return pattern?.value === value ? pattern.glob : value
+  })
+}
+
+function getLocaleDir(catalogPath: string) {
+  const localePatternIndex = catalogPath.indexOf(LOCALE)
+  if (localePatternIndex === -1) {
+    throw Error(`Invalid catalog path: ${LOCALE} variable is missing`)
+  }
+  return catalogPath.substring(0, localePatternIndex)
 }
 
 function getTemplatePath(ext: string, path: string) {

--- a/packages/cli/src/api/catalog/getCatalogs.test.ts
+++ b/packages/cli/src/api/catalog/getCatalogs.test.ts
@@ -6,10 +6,10 @@ import {
 } from "./getCatalogs.js"
 import { Catalog } from "../catalog.js"
 import { LinguiConfig, makeConfig } from "@lingui/conf"
-import fs from "fs"
-import os from "os"
 import path from "path"
 import { FormatterWrapper, getFormat } from "../formats/index.js"
+import { createFixtures } from "../../tests.js"
+import normalizePath from "normalize-path"
 
 function mockConfig(config: Partial<LinguiConfig> = {}) {
   return makeConfig(
@@ -138,65 +138,56 @@ describe("getCatalogs", () => {
   it.each(["componentA", "[slug]", "[...params]", "[[...params]]"])(
     "should extract from the named catalog directory %s",
     async (name) => {
-      const fixtureRoot = fs.mkdtempSync(
-        path.join(os.tmpdir(), "lingui-named-catalog-"),
-      )
-      const previousCwd = process.cwd()
-
-      try {
-        const routeDir = path.join(fixtureRoot, "src", "pages", name)
-        fs.mkdirSync(path.join(routeDir, "ignored"), { recursive: true })
-        fs.writeFileSync(
-          path.join(routeDir, "index.tsx"),
-          `
+      const rootDir = await createFixtures({
+        [`/src/pages/${name}/index.tsx`]: `
             import { Trans } from "@lingui/react/macro"
 
             export default function Page() {
               return <Trans>Hello World</Trans>
             }
           `,
-        )
-        fs.writeFileSync(
-          path.join(routeDir, "ignored", "index.tsx"),
-          `
+        [`/src/pages/${name}/ignored/index.tsx`]: `
             import { Trans } from "@lingui/react/macro"
 
             export default function IgnoredPage() {
               return <Trans>Ignored message</Trans>
             }
           `,
-        )
-        process.chdir(fixtureRoot)
+      })
 
-        const config = mockConfig({
-          rootDir: fixtureRoot,
-          catalogs: [
-            {
-              path: "src/locales/{name}/{locale}/messages",
-              include: ["src/pages/{name}"],
-              exclude: ["src/pages/{name}/ignored/**"],
-            },
-          ],
-        })
+      const config = mockConfig({
+        rootDir,
+        catalogs: [
+          {
+            path: "<rootDir>/src/locales/{name}/{locale}/messages",
+            include: ["<rootDir>/src/pages/{name}"],
+            exclude: ["<rootDir>/src/pages/{name}/ignored/**"],
+          },
+        ],
+      })
 
-        const [catalog] = await getCatalogs(config)
+      const [catalog] = await getCatalogs(config)
 
-        expect(catalog!.name).toBe(name)
-        expect(catalog!.path).toBe(`src/locales/${name}/{locale}/messages`)
-        expect(catalog!.include).toEqual([`src/pages/${name}/`])
-        expect(catalog!.exclude).toContain(`src/pages/${name}/ignored/**`)
-        expect(catalog!.sourcePaths.map((file) => path.basename(file))).toEqual(
-          ["index.tsx"],
-        )
+      expect(catalog!.name).toBe(name)
+      expect(catalog!.path).toBe(
+        normalizePath(
+          path.join(rootDir, "src", "locales", name, "{locale}", "messages"),
+        ),
+      )
+      expect(catalog!.include).toEqual([
+        normalizePath(path.join(rootDir, "src", "pages", name)),
+      ])
+      expect(catalog!.exclude).toContain(
+        normalizePath(path.join(rootDir, "src", "pages", name, "ignored/**")),
+      )
+      expect(catalog!.sourcePaths.map((file) => path.basename(file))).toEqual([
+        "index.tsx",
+      ])
 
-        const messages = await catalog!.collect()
-        expect(Object.values(messages!)).toEqual([
-          expect.objectContaining({ message: "Hello World" }),
-        ])
-      } finally {
-        process.chdir(previousCwd)
-        fs.rmSync(fixtureRoot, { recursive: true, force: true })
-      }
+      const messages = await catalog!.collect()
+      expect(Object.values(messages!)).toEqual([
+        expect.objectContaining({ message: "Hello World" }),
+      ])
     },
   )
 

--- a/packages/cli/src/api/catalog/getCatalogs.test.ts
+++ b/packages/cli/src/api/catalog/getCatalogs.test.ts
@@ -6,6 +6,8 @@ import {
 } from "./getCatalogs.js"
 import { Catalog } from "../catalog.js"
 import { LinguiConfig, makeConfig } from "@lingui/conf"
+import fs from "fs"
+import os from "os"
 import path from "path"
 import { FormatterWrapper, getFormat } from "../formats/index.js"
 
@@ -132,6 +134,71 @@ describe("getCatalogs", () => {
       ),
     ])
   })
+
+  it.each(["componentA", "[slug]", "[...params]", "[[...params]]"])(
+    "should extract from the named catalog directory %s",
+    async (name) => {
+      const fixtureRoot = fs.mkdtempSync(
+        path.join(os.tmpdir(), "lingui-named-catalog-"),
+      )
+      const previousCwd = process.cwd()
+
+      try {
+        const routeDir = path.join(fixtureRoot, "src", "pages", name)
+        fs.mkdirSync(path.join(routeDir, "ignored"), { recursive: true })
+        fs.writeFileSync(
+          path.join(routeDir, "index.tsx"),
+          `
+            import { Trans } from "@lingui/react/macro"
+
+            export default function Page() {
+              return <Trans>Hello World</Trans>
+            }
+          `,
+        )
+        fs.writeFileSync(
+          path.join(routeDir, "ignored", "index.tsx"),
+          `
+            import { Trans } from "@lingui/react/macro"
+
+            export default function IgnoredPage() {
+              return <Trans>Ignored message</Trans>
+            }
+          `,
+        )
+        process.chdir(fixtureRoot)
+
+        const config = mockConfig({
+          rootDir: fixtureRoot,
+          catalogs: [
+            {
+              path: "src/locales/{name}/{locale}/messages",
+              include: ["src/pages/{name}"],
+              exclude: ["src/pages/{name}/ignored/**"],
+            },
+          ],
+        })
+
+        const [catalog] = await getCatalogs(config)
+
+        expect(catalog!.name).toBe(name)
+        expect(catalog!.path).toBe(`src/locales/${name}/{locale}/messages`)
+        expect(catalog!.include).toEqual([`src/pages/${name}/`])
+        expect(catalog!.exclude).toContain(`src/pages/${name}/ignored/**`)
+        expect(catalog!.sourcePaths.map((file) => path.basename(file))).toEqual(
+          ["index.tsx"],
+        )
+
+        const messages = await catalog!.collect()
+        expect(Object.values(messages!)).toEqual([
+          expect.objectContaining({ message: "Hello World" }),
+        ])
+      } finally {
+        process.chdir(previousCwd)
+        fs.rmSync(fixtureRoot, { recursive: true, force: true })
+      }
+    },
+  )
 
   it("should expand {name} multiple times in path", async () => {
     mockFs({

--- a/packages/cli/src/api/catalog/getCatalogs.test.ts
+++ b/packages/cli/src/api/catalog/getCatalogs.test.ts
@@ -135,7 +135,7 @@ describe("getCatalogs", () => {
     ])
   })
 
-  it.each(["componentA", "[slug]", "[...params]", "[[...params]]"])(
+  it.each(["componentA", "(group)", "[slug]", "[...params]", "[[...params]]"])(
     "should extract from the named catalog directory %s",
     async (name) => {
       const rootDir = await createFixtures({

--- a/packages/cli/src/api/catalog/getCatalogs.ts
+++ b/packages/cli/src/api/catalog/getCatalogs.ts
@@ -69,7 +69,7 @@ export async function getCatalogs(
 
     candidates.forEach((catalogDir) => {
       const name = path.basename(catalogDir)
-      const globName = escapeGlobBrackets(name)
+      const globName = escapeCatalogNameForGlob(name)
       catalogs.push(
         new Catalog(
           {
@@ -112,8 +112,8 @@ export async function getCatalogs(
   return catalogs
 }
 
-function escapeGlobBrackets(value: string) {
-  return value.replace(/[[\]]/g, "[$&]")
+function escapeCatalogNameForGlob(value: string) {
+  return value.replace(/[[\]()]/g, "[$&]")
 }
 
 /**

--- a/packages/cli/src/api/catalog/getCatalogs.ts
+++ b/packages/cli/src/api/catalog/getCatalogs.ts
@@ -69,6 +69,7 @@ export async function getCatalogs(
 
     candidates.forEach((catalogDir) => {
       const name = path.basename(catalogDir)
+      const globName = escapeGlobBrackets(name)
       catalogs.push(
         new Catalog(
           {
@@ -81,6 +82,15 @@ export async function getCatalogs(
             format,
           },
           config,
+          {
+            path: replacePlaceholders(catalog.path, { name: globName }),
+            include: include.map((path) =>
+              replacePlaceholders(path, { name: globName }),
+            ),
+            exclude: exclude.map((path) =>
+              replacePlaceholders(path, { name: globName }),
+            ),
+          },
         ),
       )
     })
@@ -100,6 +110,10 @@ export async function getCatalogs(
   }
 
   return catalogs
+}
+
+function escapeGlobBrackets(value: string) {
+  return value.replace(/[[\]]/g, "[$&]")
 }
 
 /**

--- a/packages/cli/src/api/getPathsForExtractWatcher.test.ts
+++ b/packages/cli/src/api/getPathsForExtractWatcher.test.ts
@@ -32,7 +32,7 @@ describe("getPathsForExtractWatcher", () => {
     ])
   })
 
-  it.each(["componentA", "[slug]", "[...params]", "[[...params]]"])(
+  it.each(["componentA", "(group)", "[slug]", "[...params]", "[[...params]]"])(
     "should match the named catalog directory %s",
     async (name) => {
       const rootDir = await createFixtures({

--- a/packages/cli/src/api/getPathsForExtractWatcher.test.ts
+++ b/packages/cli/src/api/getPathsForExtractWatcher.test.ts
@@ -1,6 +1,10 @@
 import { makeConfig } from "@lingui/conf"
 import { getPathsForExtractWatcher } from "./getPathsForExtractWatcher.js"
+import fs from "fs"
+import os from "os"
+import { glob } from "node:fs/promises"
 import path from "path"
+import micromatch from "micromatch"
 import normalizePath from "normalize-path"
 
 describe("getPathsForExtractWatcher", () => {
@@ -28,4 +32,61 @@ describe("getPathsForExtractWatcher", () => {
       "/components/**",
     ])
   })
+
+  it.each(["componentA", "[slug]", "[...params]", "[[...params]]"])(
+    "should match the named catalog directory %s",
+    async (name) => {
+      const fixtureRoot = fs.mkdtempSync(
+        path.join(os.tmpdir(), "lingui-extract-watcher-"),
+      )
+      const previousCwd = process.cwd()
+
+      try {
+        const routeDir = path.join(fixtureRoot, "src", "pages", name)
+        fs.mkdirSync(path.join(routeDir, "ignored"), { recursive: true })
+        fs.writeFileSync(path.join(routeDir, "index.tsx"), "export {}")
+        fs.writeFileSync(
+          path.join(routeDir, "ignored", "index.tsx"),
+          "export {}",
+        )
+        process.chdir(fixtureRoot)
+
+        const config = makeConfig(
+          {
+            rootDir: fixtureRoot,
+            locales: ["en"],
+            catalogs: [
+              {
+                path: "src/locales/{name}/{locale}/messages",
+                include: ["src/pages/{name}"],
+                exclude: ["src/pages/{name}/ignored/**"],
+              },
+            ],
+          },
+          { skipValidation: true },
+        )
+
+        const { paths, ignored } = await getPathsForExtractWatcher(config)
+        const matches: string[] = []
+        for await (const match of glob(paths)) {
+          matches.push(normalizePath(match))
+        }
+
+        expect(matches).toEqual([
+          normalizePath(path.join("src", "pages", name)),
+        ])
+        expect(
+          micromatch.any(
+            normalizePath(
+              path.join("src", "pages", name, "ignored", "index.tsx"),
+            ),
+            ignored,
+          ),
+        ).toBe(true)
+      } finally {
+        process.chdir(previousCwd)
+        fs.rmSync(fixtureRoot, { recursive: true, force: true })
+      }
+    },
+  )
 })

--- a/packages/cli/src/api/getPathsForExtractWatcher.test.ts
+++ b/packages/cli/src/api/getPathsForExtractWatcher.test.ts
@@ -1,11 +1,10 @@
 import { makeConfig } from "@lingui/conf"
 import { getPathsForExtractWatcher } from "./getPathsForExtractWatcher.js"
-import fs from "fs"
-import os from "os"
 import { glob } from "node:fs/promises"
 import path from "path"
 import micromatch from "micromatch"
 import normalizePath from "normalize-path"
+import { createFixtures } from "../tests.js"
 
 describe("getPathsForExtractWatcher", () => {
   it("should generate correct paths for simple catalogs", async () => {
@@ -36,57 +35,43 @@ describe("getPathsForExtractWatcher", () => {
   it.each(["componentA", "[slug]", "[...params]", "[[...params]]"])(
     "should match the named catalog directory %s",
     async (name) => {
-      const fixtureRoot = fs.mkdtempSync(
-        path.join(os.tmpdir(), "lingui-extract-watcher-"),
+      const rootDir = await createFixtures({
+        [`/src/pages/${name}/index.tsx`]: "export {}",
+        [`/src/pages/${name}/ignored/index.tsx`]: "export {}",
+      })
+
+      const config = makeConfig(
+        {
+          rootDir,
+          locales: ["en"],
+          catalogs: [
+            {
+              path: "<rootDir>/src/locales/{name}/{locale}/messages",
+              include: ["<rootDir>/src/pages/{name}"],
+              exclude: ["<rootDir>/src/pages/{name}/ignored/**"],
+            },
+          ],
+        },
+        { skipValidation: true },
       )
-      const previousCwd = process.cwd()
 
-      try {
-        const routeDir = path.join(fixtureRoot, "src", "pages", name)
-        fs.mkdirSync(path.join(routeDir, "ignored"), { recursive: true })
-        fs.writeFileSync(path.join(routeDir, "index.tsx"), "export {}")
-        fs.writeFileSync(
-          path.join(routeDir, "ignored", "index.tsx"),
-          "export {}",
-        )
-        process.chdir(fixtureRoot)
-
-        const config = makeConfig(
-          {
-            rootDir: fixtureRoot,
-            locales: ["en"],
-            catalogs: [
-              {
-                path: "src/locales/{name}/{locale}/messages",
-                include: ["src/pages/{name}"],
-                exclude: ["src/pages/{name}/ignored/**"],
-              },
-            ],
-          },
-          { skipValidation: true },
-        )
-
-        const { paths, ignored } = await getPathsForExtractWatcher(config)
-        const matches: string[] = []
-        for await (const match of glob(paths)) {
-          matches.push(normalizePath(match))
-        }
-
-        expect(matches).toEqual([
-          normalizePath(path.join("src", "pages", name)),
-        ])
-        expect(
-          micromatch.any(
-            normalizePath(
-              path.join("src", "pages", name, "ignored", "index.tsx"),
-            ),
-            ignored,
-          ),
-        ).toBe(true)
-      } finally {
-        process.chdir(previousCwd)
-        fs.rmSync(fixtureRoot, { recursive: true, force: true })
+      const { paths, ignored } = await getPathsForExtractWatcher(config)
+      const matches: string[] = []
+      for await (const match of glob(paths)) {
+        matches.push(normalizePath(match))
       }
+
+      expect(matches).toEqual([
+        normalizePath(path.join(rootDir, "src", "pages", name)),
+      ])
+      expect(
+        micromatch.any(
+          normalizePath(
+            path.join(rootDir, "src", "pages", name, "ignored", "index.tsx"),
+          ),
+          ignored,
+        ),
+      ).toBe(true)
     },
   )
 })

--- a/packages/cli/src/api/getPathsForExtractWatcher.ts
+++ b/packages/cli/src/api/getPathsForExtractWatcher.ts
@@ -12,8 +12,9 @@ export async function getPathsForExtractWatcher(
   const ignored: string[] = []
 
   catalogs.forEach((catalog) => {
-    paths.push(...catalog.include)
-    ignored.push(...catalog.exclude)
+    const sourcePatterns = catalog.sourcePatterns
+    paths.push(...sourcePatterns.include)
+    ignored.push(...sourcePatterns.exclude)
   })
 
   return { paths, ignored }


### PR DESCRIPTION
# Description

Fixes #2183.

## Reproduction

Given this `lingui.config.js`:

```js
module.exports = {
  locales: ["en"],
  catalogs: [
    {
      path: "src/locales/{name}/{locale}/messages",
      include: ["src/pages/{name}"],
    },
  ],
}
```

and this file structure:

```text
src/
  pages/
    [...params]/
      index.tsx
```

where `index.tsx` contains:

```tsx
import { Trans } from "@lingui/react/macro"

export default function Page() {
  return <Trans>Hello World</Trans>
}
```

run:

```sh
yarn lingui extract
```

Before this change, Lingui creates:

```text
src/locales/[...params]/en/messages.po
```

but the catalog does not contain `Hello World`. The expected behavior is for the message from `src/pages/[...params]/index.tsx` to be extracted into that catalog.

## Root cause

Named catalog discovery replaces `{name}` with `*`, so it correctly discovers the directory `src/pages/[...params]`.

The discovered name is then substituted back into the configured source path:

```text
src/pages/[...params]
```

This value is later passed to Node's glob implementation. In a glob, `[...]` is interpreted as a character class instead of literal path data. The resulting pattern therefore does not match the actual `[...params]` directory, and its source files are omitted from extraction.

## Solution

This change keeps two representations of named catalog paths:

- Literal values for catalog paths and the public `include` and `exclude` properties.
- Glob-safe values for matching source files.

Only bracket and parenthesis characters originating from the `{name}` replacement are escaped:

```text
[...params] -> [[]...params[]]
(group) -> [(]group[)]
```

Configured glob syntax in `include` and `exclude`, including patterns such as `**/*.{ts,tsx}`, remains unchanged. The glob-safe patterns are used by both regular extraction and watch mode.

This fix intentionally targets bracket and parenthesis characters used by Next.js dynamic route and route group directory names. It does not introduce general escaping for every possible glob metacharacter.

## Validation

- `yarn vitest --run packages/cli/src/api/catalog/getCatalogs.test.ts packages/cli/src/api/getPathsForExtractWatcher.test.ts packages/cli/src/api/catalog.test.ts` on Node 22.19 and Node 24
- `yarn exec tsc --noEmit -p packages/cli/tsconfig.json`
- Targeted ESLint and Prettier checks
- `git diff --check`

Regression tests cover ordinary named directories, `(group)`, `[slug]`, `[...params]`, `[[...params]]`, exclusion patterns, watch-mode matching, and updated public `include` and `exclude` values.

No new dependencies were added.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] Documentation update
- [ ] Examples update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)