### PR TITLE
fix: improved error message for "useLingui hook was used without I18nProvider"

### DIFF
--- a/packages/babel-plugin-lingui-macro/test/__snapshots__/js-t.test.ts.snap
+++ b/packages/babel-plugin-lingui-macro/test/__snapshots__/js-t.test.ts.snap
@@ -511,6 +511,26 @@ _i18n._(
 
 `;
 
+exports[`Variables with non-null assertion get a named placeholder (parity with \`as\`) 1`] = `
+import { t } from "@lingui/core/macro";
+t\`Variable \${name!}\`;
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { i18n as _i18n } from "@lingui/core";
+_i18n._(
+  /** i18n */
+  {
+    id: "xRRkAE",
+    message: "Variable {name}",
+    values: {
+      name: name,
+    },
+  },
+);
+
+`;
+
 exports[`Variables with escaped double quotes are correctly formatted 1`] = `
 import { t } from "@lingui/core/macro";
 t\`Variable "name"\`;
@@ -602,26 +622,6 @@ _i18n._(
     message: "Variable {name}",
     values: {
       name: random(),
-    },
-  },
-);
-
-`;
-
-exports[`Variables with non-null assertion get a named placeholder (parity with \`as\`) 1`] = `
-import { t } from "@lingui/core/macro";
-t\`Variable \${name!}\`;
-
-↓ ↓ ↓ ↓ ↓ ↓
-
-import { i18n as _i18n } from "@lingui/core";
-_i18n._(
-  /** i18n */
-  {
-    id: "xRRkAE",
-    message: "Variable {name}",
-    values: {
-      name: name,
     },
   },
 );

--- a/packages/babel-plugin-lingui-macro/test/__snapshots__/js-t.test.ts.snap
+++ b/packages/babel-plugin-lingui-macro/test/__snapshots__/js-t.test.ts.snap
@@ -511,26 +511,6 @@ _i18n._(
 
 `;
 
-exports[`Variables with non-null assertion get a named placeholder (parity with \`as\`) 1`] = `
-import { t } from "@lingui/core/macro";
-t\`Variable \${name!}\`;
-
-↓ ↓ ↓ ↓ ↓ ↓
-
-import { i18n as _i18n } from "@lingui/core";
-_i18n._(
-  /** i18n */
-  {
-    id: "xRRkAE",
-    message: "Variable {name}",
-    values: {
-      name: name,
-    },
-  },
-);
-
-`;
-
 exports[`Variables with escaped double quotes are correctly formatted 1`] = `
 import { t } from "@lingui/core/macro";
 t\`Variable "name"\`;
@@ -622,6 +602,26 @@ _i18n._(
     message: "Variable {name}",
     values: {
       name: random(),
+    },
+  },
+);
+
+`;
+
+exports[`Variables with non-null assertion get a named placeholder (parity with \`as\`) 1`] = `
+import { t } from "@lingui/core/macro";
+t\`Variable \${name!}\`;
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { i18n as _i18n } from "@lingui/core";
+_i18n._(
+  /** i18n */
+  {
+    id: "xRRkAE",
+    message: "Variable {name}",
+    values: {
+      name: name,
     },
   },
 );

--- a/packages/react/src/I18nProvider.tsx
+++ b/packages/react/src/I18nProvider.tsx
@@ -23,7 +23,12 @@ export const useLinguiInternal = (devErrorMessage?: string): I18nContext => {
   if (process.env.NODE_ENV !== "production") {
     if (context == null) {
       throw new Error(
-        devErrorMessage ?? "useLingui hook was used without I18nProvider.",
+        devErrorMessage ??
+          "useLingui hook was used without I18nProvider." +
+            "\n\nThis often happens when multiple instances of @lingui/react are installed " +
+            "(e.g. due to a version mismatch or misconfiguration in a monorepo). " +
+            "Verify you have only one version installed by running: " +
+            "npm ls @lingui/react (or pnpm why @lingui/react / yarn why @lingui/react).",
       )
     }
   }

--- a/packages/react/src/Trans.test.tsx
+++ b/packages/react/src/Trans.test.tsx
@@ -109,14 +109,16 @@ describe("Trans component", () => {
 
       expect(() => render(<Trans id="unknown" />))
         .toThrowErrorMatchingInlineSnapshot(`
-          [Error: Trans component was rendered without I18nProvider.
-          Attempted to render message: undefined id: unknown. Make sure this component is rendered inside a I18nProvider.]
+          [Error: Trans component was rendered without I18nProvider. Attempted to render message: undefined id: unknown. Make sure this component is rendered inside a I18nProvider.
+
+          This often happens when multiple instances of @lingui/react are installed (e.g. due to a version mismatch or misconfiguration in a monorepo). Verify you have only one version installed by running: npm ls @lingui/react (or pnpm why @lingui/react / yarn why @lingui/react).]
         `)
       expect(() =>
         render(<Trans id="unknown" message={"some valid message"} />),
       ).toThrowErrorMatchingInlineSnapshot(`
-        [Error: Trans component was rendered without I18nProvider.
-        Attempted to render message: some valid message id: unknown. Make sure this component is rendered inside a I18nProvider.]
+        [Error: Trans component was rendered without I18nProvider. Attempted to render message: some valid message id: unknown. Make sure this component is rendered inside a I18nProvider.
+
+        This often happens when multiple instances of @lingui/react are installed (e.g. due to a version mismatch or misconfiguration in a monorepo). Verify you have only one version installed by running: npm ls @lingui/react (or pnpm why @lingui/react / yarn why @lingui/react).]
       `)
 
       console.error = originalConsole

--- a/packages/react/src/Trans.tsx
+++ b/packages/react/src/Trans.tsx
@@ -4,8 +4,14 @@ import { TransNoContext, type TransProps } from "./TransNoContext"
 export function Trans(props: TransProps): React.ReactElement<any, any> | null {
   let errMessage = undefined
   if (process.env.NODE_ENV !== "production") {
-    errMessage = `Trans component was rendered without I18nProvider.
-Attempted to render message: ${props.message} id: ${props.id}. Make sure this component is rendered inside a I18nProvider.`
+    errMessage =
+      `Trans component was rendered without I18nProvider. ` +
+      `Attempted to render message: ${props.message} id: ${props.id}. ` +
+      `Make sure this component is rendered inside a I18nProvider.` +
+      `\n\nThis often happens when multiple instances of @lingui/react are installed ` +
+      `(e.g. due to a version mismatch or misconfiguration in a monorepo). ` +
+      `Verify you have only one version installed by running: ` +
+      `npm ls @lingui/react (or pnpm why @lingui/react / yarn why @lingui/react).`
   }
   const lingui = useLinguiInternal(errMessage)
 

--- a/packages/solid/src/I18nProvider.tsx
+++ b/packages/solid/src/I18nProvider.tsx
@@ -33,7 +33,12 @@ export const useLinguiInternal = (devErrorMessage?: string): I18nContext => {
 
   if (process.env.NODE_ENV !== "production" && context == null) {
     throw new Error(
-      devErrorMessage ?? "useLingui hook was used without I18nProvider.",
+      devErrorMessage ??
+        "useLingui hook was used without I18nProvider." +
+          "\n\nThis often happens when multiple instances of @lingui/solid are installed " +
+          "(e.g. due to a version mismatch or misconfiguration in a monorepo). " +
+          "Verify you have only one version installed by running: " +
+          "npm ls @lingui/solid (or pnpm why @lingui/solid / yarn why @lingui/solid).",
     )
   }
 

--- a/packages/solid/src/Trans.test.tsx
+++ b/packages/solid/src/Trans.test.tsx
@@ -111,14 +111,16 @@ describe("Trans component", () => {
       mockConsole(() => {
         expect(() => render(() => <Trans id="unknown" />))
           .toThrowErrorMatchingInlineSnapshot(`
-          [Error: Trans component was rendered without I18nProvider.
-          Attempted to render message: undefined id: unknown. Make sure this component is rendered inside a I18nProvider.]
-        `)
+            [Error: Trans component was rendered without I18nProvider. Attempted to render message: undefined id: unknown. Make sure this component is rendered inside a I18nProvider.
+
+            This often happens when multiple instances of @lingui/solid are installed (e.g. due to a version mismatch or misconfiguration in a monorepo). Verify you have only one version installed by running: npm ls @lingui/solid (or pnpm why @lingui/solid / yarn why @lingui/solid).]
+          `)
         expect(() =>
           render(() => <Trans id="unknown" message={"some valid message"} />),
         ).toThrowErrorMatchingInlineSnapshot(`
-          [Error: Trans component was rendered without I18nProvider.
-          Attempted to render message: some valid message id: unknown. Make sure this component is rendered inside a I18nProvider.]
+          [Error: Trans component was rendered without I18nProvider. Attempted to render message: some valid message id: unknown. Make sure this component is rendered inside a I18nProvider.
+
+          This often happens when multiple instances of @lingui/solid are installed (e.g. due to a version mismatch or misconfiguration in a monorepo). Verify you have only one version installed by running: npm ls @lingui/solid (or pnpm why @lingui/solid / yarn why @lingui/solid).]
         `)
       })
     })

