### PR TITLE
fix(babel-plugin-lingui-macro): restore `@babel/types` as a runtime dependency

### DIFF
--- a/packages/babel-plugin-lingui-macro/package.json
+++ b/packages/babel-plugin-lingui-macro/package.json
@@ -55,18 +55,15 @@
     "node": ">=22.19.0"
   },
   "dependencies": {
+    "@babel/types": "^7.20.7",
     "@lingui/conf": "workspace:*",
     "@lingui/message-utils": "workspace:*"
   },
   "peerDependencies": {
-    "@babel/core": "^7.20.12 || ^8.0.0",
-    "@babel/types": "^7.20.7 || ^8.0.0"
+    "@babel/core": "^7.20.12 || ^8.0.0"
   },
   "peerDependenciesMeta": {
     "@babel/core": {
-      "optional": true
-    },
-    "@babel/types": {
       "optional": true
     }
   },
@@ -76,7 +73,6 @@
     "@babel/plugin-syntax-jsx": "^7.28.6",
     "@babel/preset-typescript": "^7.18.6",
     "@babel/traverse": "^7.20.12",
-    "@babel/types": "^7.29.0",
     "babel-plugin-macros": "^3.1.0",
     "babel-plugin-react-compiler": "^1.0.0",
     "prettier": "3.9.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1464,7 +1464,7 @@ __metadata:
     "@babel/plugin-syntax-jsx": "npm:^7.28.6"
     "@babel/preset-typescript": "npm:^7.18.6"
     "@babel/traverse": "npm:^7.20.12"
-    "@babel/types": "npm:^7.29.0"
+    "@babel/types": "npm:^7.20.7"
     "@lingui/conf": "workspace:*"
     "@lingui/message-utils": "workspace:*"
     babel-plugin-macros: "npm:^3.1.0"
@@ -1475,11 +1475,8 @@ __metadata:
     vitest: "catalog:"
   peerDependencies:
     "@babel/core": ^7.20.12 || ^8.0.0
-    "@babel/types": ^7.20.7 || ^8.0.0
   peerDependenciesMeta:
     "@babel/core":
-      optional: true
-    "@babel/types":
       optional: true
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
`@babel/types` is imported as a runtime value in ~140 places across the plugin sources (`t.identifier`, `t.stringLiteral`, `t.isStringLiteral`, …) and survives into the build as `import * as t from '@babel/types'` in `dist/shared/*.mjs`.

#2623 moved it from `dependencies` to an *optional* `peerDependency`, so package managers neither install it nor warn. Resolution then only succeeded when `@babel/types` happened to be hoisted into the consumer tree; under strict or nested resolution it failed with `ERR_MODULE_NOT_FOUND`.

Move it back into `dependencies` and drop the redundant devDependency entry. `@babel/core` stays an optional peer since it is type-only at runtime, so Babel 8 support from #2623 is unaffected.

Fixes #2628

# Description

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
