### PR TITLE
fix(cli): export types needed by TypeScript

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,1 +1,2 @@
+export type * from "@lingui/conf"
 export { defineConfig } from "@lingui/conf"


### PR DESCRIPTION
# Description

Fixes the following TypeScript error:

> The inferred type of 'default' cannot be named without a reference to 'LinguiConfig' from '.pnpm/@lingui+conf@6.6.0/node_modules/@lingui/conf'. This is likely not portable. A type annotation is necessary.

<img width="1426" height="420" alt="Capture d’écran 2026-08-03 à 13 18 04" src="https://github.com/user-attachments/assets/122311ec-198f-4cdb-a7c1-340bb63a5663" />


<img width="1385" height="371" alt="Capture d’écran 2026-08-03 à 13 20 32" src="https://github.com/user-attachments/assets/45640969-094d-4390-b429-ff3bde70f3d2" />


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

Fixes # (issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
