### PR TITLE
fix(babel-plugin-lingui-macro): unwrap non-null assertion (`x!`) / `satisfies` in placeholders to match SWC plugin

### DIFF
--- a/packages/babel-plugin-lingui-macro/src/macroJsAst.ts
+++ b/packages/babel-plugin-lingui-macro/src/macroJsAst.ts
@@ -262,7 +262,13 @@ export function tokenizeExpression(
   node: Node | Expression,
   ctx: MacroJsContext,
 ): ArgToken {
-  if (t.isTSAsExpression(node)) {
+  if (
+    t.isTSAsExpression(node) ||
+    t.isTSNonNullExpression(node) ||
+    t.isTSSatisfiesExpression(node)
+  ) {
+    // Unwrap TS-only expression wrappers (`x as T`, `x!`, `x satisfies T`) so the
+    // inner expression drives placeholder naming (e.g. `${x!}` → `{x}`, not `{0}`).
     return tokenizeExpression(node.expression, ctx)
   }
   if (t.isObjectExpression(node)) {

--- a/packages/babel-plugin-lingui-macro/test/__snapshots__/js-t.test.ts.snap
+++ b/packages/babel-plugin-lingui-macro/test/__snapshots__/js-t.test.ts.snap
@@ -511,6 +511,26 @@ _i18n._(
 
 `;
 
+exports[`Variables with non-null assertion get a named placeholder (parity with \`as\`) 1`] = `
+import { t } from "@lingui/core/macro";
+t\`Variable \${name!}\`;
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { i18n as _i18n } from "@lingui/core";
+_i18n._(
+  /** i18n */
+  {
+    id: "xRRkAE",
+    message: "Variable {name}",
+    values: {
+      name: name,
+    },
+  },
+);
+
+`;
+
 exports[`Variables with escaped double quotes are correctly formatted 1`] = `
 import { t } from "@lingui/core/macro";
 t\`Variable "name"\`;

--- a/packages/babel-plugin-lingui-macro/test/js-t.test.ts
+++ b/packages/babel-plugin-lingui-macro/test/js-t.test.ts
@@ -105,8 +105,17 @@ macroTester({
       name: "Variables with `as` type casting",
       code: `
         import { t } from '@lingui/core/macro';
-     
+
         t\`Variable \${{name} as any}\`;
+    `,
+    },
+    {
+      useTypescriptPreset: true,
+      name: "Variables with non-null assertion get a named placeholder (parity with `as`)",
+      code: `
+        import { t } from '@lingui/core/macro';
+
+        t\`Variable \${name!}\`;
     `,
     },
     {


### PR DESCRIPTION
## Description

`tokenizeExpression` in the babel macro only unwraps `TSAsExpression`, so a placeholder that wraps its expression in a **non-null assertion** (`x!`) or `satisfies` is treated as a *complex* expression and assigned an **indexed** placeholder (`{0}`). `@lingui/swc-plugin`, however, unwraps those TS-only wrappers and produces a **named** placeholder (`{x}`).

Because the message id is derived from the normalized message, the two toolchains generate **different ids for identical source**, which breaks catalog lookups in projects that **extract with the JS macro/CLI but run with the SWC plugin** — the runtime asks for an id the compiled (babel-extracted) catalog doesn't contain, so the raw id renders. This is the same class of JS↔SWC divergence addressed for numeric placeholders in lingui/swc-plugin#239.

## Reproduction

```ts
t`Value: ${x!}`
```

| toolchain | message | placeholder |
|---|---|---|
| `@lingui/babel-plugin-lingui-macro` (extract) — **before** | `Value: {0}` | indexed |
| `@lingui/swc-plugin` (runtime) | `Value: {x}` | named |

`${x as T}` already agrees (`{x}` on both) because babel unwraps `as`; only `!` (and `satisfies`) diverged.

## Fix

Unwrap `TSNonNullExpression` and `TSSatisfiesExpression` alongside `TSAsExpression` in `tokenizeExpression`, so all TS-only expression wrappers let the inner expression drive placeholder naming — matching the SWC plugin and the existing `as` behavior. After the fix, `t`Value: ${x!}`` extracts as `Value: {x}` on both toolchains.

## Notes

- Adds a regression test in `js-t.test.ts` (`useTypescriptPreset`).
- This changes the generated id for existing `${x!}` usages (`{0}` → named). That's the point (aligning with the SWC plugin), but worth a note in release notes for anyone relying on the old indexed id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)