--- a/packages/solid/src/Trans.tsx
+++ b/packages/solid/src/Trans.tsx
@@ -6,8 +6,14 @@ export function Trans(props: TransProps): JSXElement {
   let errMessage = undefined
 
   if (process.env.NODE_ENV !== "production") {
-    errMessage = `Trans component was rendered without I18nProvider.
-Attempted to render message: ${props.message} id: ${props.id}. Make sure this component is rendered inside a I18nProvider.`
+    errMessage =
+      `Trans component was rendered without I18nProvider. ` +
+      `Attempted to render message: ${props.message} id: ${props.id}. ` +
+      `Make sure this component is rendered inside a I18nProvider.` +
+      `\n\nThis often happens when multiple instances of @lingui/solid are installed ` +
+      `(e.g. due to a version mismatch or misconfiguration in a monorepo). ` +
+      `Verify you have only one version installed by running: ` +
+      `npm ls @lingui/solid (or pnpm why @lingui/solid / yarn why @lingui/solid).`
   }
 
   const lingui = useLinguiInternal(errMessage)


### PR DESCRIPTION
# Description

That happened in our monorepo very often. When dependabot or renovate bumps versions, sometimes it left two version at the same time (one in the app another in the package for example) and it breaks the app. 

 Each error message now appends a paragraph explaining that the most common cause is having multiple instances of @lingui/react (or @lingui/solid) installed, and suggests running `npm ls @lingui/react` (or `pnpm why` / `yarn why`) to verify only one version is present.


## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
