### PR TITLE
feat(babel-plugin): support Babel 8 via peer dependencies

### DIFF
--- a/packages/babel-plugin-extract-messages/test/extract-messages.test.ts
+++ b/packages/babel-plugin-extract-messages/test/extract-messages.test.ts
@@ -1,6 +1,6 @@
 import path from "path"
 import fs from "fs"
-import { transform as babelTransform } from "@babel/core"
+import { transformSync as babelTransform } from "@babel/core"
 import plugin, { ExtractedMessage, ExtractPluginOpts } from "../src/index"
 import { mockConsole } from "@lingui/test-utils"
 import linguiMacroPlugin, {

--- a/packages/babel-plugin-lingui-macro/package.json
+++ b/packages/babel-plugin-lingui-macro/package.json
@@ -55,16 +55,28 @@
     "node": ">=22.19.0"
   },
   "dependencies": {
-    "@babel/core": "^7.20.12",
-    "@babel/types": "^7.20.7",
     "@lingui/conf": "workspace:*",
     "@lingui/message-utils": "workspace:*"
   },
+  "peerDependencies": {
+    "@babel/core": "^7.20.12 || ^8.0.0",
+    "@babel/types": "^7.20.7 || ^8.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@babel/core": {
+      "optional": true
+    },
+    "@babel/types": {
+      "optional": true
+    }
+  },
   "devDependencies": {
+    "@babel/core": "^7.29.0",
     "@babel/parser": "^7.29.2",
     "@babel/plugin-syntax-jsx": "^7.28.6",
     "@babel/preset-typescript": "^7.18.6",
     "@babel/traverse": "^7.20.12",
+    "@babel/types": "^7.29.0",
     "babel-plugin-macros": "^3.1.0",
     "babel-plugin-react-compiler": "^1.0.0",
     "prettier": "3.9.4",

--- a/packages/babel-plugin-lingui-macro/src/messageDescriptorUtils.ts
+++ b/packages/babel-plugin-lingui-macro/src/messageDescriptorUtils.ts
@@ -185,9 +185,14 @@ function createIdProperty(message: string, context?: string) {
 function createValuesProperty(key: string, values: Record<string, Expression>) {
   const valuesObject = Object.keys(values).map((key) =>
     types.objectProperty(
-      types.isValidIdentifier(key) || /^\d+$/.test(key)
+      types.isValidIdentifier(key)
         ? types.identifier(key)
-        : types.stringLiteral(key),
+        : // Numeric placeholder keys (e.g. plural/select indices) must be built
+          // as numeric literals. Babel 8's @babel/types validates identifier
+          // names, so types.identifier("0") throws "not a valid identifier name".
+          /^\d+$/.test(key)
+          ? types.numericLiteral(Number(key))
+          : types.stringLiteral(key),
       values[key],
     ),
   )

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -46,7 +46,7 @@
     "@lingui/conf": "workspace:*"
   },
   "peerDependencies": {
-    "@babel/core": "^7.29.0 || ^8.0.0-rc.1",
+    "@babel/core": "^7.29.0 || ^8.0.0",
     "@lingui/babel-plugin-lingui-macro": "^5 || ^6",
     "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
     "rolldown": "^1.0.0-rc.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -34,7 +34,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:7.29.7, @babel/core@npm:^7.17.7, @babel/core@npm:^7.20.12, @babel/core@npm:^7.21.0, @babel/core@npm:^7.23.3, @babel/core@npm:^7.24.4, @babel/core@npm:^7.29.0":
+"@babel/core@npm:7.29.7, @babel/core@npm:^7.17.7, @babel/core@npm:^7.21.0, @babel/core@npm:^7.23.3, @babel/core@npm:^7.24.4, @babel/core@npm:^7.29.0":
   version: 7.29.7
   resolution: "@babel/core@npm:7.29.7"
   dependencies:
@@ -57,7 +57,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/generator@npm:^7.23.6, @babel/generator@npm:^7.29.7":
+"@babel/generator@npm:^7.23.6, @babel/generator@npm:^7.28.5, @babel/generator@npm:^7.29.7":
   version: 7.29.7
   resolution: "@babel/generator@npm:7.29.7"
   dependencies:
@@ -67,19 +67,6 @@ __metadata:
     "@jridgewell/trace-mapping": "npm:^0.3.28"
     jsesc: "npm:^3.0.2"
   checksum: 10/60fb0432ebeab791b2d68e5fc49da6f8e8b68bcc4751211ccf08ac0101e9dcaddefd0cbbbd488afb1c1517515c7c3e76f63d9b05d06deaeb008afd499488db9c
-  languageName: node
-  linkType: hard
-
-"@babel/generator@npm:^7.28.5":
-  version: 7.29.1
-  resolution: "@babel/generator@npm:7.29.1"
-  dependencies:
-    "@babel/parser": "npm:^7.29.0"
-    "@babel/types": "npm:^7.29.0"
-    "@jridgewell/gen-mapping": "npm:^0.3.12"
-    "@jridgewell/trace-mapping": "npm:^0.3.28"
-    jsesc: "npm:^3.0.2"
-  checksum: 10/61fe4ddd6e817aa312a14963ccdbb5c9a8c57e8b97b98d19a8a99ccab2215fda1a5f52bc8dd8d2e3c064497ddeb3ab8ceb55c76fa0f58f8169c34679d2256fe0
   languageName: node
   linkType: hard
 
@@ -180,7 +167,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-plugin-utils@npm:^7.22.5, @babel/helper-plugin-utils@npm:^7.28.6":
+"@babel/helper-plugin-utils@npm:^7.22.5":
   version: 7.28.6
   resolution: "@babel/helper-plugin-utils@npm:7.28.6"
   checksum: 10/21c853bbc13dbdddf03309c9a0477270124ad48989e1ad6524b83e83a77524b333f92edd2caae645c5a7ecf264ec6d04a9ebe15aeb54c7f33c037b71ec521e4a
@@ -214,13 +201,6 @@ __metadata:
     "@babel/traverse": "npm:^7.29.7"
     "@babel/types": "npm:^7.29.7"
   checksum: 10/a5800bfcdca6cef7f6fe33ac02a0f05ff33da9746f97806553f249733f7ba8400290a17f3831d7faa5d91656f254ab749931f53c8a29f301d958d7dd00499637
-  languageName: node
-  linkType: hard
-
-"@babel/helper-string-parser@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/helper-string-parser@npm:7.27.1"
-  checksum: 10/0ae29cc2005084abdae2966afdb86ed14d41c9c37db02c3693d5022fba9f5d59b011d039380b8e537c34daf117c549f52b452398f576e908fb9db3c7abbb3a00
   languageName: node
   linkType: hard
 
@@ -273,18 +253,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-syntax-jsx@npm:^7.16.7":
-  version: 7.28.6
-  resolution: "@babel/plugin-syntax-jsx@npm:7.28.6"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.28.6"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10/572e38f5c1bb4b8124300e7e3dd13e82ae84a21f90d3f0786c98cd05e63c78ca1f32d1cfe462dfbaf5e7d5102fa7cd8fd741dfe4f3afc2e01a3b2877dcc8c866
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-syntax-jsx@npm:^7.18.6, @babel/plugin-syntax-jsx@npm:^7.28.6, @babel/plugin-syntax-jsx@npm:^7.29.7":
+"@babel/plugin-syntax-jsx@npm:^7.16.7, @babel/plugin-syntax-jsx@npm:^7.18.6, @babel/plugin-syntax-jsx@npm:^7.28.6, @babel/plugin-syntax-jsx@npm:^7.29.7":
   version: 7.29.7
   resolution: "@babel/plugin-syntax-jsx@npm:7.29.7"
   dependencies:
@@ -394,17 +363,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.0.0, @babel/types@npm:^7.18.6, @babel/types@npm:^7.20.7, @babel/types@npm:^7.21.2, @babel/types@npm:^7.26.0, @babel/types@npm:^7.29.0, @babel/types@npm:^7.3.0":
-  version: 7.29.0
-  resolution: "@babel/types@npm:7.29.0"
-  dependencies:
-    "@babel/helper-string-parser": "npm:^7.27.1"
-    "@babel/helper-validator-identifier": "npm:^7.28.5"
-  checksum: 10/bfc2b211210f3894dcd7e6a33b2d1c32c93495dc1e36b547376aa33441abe551ab4bc1640d4154ee2acd8e46d3bbc925c7224caae02fcaf0e6a771e97fccc661
-  languageName: node
-  linkType: hard
-
-"@babel/types@npm:^7.23.6, @babel/types@npm:^7.29.7":
+"@babel/types@npm:^7.0.0, @babel/types@npm:^7.18.6, @babel/types@npm:^7.20.7, @babel/types@npm:^7.21.2, @babel/types@npm:^7.23.6, @babel/types@npm:^7.26.0, @babel/types@npm:^7.29.0, @babel/types@npm:^7.29.7, @babel/types@npm:^7.3.0":
   version: 7.29.7
   resolution: "@babel/types@npm:7.29.7"
   dependencies:
@@ -1500,12 +1459,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@lingui/babel-plugin-lingui-macro@workspace:packages/babel-plugin-lingui-macro"
   dependencies:
-    "@babel/core": "npm:^7.20.12"
+    "@babel/core": "npm:^7.29.0"
     "@babel/parser": "npm:^7.29.2"
     "@babel/plugin-syntax-jsx": "npm:^7.28.6"
     "@babel/preset-typescript": "npm:^7.18.6"
     "@babel/traverse": "npm:^7.20.12"
-    "@babel/types": "npm:^7.20.7"
+    "@babel/types": "npm:^7.29.0"
     "@lingui/conf": "workspace:*"
     "@lingui/message-utils": "workspace:*"
     babel-plugin-macros: "npm:^3.1.0"
@@ -1514,6 +1473,14 @@ __metadata:
     typescript: "catalog:"
     unbuild: "catalog:"
     vitest: "catalog:"
+  peerDependencies:
+    "@babel/core": ^7.20.12 || ^8.0.0
+    "@babel/types": ^7.20.7 || ^8.0.0
+  peerDependenciesMeta:
+    "@babel/core":
+      optional: true
+    "@babel/types":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -1833,7 +1800,7 @@ __metadata:
     vite-plugin-babel-macros: "npm:^1.0.6"
     vitest: "catalog:"
   peerDependencies:
-    "@babel/core": ^7.29.0 || ^8.0.0-rc.1
+    "@babel/core": ^7.29.0 || ^8.0.0
     "@lingui/babel-plugin-lingui-macro": ^5 || ^6
     "@rolldown/plugin-babel": ^0.1.7 || ^0.2.0
     rolldown: ^1.0.0-rc.5


### PR DESCRIPTION
## What

Adds Babel 8 support to the macro/babel plugins via peer dependencies, per #2592 and the direction @timofei-iatsenko and @andrii-bodnar set (support both Babel 7 and 8 via peer deps, not a hard upgrade).

## Changes

- **`@lingui/babel-plugin-lingui-macro`**: move `@babel/core` / `@babel/types` from direct `dependencies` to optional `peerDependencies` (`^7.20.12 || ^8.0.0` / `^7.20.7 || ^8.0.0`), mirroring `@lingui/vite-plugin`'s existing peer pattern. Added matching devDeps so the package still builds and tests locally.
- **`@lingui/vite-plugin`**: extend the existing peer from `^8.0.0-rc.1` to stable `^8.0.0`.
- **`@lingui/cli`** (extractor): unchanged — keeps its fixed Babel 7 direct deps, per the architectural line.

## Why peer, not direct-widening

I first tried simply widening the macro's direct deps to `^7 || ^8`. On the repo's own install the resolver then pulled **two** `@babel/core` majors (7.x for the CLI/others, 8.x for the macro) — exactly the "two Babel majors installed" outcome the issue wants to avoid, and it broke macro tests. Expressing them as peers keeps the repo (and consumers) on a single coherent major while advertising `^7 || ^8` downstream. The macro doesn't import `@babel/*` at consumer runtime (Babel is only touched inside a Babel transform), so the peers are optional — install completes with only the non-fatal optional-peer notices.

## Babel 8 fixes (small, mechanical)

- `messageDescriptorUtils.ts`: numeric placeholder keys (plural/select indices) were built as `types.identifier("0")`; Babel 8's `@babel/types` validates identifier names and rejects that, so numeric keys are now emitted as numeric literals (identical `{ 0: ... }` output on both majors).
- `babel-plugin-extract-messages` test: use `transformSync` (Babel 8 made `transform` callback-only; `transformSync` exists on both).

## Verification

Tests pass on **both** Babel 7 (shipping default) and Babel 8 (validated with a temporary root `resolutions` pin): the macro + extract-messages + cli suites are green, and `tsc` is clean on the changed packages.

Note: the CLI extractor intentionally stays on Babel 7 (per the architectural line above), so this PR does not migrate it. Moving the CLI itself onto Babel 8 would be a separate, larger change (a few type-only frictions around `@babel/core`/`@babel/parser` re-exports and Babel 8's tightened plugin/parser types).

Closes #2592.

---

*AI disclosure: this PR was drafted with Claude Code (AI-assisted). I verified it by running the macro + extract-messages suites on both Babel 7 and Babel 8 (green) plus `tsc` on the changed packages.*
