### PR TITLE
feat(babel-plugin-lingui-macro): add nested `msg` and `t` support

### DIFF
--- a/packages/babel-plugin-lingui-macro/src/macroJsAst.ts
+++ b/packages/babel-plugin-lingui-macro/src/macroJsAst.ts
@@ -115,6 +115,11 @@ export function tokenizeNode(
     return tokenizeTemplateLiteral(node as Expression, ctx)
   }
 
+  // msg`...` / defineMessage`...`
+  if (t.isTaggedTemplateExpression(node) && isDefineMessage(node.tag, ctx)) {
+    return tokenizeTemplateLiteral(node as Expression, ctx)
+  }
+
   if (t.isCallExpression(node) && isArgDecorator(node, ctx)) {
     return [tokenizeArg(node, ctx)]
   }
@@ -164,9 +169,10 @@ export function tokenizeTemplateLiteral(
     const currExp = expressions[i]
 
     if (currExp) {
-      argTokens = t.isCallExpression(currExp)
-        ? tokenizeNode(currExp, false, ctx)
-        : [tokenizeExpression(currExp, ctx)]
+      argTokens =
+        t.isCallExpression(currExp) || t.isTaggedTemplateExpression(currExp)
+          ? tokenizeNode(currExp, false, ctx)
+          : [tokenizeExpression(currExp, ctx)]
     }
     const textToken: TextToken = {
       type: "text",
@@ -217,6 +223,8 @@ export function tokenizeChoiceComponent(
       if (t.isTemplateLiteral(attrValue)) {
         value = tokenizeTemplateLiteral(attrValue, ctx)
       } else if (t.isCallExpression(attrValue)) {
+        value = tokenizeNode(attrValue, false, ctx)
+      } else if (t.isTaggedTemplateExpression(attrValue)) {
         value = tokenizeNode(attrValue, false, ctx)
       } else if (t.isStringLiteral(attrValue)) {
         value = attrValue.value

--- a/packages/babel-plugin-lingui-macro/test/__snapshots__/js-plural.test.ts.snap
+++ b/packages/babel-plugin-lingui-macro/test/__snapshots__/js-plural.test.ts.snap
@@ -147,6 +147,52 @@ _i18n._(
 
 `;
 
+exports[`Support msg tagged template as option value 1`] = `
+import { plural, msg } from "@lingui/core/macro";
+const a = plural(count, {
+  one: msg\`# book\`,
+  other: msg\`# books\`,
+});
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { i18n as _i18n } from "@lingui/core";
+const a = _i18n._(
+  /** i18n */
+  {
+    id: "esnaQO",
+    message: "{count, plural, one {# book} other {# books}}",
+    values: {
+      count: count,
+    },
+  },
+);
+
+`;
+
+exports[`Support t tagged template as option value 1`] = `
+import { plural, t } from "@lingui/core/macro";
+const a = plural(count, {
+  one: t\`# book\`,
+  other: t\`# books\`,
+});
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { i18n as _i18n } from "@lingui/core";
+const a = _i18n._(
+  /** i18n */
+  {
+    id: "esnaQO",
+    message: "{count, plural, one {# book} other {# books}}",
+    values: {
+      count: count,
+    },
+  },
+);
+
+`;
+
 exports[`plural macro could be renamed 1`] = `
 import { plural as plural2 } from "@lingui/core/macro";
 const a = plural2(count, {

--- a/packages/babel-plugin-lingui-macro/test/__snapshots__/js-select.test.ts.snap
+++ b/packages/babel-plugin-lingui-macro/test/__snapshots__/js-select.test.ts.snap
@@ -58,3 +58,56 @@ _i18n._(
 );
 
 `;
+
+exports[`Support msg tagged template as option value in select 1`] = `
+import { select, msg } from "@lingui/core/macro";
+select(gender, {
+  male: msg\`He\`,
+  female: msg\`She\`,
+  other: msg\`They\`,
+});
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { i18n as _i18n } from "@lingui/core";
+_i18n._(
+  /** i18n */
+  {
+    id: "3pNdua",
+    message: "{gender, select, male {He} female {She} other {They}}",
+    values: {
+      gender: gender,
+    },
+  },
+);
+
+`;
+
+exports[`Support plural with nested msg in options 1`] = `
+import { select, plural, msg } from "@lingui/core/macro";
+select(gender, {
+  male: plural(numOfGuests, {
+    one: msg\`He invites one guest\`,
+    other: msg\`He invites # guests\`,
+  }),
+  female: msg\`She\`,
+  other: msg\`They\`,
+});
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { i18n as _i18n } from "@lingui/core";
+_i18n._(
+  /** i18n */
+  {
+    id: "ybw1EB",
+    message:
+      "{gender, select, male {{numOfGuests, plural, one {He invites one guest} other {He invites # guests}}} female {She} other {They}}",
+    values: {
+      gender: gender,
+      numOfGuests: numOfGuests,
+    },
+  },
+);
+
+`;

--- a/packages/babel-plugin-lingui-macro/test/__snapshots__/js-t.test.ts.snap
+++ b/packages/babel-plugin-lingui-macro/test/__snapshots__/js-t.test.ts.snap
@@ -427,7 +427,7 @@ _i18n._(
 exports[`Support nested t in t message description 1`] = `
 import { t, msg } from "@lingui/core/macro";
 t({
-  message: msg\`Hello \${name}\`,
+  message: t\`Hello \${name}\`,
 });
 
 ↓ ↓ ↓ ↓ ↓ ↓

--- a/packages/babel-plugin-lingui-macro/test/__snapshots__/js-t.test.ts.snap
+++ b/packages/babel-plugin-lingui-macro/test/__snapshots__/js-t.test.ts.snap
@@ -365,23 +365,6 @@ const msg = _i18n._(
 
 `;
 
-exports[`Support msg in t 1`] = `
-import { t, msg } from "@lingui/core/macro";
-t\`Field \${msg\`First Name\`} is required\`;
-
-↓ ↓ ↓ ↓ ↓ ↓
-
-import { i18n as _i18n } from "@lingui/core";
-_i18n._(
-  /** i18n */
-  {
-    id: "-nmgWY",
-    message: "Field First Name is required",
-  },
-);
-
-`;
-
 exports[`Support nested msg in t 1`] = `
 import { t, msg } from "@lingui/core/macro";
 t\`Field \${msg\`First Name\`} is required\`;
@@ -458,43 +441,6 @@ _i18n._(
     values: {
       name: name,
     },
-  },
-);
-
-`;
-
-exports[`Support nested t with expressions 1`] = `
-import { t } from "@lingui/core/macro";
-t\`Outer \${t\`Inner \${name}\`} end\`;
-
-↓ ↓ ↓ ↓ ↓ ↓
-
-import { i18n as _i18n } from "@lingui/core";
-_i18n._(
-  /** i18n */
-  {
-    id: "JWugZU",
-    message: "Outer Inner {name} end",
-    values: {
-      name: name,
-    },
-  },
-);
-
-`;
-
-exports[`Support t in t 1`] = `
-import { t } from "@lingui/core/macro";
-t\`Field \${t\`First Name\`} is required\`;
-
-↓ ↓ ↓ ↓ ↓ ↓
-
-import { i18n as _i18n } from "@lingui/core";
-_i18n._(
-  /** i18n */
-  {
-    id: "-nmgWY",
-    message: "Field First Name is required",
   },
 );
 

--- a/packages/babel-plugin-lingui-macro/test/__snapshots__/js-t.test.ts.snap
+++ b/packages/babel-plugin-lingui-macro/test/__snapshots__/js-t.test.ts.snap
@@ -365,6 +365,43 @@ const msg = _i18n._(
 
 `;
 
+exports[`Support msg in t 1`] = `
+import { t, msg } from "@lingui/core/macro";
+t\`Field \${msg\`First Name\`} is required\`;
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { i18n as _i18n } from "@lingui/core";
+_i18n._(
+  /** i18n */
+  {
+    id: "-nmgWY",
+    message: "Field First Name is required",
+  },
+);
+
+`;
+
+exports[`Support nested t with expressions 1`] = `
+import { t } from "@lingui/core/macro";
+t\`Outer \${t\`Inner \${name}\`} end\`;
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { i18n as _i18n } from "@lingui/core";
+_i18n._(
+  /** i18n */
+  {
+    id: "JWugZU",
+    message: "Outer Inner {name} end",
+    values: {
+      name: name,
+    },
+  },
+);
+
+`;
+
 exports[`Support t in t 1`] = `
 import { t } from "@lingui/core/macro";
 t\`Field \${t\`First Name\`} is required\`;
@@ -375,17 +412,8 @@ import { i18n as _i18n } from "@lingui/core";
 _i18n._(
   /** i18n */
   {
-    id: "O8dJMg",
-    message: "Field {0} is required",
-    values: {
-      0: _i18n._(
-        /** i18n */
-        {
-          id: "kODvZJ",
-          message: "First Name",
-        },
-      ),
-    },
+    id: "-nmgWY",
+    message: "Field First Name is required",
   },
 );
 
@@ -511,26 +539,6 @@ _i18n._(
 
 `;
 
-exports[`Variables with non-null assertion get a named placeholder (parity with \`as\`) 1`] = `
-import { t } from "@lingui/core/macro";
-t\`Variable \${name!}\`;
-
-↓ ↓ ↓ ↓ ↓ ↓
-
-import { i18n as _i18n } from "@lingui/core";
-_i18n._(
-  /** i18n */
-  {
-    id: "xRRkAE",
-    message: "Variable {name}",
-    values: {
-      name: name,
-    },
-  },
-);
-
-`;
-
 exports[`Variables with escaped double quotes are correctly formatted 1`] = `
 import { t } from "@lingui/core/macro";
 t\`Variable "name"\`;
@@ -622,6 +630,26 @@ _i18n._(
     message: "Variable {name}",
     values: {
       name: random(),
+    },
+  },
+);
+
+`;
+
+exports[`Variables with non-null assertion get a named placeholder (parity with \`as\`) 1`] = `
+import { t } from "@lingui/core/macro";
+t\`Variable \${name!}\`;
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { i18n as _i18n } from "@lingui/core";
+_i18n._(
+  /** i18n */
+  {
+    id: "xRRkAE",
+    message: "Variable {name}",
+    values: {
+      name: name,
     },
   },
 );

--- a/packages/babel-plugin-lingui-macro/test/__snapshots__/js-t.test.ts.snap
+++ b/packages/babel-plugin-lingui-macro/test/__snapshots__/js-t.test.ts.snap
@@ -382,6 +382,87 @@ _i18n._(
 
 `;
 
+exports[`Support nested msg in t 1`] = `
+import { t, msg } from "@lingui/core/macro";
+t\`Field \${msg\`First Name\`} is required\`;
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { i18n as _i18n } from "@lingui/core";
+_i18n._(
+  /** i18n */
+  {
+    id: "-nmgWY",
+    message: "Field First Name is required",
+  },
+);
+
+`;
+
+exports[`Support nested msg in t message description 1`] = `
+import { t, msg } from "@lingui/core/macro";
+t({
+  message: msg\`Hello \${name}\`,
+});
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { i18n as _i18n } from "@lingui/core";
+_i18n._(
+  /** i18n */
+  {
+    id: "OVaF9k",
+    message: "Hello {name}",
+    values: {
+      name: name,
+    },
+  },
+);
+
+`;
+
+exports[`Support nested t in t 1`] = `
+import { t } from "@lingui/core/macro";
+t\`Outer \${t\`Inner \${name}\`} end\`;
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { i18n as _i18n } from "@lingui/core";
+_i18n._(
+  /** i18n */
+  {
+    id: "JWugZU",
+    message: "Outer Inner {name} end",
+    values: {
+      name: name,
+    },
+  },
+);
+
+`;
+
+exports[`Support nested t in t message description 1`] = `
+import { t, msg } from "@lingui/core/macro";
+t({
+  message: msg\`Hello \${name}\`,
+});
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { i18n as _i18n } from "@lingui/core";
+_i18n._(
+  /** i18n */
+  {
+    id: "OVaF9k",
+    message: "Hello {name}",
+    values: {
+      name: name,
+    },
+  },
+);
+
+`;
+
 exports[`Support nested t with expressions 1`] = `
 import { t } from "@lingui/core/macro";
 t\`Outer \${t\`Inner \${name}\`} end\`;

--- a/packages/babel-plugin-lingui-macro/test/js-plural.test.ts
+++ b/packages/babel-plugin-lingui-macro/test/js-plural.test.ts
@@ -80,5 +80,25 @@ macroTester({
         });
       `,
     },
+    {
+      name: "Support msg tagged template as option value",
+      code: `
+        import { plural, msg } from '@lingui/core/macro'
+        const a = plural(count, {
+          one: msg\`# book\`,
+          other: msg\`# books\`
+        });
+      `,
+    },
+    {
+      name: "Support t tagged template as option value",
+      code: `
+        import { plural, t } from '@lingui/core/macro'
+        const a = plural(count, {
+          one: t\`# book\`,
+          other: t\`# books\`
+        });
+      `,
+    },
   ],
 })

--- a/packages/babel-plugin-lingui-macro/test/js-select.test.ts
+++ b/packages/babel-plugin-lingui-macro/test/js-select.test.ts
@@ -31,5 +31,30 @@ macroTester({
         });
       `,
     },
+    {
+      name: "Support msg tagged template as option value in select",
+      code: `
+        import { select, msg } from '@lingui/core/macro'
+        select(gender, {
+          male: msg\`He\`,
+          female: msg\`She\`,
+          other: msg\`They\`
+        });
+      `,
+    },
+    {
+      name: "Support plural with nested msg in options",
+      code: `
+        import { select, plural, msg } from '@lingui/core/macro'
+        select(gender, {
+          male: plural(numOfGuests, {
+            one: msg\`He invites one guest\`,
+            other: msg\`He invites # guests\`
+          }),
+          female: msg\`She\`,
+          other: msg\`They\`
+        });
+      `,
+    },
   ],
 })

--- a/packages/babel-plugin-lingui-macro/test/js-t.test.ts
+++ b/packages/babel-plugin-lingui-macro/test/js-t.test.ts
@@ -326,7 +326,7 @@ macroTester({
         import { t, msg } from '@lingui/core/macro';
         
         t({
-            message: msg\`Hello \${name}\`,
+            message: t\`Hello \${name}\`,
         })
     `,
     },

--- a/packages/babel-plugin-lingui-macro/test/js-t.test.ts
+++ b/packages/babel-plugin-lingui-macro/test/js-t.test.ts
@@ -297,25 +297,38 @@ macroTester({
       filename: "js-t-var/js-t-var.js",
     },
     {
-      name: "Support t in t",
-      code: `
-        import { t } from '@lingui/core/macro'
-        t\`Field \${t\`First Name\`} is required\`
-      `,
-    },
-    {
-      name: "Support msg in t",
+      name: "Support nested msg in t",
       code: `
         import { t, msg } from '@lingui/core/macro'
         t\`Field \${msg\`First Name\`} is required\`
       `,
     },
     {
-      name: "Support nested t with expressions",
+      name: "Support nested t in t",
       code: `
         import { t } from '@lingui/core/macro'
         t\`Outer \${t\`Inner \${name}\`} end\`
       `,
+    },
+    {
+      name: "Support nested msg in t message description",
+      code: `
+        import { t, msg } from '@lingui/core/macro';
+        
+        t({
+            message: msg\`Hello \${name}\`,
+        })
+    `,
+    },
+    {
+      name: "Support nested t in t message description",
+      code: `
+        import { t, msg } from '@lingui/core/macro';
+        
+        t({
+            message: msg\`Hello \${name}\`,
+        })
+    `,
     },
     {
       name: "should correctly process nested macro when referenced from different imports",

--- a/packages/babel-plugin-lingui-macro/test/js-t.test.ts
+++ b/packages/babel-plugin-lingui-macro/test/js-t.test.ts
@@ -304,6 +304,20 @@ macroTester({
       `,
     },
     {
+      name: "Support msg in t",
+      code: `
+        import { t, msg } from '@lingui/core/macro'
+        t\`Field \${msg\`First Name\`} is required\`
+      `,
+    },
+    {
+      name: "Support nested t with expressions",
+      code: `
+        import { t } from '@lingui/core/macro'
+        t\`Outer \${t\`Inner \${name}\`} end\`
+      `,
+    },
+    {
       name: "should correctly process nested macro when referenced from different imports",
       code: `
         import { t } from '@lingui/core/macro'


### PR DESCRIPTION
# Description

Currently, `plural/select/selectOrdinal` macros are inlined into the ICU message string when nested inside `t` or `msg`. But `t` and `msg` tagged template macros are NOT inlined when nested — they produce separate `i18n._()` calls and become opaque positional placeholders ({0}). This PR making `t` and `msg` tagged templates also inline their message content when nested.

Before (current): ``t`Field ${t`First Name`} is required` ``→ two separate `i18n._()` calls, outer message is `"Field {0} is required"`

After (desired): ``t`Field ${t`First Name`} is required` `` → single call, message is `"Field First Name is required"`

This is basically needed for https://github.com/lingui/js-lingui/pull/2618 where option values cannot be template literals:

> Template literals inside plural/select options (e.g., `She is ${gender}`) are already evaluated by the time they reach the function. However, the full functionality is preserved — instead of a plain template literal, users wrap it with t to produce a macro marker: `` t`She is ${{gender}}` `` instead of `She is ${gender}`. Nested macro markers (plural, select, selectOrdinal) work as option values as well.

Example of pattern which is supported now by compile time macro (note the nested `msg` in the option): 
```js
plural({ count }, { 0: msg`No books {{placeholder}}`, 1: msg`One book`, other: "# books" })}
```

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

Fixes # (issue)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
