### PR TITLE
feat(cli): move the extractor toolchain to Babel 8

### DIFF
--- a/packages/babel-plugin-extract-messages/package.json
+++ b/packages/babel-plugin-extract-messages/package.json
@@ -46,9 +46,9 @@
     "@lingui/conf": "workspace:*"
   },
   "devDependencies": {
-    "@babel/core": "^7.29.0",
-    "@babel/traverse": "^7.29.0",
-    "@babel/types": "^7.29.0",
+    "@babel/core": "^8.0.0",
+    "@babel/traverse": "^8.0.0",
+    "@babel/types": "^8.0.0",
     "@lingui/babel-plugin-lingui-macro": "workspace:*",
     "@lingui/test-utils": "workspace:*",
     "typescript": "catalog:",

--- a/packages/babel-plugin-extract-messages/src/index.ts
+++ b/packages/babel-plugin-extract-messages/src/index.ts
@@ -8,14 +8,24 @@ import type {
   ObjectProperty,
   // eslint-disable-next-line import/no-duplicates
 } from "@babel/types"
-import type { PluginObj, PluginPass, NodePath } from "@babel/core"
-import type { Hub } from "@babel/traverse"
+import type { PluginPass, NodePath, Visitor } from "@babel/core"
+import type { HubInterface } from "@babel/traverse"
 import {
   getConfig as loadConfig,
   type LinguiConfigNormalized,
 } from "@lingui/conf"
 
 type BabelTypes = typeof BabelTypesNamespace
+
+/**
+ * `@babel/core` exports this shape as `PluginObj` in Babel 7 and `PluginObject`
+ * in Babel 8. Declaring it structurally keeps the plugin type-checking against
+ * either major, matching the `^7 || ^8` peer range.
+ */
+type PluginObj = {
+  name?: string
+  visitor: Visitor<PluginPass>
+}
 
 export type ExtractedMessage = {
   id: string
@@ -71,7 +81,7 @@ function collectMessage(
 function getTextFromExpression(
   t: BabelTypes,
   exp: Expression,
-  hub: Hub,
+  hub: HubInterface,
   emitErrorOnVariable = true,
 ): string {
   if (t.isStringLiteral(exp)) {
@@ -130,7 +140,7 @@ function getNodeSource(fileContents: string, node: Node) {
 function valuesObjectExpressionToPlaceholdersRecord(
   t: BabelTypes,
   exp: ObjectExpression,
-  hub: Hub,
+  hub: HubInterface,
 ) {
   const props: Record<string, string> = {}
 
@@ -162,7 +172,7 @@ function valuesObjectExpressionToPlaceholdersRecord(
 function extractFromObjectExpression(
   t: BabelTypes,
   exp: ObjectExpression,
-  hub: Hub,
+  hub: HubInterface,
 ) {
   const props: RawMessage = {}
 

--- a/packages/babel-plugin-lingui-macro/package.json
+++ b/packages/babel-plugin-lingui-macro/package.json
@@ -71,12 +71,12 @@
     }
   },
   "devDependencies": {
-    "@babel/core": "^7.29.0",
-    "@babel/parser": "^7.29.2",
-    "@babel/plugin-syntax-jsx": "^7.28.6",
-    "@babel/preset-typescript": "^7.18.6",
-    "@babel/traverse": "^7.20.12",
-    "@babel/types": "^7.29.0",
+    "@babel/core": "^8.0.0",
+    "@babel/parser": "^8.0.0",
+    "@babel/plugin-syntax-jsx": "^8.0.0",
+    "@babel/preset-typescript": "^8.0.0",
+    "@babel/traverse": "^8.0.0",
+    "@babel/types": "^8.0.0",
     "babel-plugin-macros": "^3.1.0",
     "babel-plugin-react-compiler": "^1.0.0",
     "prettier": "3.9.6",

--- a/packages/babel-plugin-lingui-macro/src/index.ts
+++ b/packages/babel-plugin-lingui-macro/src/index.ts
@@ -1,4 +1,15 @@
-import type { PluginObj, PluginPass, Visitor } from "@babel/core"
+import type { PluginPass, Visitor } from "@babel/core"
+
+/**
+ * `@babel/core` exports this shape as `PluginObj` in Babel 7 and `PluginObject`
+ * in Babel 8. Declaring it structurally keeps the plugin type-checking against
+ * either major, matching the `^7 || ^8` peer range.
+ */
+type PluginObj = {
+  name?: string
+  visitor: Visitor<PluginPass>
+}
+
 import type * as babelTypes from "@babel/types"
 import { Expression, Identifier, Program } from "@babel/types"
 import { MacroJSX } from "./macroJsx"
@@ -397,7 +408,6 @@ function wrapJsxElementAsComponent(
       ),
       null,
       [],
-      true,
     ),
   )
 }

--- a/packages/babel-plugin-lingui-macro/src/macro.ts
+++ b/packages/babel-plugin-lingui-macro/src/macro.ts
@@ -1,5 +1,14 @@
-import type { VisitNodeObject } from "@babel/traverse"
-import { Program } from "@babel/types"
+import type { NodePath } from "@babel/core"
+
+/**
+ * `@babel/traverse` 8 stopped exporting `VisitNodeObject`. Declare the same
+ * shape locally so this resolves against either major.
+ */
+type VisitNodeObject<S, P extends Node> = {
+  enter?: (path: NodePath<P>, state: S) => void
+  exit?: (path: NodePath<P>, state: S) => void
+}
+import { Node, Program } from "@babel/types"
 
 import linguiPlugin from "./index"
 import * as Babel from "@babel/core"

--- a/packages/babel-plugin-lingui-macro/src/macroJsAst.test.ts
+++ b/packages/babel-plugin-lingui-macro/src/macroJsAst.test.ts
@@ -5,7 +5,7 @@ import {
   createMacroJsContext,
 } from "./macroJsAst"
 import type { NodePath } from "@babel/traverse"
-import { transformSync } from "@babel/core"
+import { transformSync, type PluginItem } from "@babel/core"
 import { JsMacroName } from "./constants"
 
 const parseExpression = (expression: string) => {
@@ -18,7 +18,9 @@ const parseExpression = (expression: string) => {
     presets: [],
     plugins: [
       "@babel/plugin-syntax-jsx",
-      {
+      // Babel 8 narrows PluginTarget to a string or a plugin factory, so an
+      // inline plugin is expressed as a function returning the visitor.
+      (() => ({
         visitor: {
           "CallExpression|TaggedTemplateExpression": (
             d: NodePath<Expression>,
@@ -27,7 +29,7 @@ const parseExpression = (expression: string) => {
             d.stop()
           },
         },
-      },
+      })) as PluginItem,
     ],
   })
 

--- a/packages/babel-plugin-lingui-macro/src/macroJsx.test.ts
+++ b/packages/babel-plugin-lingui-macro/src/macroJsx.test.ts
@@ -17,17 +17,19 @@ const parseExpression = (expression: string) => {
     presets: [],
     plugins: [
       "@babel/plugin-syntax-jsx",
-      {
+      // Babel 8 narrows PluginTarget to a string or a plugin factory, so an
+      // inline plugin is expressed as a function returning the visitor.
+      () => ({
         visitor: {
           JSXElement: (d, state) => {
             state.set("linguiConfig", makeConfig({}, { skipValidation: true }))
 
-            path = d
+            path = d as NodePath<JSXElement>
             path.context.state = state
             d.stop()
           },
         },
-      },
+      }),
     ],
   })
 

--- a/packages/babel-plugin-lingui-macro/src/macroJsx.ts
+++ b/packages/babel-plugin-lingui-macro/src/macroJsx.ts
@@ -142,7 +142,6 @@ export class MacroJSX {
       ),
       null,
       [],
-      true,
     )
     newNode.loc = path.node.loc
 
@@ -206,7 +205,7 @@ export class MacroJSX {
       // plural, select and selectOrdinal
       return [
         this.tokenizeChoiceComponent(
-          path as NodePath<JSXElement>,
+          path as unknown as NodePath<JSXElement>,
           componentName,
         ),
       ]

--- a/packages/babel-plugin-lingui-macro/test/macroTester.ts
+++ b/packages/babel-plugin-lingui-macro/test/macroTester.ts
@@ -1,5 +1,9 @@
 import linguiMacroPlugin, { LinguiPluginOpts } from "../src"
-import { transformFileSync, transformSync, TransformOptions } from "@babel/core"
+import { transformFileSync, transformSync, type PluginItem } from "@babel/core"
+
+// `TransformOptions` in Babel 7 is `InputOptions` in Babel 8; derive it from
+// the function signature so either major resolves.
+type TransformOptions = NonNullable<Parameters<typeof transformSync>[1]>
 import { format } from "prettier"
 import path from "path"
 import fs from "fs"
@@ -234,7 +238,7 @@ export const getDefaultBabelOptions = (
               {
                 panicThreshold: "critical_errors",
               },
-            ],
+            ] as PluginItem,
           ]
         : []),
     ],

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -50,10 +50,10 @@
     "dist/"
   ],
   "dependencies": {
-    "@babel/core": "^7.21.0",
-    "@babel/generator": "^7.28.5",
-    "@babel/parser": "^7.22.0",
-    "@babel/types": "^7.21.2",
+    "@babel/core": "^8.0.0",
+    "@babel/generator": "^8.0.0",
+    "@babel/parser": "^8.0.0",
+    "@babel/types": "^8.0.0",
     "@lingui/babel-plugin-extract-messages": "workspace:*",
     "@lingui/babel-plugin-lingui-macro": "workspace:*",
     "@lingui/conf": "workspace:*",

--- a/packages/cli/src/api/extractors/babel.ts
+++ b/packages/cli/src/api/extractors/babel.ts
@@ -1,4 +1,8 @@
-import { DEFAULT_EXTENSIONS, transformAsync, ParserOptions } from "@babel/core"
+import {
+  DEFAULT_EXTENSIONS,
+  transformAsync,
+  type PluginItem,
+} from "@babel/core"
 
 import type {
   ExtractPluginOpts,
@@ -7,7 +11,7 @@ import type {
 import linguiExtractMessages from "@lingui/babel-plugin-extract-messages"
 
 import { ExtractorType, ExtractedMessage, ExtractorCtx } from "@lingui/conf"
-import { ParserPlugin } from "@babel/parser"
+import { ParserOptions, ParserPlugin } from "@babel/parser"
 
 import linguiMacroPlugin, {
   type LinguiPluginOpts,
@@ -143,7 +147,7 @@ export async function extractFromFileWithBabel(
                 descriptorFields: "all",
                 linguiConfig: ctx.linguiConfig,
               } satisfies LinguiPluginOpts,
-            ],
+            ] as PluginItem,
           ]
         : []),
       [
@@ -170,8 +174,8 @@ export function getBabelParserOptions(
 ) {
   // https://babeljs.io/docs/en/babel-parser#latest-ecmascript-features
   const parserPlugins: ParserPlugin[] = [
-    "importAttributes", // stage3
-    "explicitResourceManagement", // stage3,
+    // importAttributes and explicitResourceManagement are enabled by default
+    // in Babel 8 and are no longer accepted as plugin names.
     "decoratorAutoAccessors", // stage3,
     "deferredImportEvaluation", // stage3
   ]

--- a/packages/cli/src/extract-experimental/bundlers/rolldown.ts
+++ b/packages/cli/src/extract-experimental/bundlers/rolldown.ts
@@ -100,7 +100,23 @@ export function createRolldownBundler(
               ],
             })
 
-            return { code: result?.code ?? undefined, map: result?.map }
+            // Babel 8 types the source map's array fields as readonly, while
+            // rolldown's ExistingRawSourceMap requires mutable arrays.
+            const map = result?.map
+              ? {
+                  ...result.map,
+                  names: [...result.map.names],
+                  sources: [...result.map.sources],
+                  sourcesContent: result.map.sourcesContent
+                    ? [...result.map.sourcesContent]
+                    : undefined,
+                  ignoreList: result.map.ignoreList
+                    ? [...result.map.ignoreList]
+                    : undefined,
+                }
+              : undefined
+
+            return { code: result?.code ?? undefined, map }
           },
         },
       }

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -75,7 +75,7 @@
     "@lingui/core": "workspace:*"
   },
   "devDependencies": {
-    "@babel/core": "7.29.7",
+    "@babel/core": "8.0.1",
     "@lingui/test-utils": "workspace:*",
     "@rollup/plugin-babel": "7.1.0",
     "@solidjs/testing-library": "^0.8.10",

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -67,7 +67,7 @@
     }
   },
   "devDependencies": {
-    "@babel/core": "7.29.7",
+    "@babel/core": "8.0.1",
     "@lingui/babel-plugin-lingui-macro": "workspace:^",
     "@lingui/core": "workspace:^",
     "@lingui/format-json": "workspace:^",

--- a/packages/vite-plugin/src/linguiTransformerPreset.ts
+++ b/packages/vite-plugin/src/linguiTransformerPreset.ts
@@ -58,9 +58,12 @@ export const linguiTransformerBabelPreset = (
     .join("|")
 
   return {
+    // Babel 8 narrows PresetItem so a bare preset object no longer satisfies
+    // it, though Babel still accepts one at runtime. Cast rather than reshape
+    // so the emitted preset is unchanged on both majors.
     preset: {
       plugins: [["@lingui/babel-plugin-lingui-macro", options]],
-    },
+    } as unknown as RolldownBabelPreset["preset"],
     rolldown: {
       filter: {
         code: new RegExp(`from ['"](?:${macroPattern})['"]`),

--- a/yarn.lock
+++ b/yarn.lock
@@ -27,6 +27,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/code-frame@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "@babel/code-frame@npm:8.0.0"
+  dependencies:
+    "@babel/helper-validator-identifier": "npm:^8.0.0"
+    js-tokens: "npm:^10.0.0"
+  checksum: 10/735b64f3ae476ec1841be118f79639d2ec99e2cc391a196b0160c53e4ed52253ee5c2170da510c00ea0f23faa26636364052ed507bfa4cd8caea87c5b1e8adad
+  languageName: node
+  linkType: hard
+
 "@babel/compat-data@npm:^7.29.7":
   version: 7.29.7
   resolution: "@babel/compat-data@npm:7.29.7"
@@ -34,7 +44,38 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:7.29.7, @babel/core@npm:^7.17.7, @babel/core@npm:^7.21.0, @babel/core@npm:^7.23.3, @babel/core@npm:^7.24.4, @babel/core@npm:^7.29.0":
+"@babel/compat-data@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "@babel/compat-data@npm:8.0.0"
+  checksum: 10/83b1776ecfdaf02559a4b4fb2f4a2c5e6ba8a2b41bf898807caaf863379ee9c8e91c163de71e79d73eb68659b58bcb18cbcff9a39aae6f88c106af680619326c
+  languageName: node
+  linkType: hard
+
+"@babel/core@npm:8.0.1, @babel/core@npm:^8.0.0":
+  version: 8.0.1
+  resolution: "@babel/core@npm:8.0.1"
+  dependencies:
+    "@babel/code-frame": "npm:^8.0.0"
+    "@babel/generator": "npm:^8.0.0"
+    "@babel/helper-compilation-targets": "npm:^8.0.0"
+    "@babel/helpers": "npm:^8.0.0"
+    "@babel/parser": "npm:^8.0.0"
+    "@babel/template": "npm:^8.0.0"
+    "@babel/traverse": "npm:^8.0.0"
+    "@babel/types": "npm:^8.0.0"
+    "@types/gensync": "npm:^1.0.5"
+    convert-source-map: "npm:^2.0.0"
+    empathic: "npm:^2.0.1"
+    gensync: "npm:^1.0.0-beta.2"
+    import-meta-resolve: "npm:^4.2.0"
+    json5: "npm:^2.2.3"
+    obug: "npm:^2.1.1"
+    semver: "npm:^7.7.3"
+  checksum: 10/def06f2ddcb0cf6872ccbd72742d21b16c4af1eee01b5aae800b4456e03ef50a3f8e976c09158b1a684d0c3f09b6c9a1c1bed65cc15390f0d8abbbe3c9516a28
+  languageName: node
+  linkType: hard
+
+"@babel/core@npm:^7.17.7, @babel/core@npm:^7.23.3, @babel/core@npm:^7.24.4":
   version: 7.29.7
   resolution: "@babel/core@npm:7.29.7"
   dependencies:
@@ -57,7 +98,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/generator@npm:^7.23.6, @babel/generator@npm:^7.28.5, @babel/generator@npm:^7.29.7":
+"@babel/generator@npm:^7.23.6, @babel/generator@npm:^7.29.7":
   version: 7.29.7
   resolution: "@babel/generator@npm:7.29.7"
   dependencies:
@@ -70,12 +111,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-annotate-as-pure@npm:^7.29.7":
-  version: 7.29.7
-  resolution: "@babel/helper-annotate-as-pure@npm:7.29.7"
+"@babel/generator@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "@babel/generator@npm:8.0.0"
   dependencies:
-    "@babel/types": "npm:^7.29.7"
-  checksum: 10/acd9e128de634a5144b5d622357d018fa616de45f64c74e42007c048dd15d0a0be213f4d5a2bf02307bdaddf053791b87900a99d183de828c08dc3b556329009
+    "@babel/parser": "npm:^8.0.0"
+    "@babel/types": "npm:^8.0.0"
+    "@jridgewell/gen-mapping": "npm:^0.3.12"
+    "@jridgewell/trace-mapping": "npm:^0.3.28"
+    "@types/jsesc": "npm:^2.5.0"
+    jsesc: "npm:^3.0.2"
+  checksum: 10/8d9b801886b4bbe46b101768abae0ffa1c9435601a8788358331c115b1a38a7c5acdd0e8b85b4d0c00806b0b74a0cc0e75ef50647f7322ffa3646a238e1b5420
+  languageName: node
+  linkType: hard
+
+"@babel/helper-annotate-as-pure@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "@babel/helper-annotate-as-pure@npm:8.0.0"
+  dependencies:
+    "@babel/types": "npm:^8.0.0"
+  checksum: 10/686ed7f002e0810e675dcd449a1e158f93967a2a89997a96e9275a17fc85f55cfc986d8b44995c915dcbfd3742afe6317bac2dd1037f58aa3997345e77abcb7b
   languageName: node
   linkType: hard
 
@@ -92,20 +147,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-create-class-features-plugin@npm:^7.29.7":
-  version: 7.29.7
-  resolution: "@babel/helper-create-class-features-plugin@npm:7.29.7"
+"@babel/helper-compilation-targets@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "@babel/helper-compilation-targets@npm:8.0.0"
   dependencies:
-    "@babel/helper-annotate-as-pure": "npm:^7.29.7"
-    "@babel/helper-member-expression-to-functions": "npm:^7.29.7"
-    "@babel/helper-optimise-call-expression": "npm:^7.29.7"
-    "@babel/helper-replace-supers": "npm:^7.29.7"
-    "@babel/helper-skip-transparent-expression-wrappers": "npm:^7.29.7"
-    "@babel/traverse": "npm:^7.29.7"
-    semver: "npm:^6.3.1"
+    "@babel/compat-data": "npm:^8.0.0"
+    "@babel/helper-validator-option": "npm:^8.0.0"
+    browserslist: "npm:^4.24.0"
+    lru-cache: "npm:^11.0.0"
+    semver: "npm:^7.7.3"
+  checksum: 10/2814f178f119887abe5221fb6178f62f1adfec9561a915aa67ca65f5ece8d6f1ee83ed731a3e335065d579c1f3c73fc4fdbf83a70fa4ea0113b8932f173b2262
+  languageName: node
+  linkType: hard
+
+"@babel/helper-create-class-features-plugin@npm:^8.0.1":
+  version: 8.0.1
+  resolution: "@babel/helper-create-class-features-plugin@npm:8.0.1"
+  dependencies:
+    "@babel/helper-annotate-as-pure": "npm:^8.0.0"
+    "@babel/helper-member-expression-to-functions": "npm:^8.0.0"
+    "@babel/helper-optimise-call-expression": "npm:^8.0.0"
+    "@babel/helper-replace-supers": "npm:^8.0.1"
+    "@babel/helper-skip-transparent-expression-wrappers": "npm:^8.0.0"
+    "@babel/traverse": "npm:^8.0.0"
+    semver: "npm:^7.7.3"
   peerDependencies:
-    "@babel/core": ^7.0.0
-  checksum: 10/74f871e5389beca9fb52670f2bd83abdd6dc7b7a10f34679ffab5eabf91077dccaabf55438b9f3c897258fb81fbb80bfbf469b836a404abb7e64b4d7c141a8da
+    "@babel/core": ^8.0.0
+  checksum: 10/97d111c4b06da821d4cbd4c8439b7ba9614faaf6a7e565df14660b9a2f8f39aae6b903c07c3f34288ff44ca1c8f95b782430f4ab7afce8a5a0fdd72af914d553
   languageName: node
   linkType: hard
 
@@ -116,13 +184,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-member-expression-to-functions@npm:^7.29.7":
-  version: 7.29.7
-  resolution: "@babel/helper-member-expression-to-functions@npm:7.29.7"
+"@babel/helper-globals@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "@babel/helper-globals@npm:8.0.0"
+  checksum: 10/dbb78c61e46c391d72dabd7fffc87a192350ec4e97314befa928cda14f32c77d30d70560122aec1b15bc287cfb59f03bbb59f061c856b7594abe00c9aa719855
+  languageName: node
+  linkType: hard
+
+"@babel/helper-member-expression-to-functions@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "@babel/helper-member-expression-to-functions@npm:8.0.0"
   dependencies:
-    "@babel/traverse": "npm:^7.29.7"
-    "@babel/types": "npm:^7.29.7"
-  checksum: 10/bb8dc59a65b4404260e0b7ff70f491de5a1607876f61736d26605ab3cba5b368827b0551acd3458212f5cfa99cbcd48bb66a96497b0fe00af09a6a2cbea4276b
+    "@babel/traverse": "npm:^8.0.0"
+    "@babel/types": "npm:^8.0.0"
+  checksum: 10/ec4ab0494f3500a69b4b85034eb03e82941e2e0140f5608b51cdccb5586426d573939e06489714d7d7c0b6cb6585cb71fde7a8d51e1c0bb82dabf917acb094ad
   languageName: node
   linkType: hard
 
@@ -145,6 +220,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-module-imports@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "@babel/helper-module-imports@npm:8.0.0"
+  dependencies:
+    "@babel/traverse": "npm:^8.0.0"
+    "@babel/types": "npm:^8.0.0"
+  checksum: 10/61978e727e2c26144aab354b18e532c28ef864fd2dd57088a45122a0e6ab13f3b5463a5777d0f8f4407b5de2963b1d2cac662d59875382baa9f69e57d747e1e6
+  languageName: node
+  linkType: hard
+
 "@babel/helper-module-transforms@npm:^7.29.7":
   version: 7.29.7
   resolution: "@babel/helper-module-transforms@npm:7.29.7"
@@ -158,12 +243,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-optimise-call-expression@npm:^7.29.7":
-  version: 7.29.7
-  resolution: "@babel/helper-optimise-call-expression@npm:7.29.7"
+"@babel/helper-module-transforms@npm:^8.0.1":
+  version: 8.0.1
+  resolution: "@babel/helper-module-transforms@npm:8.0.1"
   dependencies:
-    "@babel/types": "npm:^7.29.7"
-  checksum: 10/6b477e01b403fd48349336cb1d94722bff4fa54af2841b5fa950c557b796f4ecc14724052252ed1362ccfc23d1c09c54dc03e182fea59d3dc5bd69f8c626ba25
+    "@babel/helper-module-imports": "npm:^8.0.0"
+    "@babel/helper-validator-identifier": "npm:^8.0.0"
+    "@babel/traverse": "npm:^8.0.0"
+  peerDependencies:
+    "@babel/core": ^8.0.0
+  checksum: 10/cccf680dacfd8d961ee67a5519247a60bac9be814459894fd99aacbc51217ac6869b75844a48a2fb20d1ca0184a7e00f2998c74e87506f154d51f50b43b5e4f3
+  languageName: node
+  linkType: hard
+
+"@babel/helper-optimise-call-expression@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "@babel/helper-optimise-call-expression@npm:8.0.0"
+  dependencies:
+    "@babel/types": "npm:^8.0.0"
+  checksum: 10/8e2a8b469ad074143bc9478e642e16eca8eaf2ede042ae579c58308939e4feca2f56e341de2e7b6ad26fa0f0f7afd2ea6c7f2a8d42fcfc6f54fd057d790e8b6e
   languageName: node
   linkType: hard
 
@@ -181,26 +279,35 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-replace-supers@npm:^7.29.7":
-  version: 7.29.7
-  resolution: "@babel/helper-replace-supers@npm:7.29.7"
-  dependencies:
-    "@babel/helper-member-expression-to-functions": "npm:^7.29.7"
-    "@babel/helper-optimise-call-expression": "npm:^7.29.7"
-    "@babel/traverse": "npm:^7.29.7"
+"@babel/helper-plugin-utils@npm:^8.0.1":
+  version: 8.0.1
+  resolution: "@babel/helper-plugin-utils@npm:8.0.1"
   peerDependencies:
-    "@babel/core": ^7.0.0
-  checksum: 10/4aa7b48a6078db99bba24b67f63f97cd08ad9b3c476dcca196c6421dc2080f3566d683fba64c772e2f9597603d42ad4ac2ce9ccf0559643823c540f08cf0efa7
+    "@babel/core": ^8.0.0
+  checksum: 10/d9c8b9dc626640233a52d4fec0e31766a5dbcd5c9b799bd6e3c9efa6e73f0f8e389395fea33f00bce395482c2a4b99fa73d74c59720f3c8cbd019ba9ea82ad6a
   languageName: node
   linkType: hard
 
-"@babel/helper-skip-transparent-expression-wrappers@npm:^7.29.7":
-  version: 7.29.7
-  resolution: "@babel/helper-skip-transparent-expression-wrappers@npm:7.29.7"
+"@babel/helper-replace-supers@npm:^8.0.1":
+  version: 8.0.1
+  resolution: "@babel/helper-replace-supers@npm:8.0.1"
   dependencies:
-    "@babel/traverse": "npm:^7.29.7"
-    "@babel/types": "npm:^7.29.7"
-  checksum: 10/a5800bfcdca6cef7f6fe33ac02a0f05ff33da9746f97806553f249733f7ba8400290a17f3831d7faa5d91656f254ab749931f53c8a29f301d958d7dd00499637
+    "@babel/helper-member-expression-to-functions": "npm:^8.0.0"
+    "@babel/helper-optimise-call-expression": "npm:^8.0.0"
+    "@babel/traverse": "npm:^8.0.0"
+  peerDependencies:
+    "@babel/core": ^8.0.0
+  checksum: 10/515a993ac7bbe831520e6683dc07a639aef1b228e1e504a80255211362f46aca2469ccbfc6e8b58a00ca811ff00ca4996c2dddb4496614e7a79b309a44a59950
+  languageName: node
+  linkType: hard
+
+"@babel/helper-skip-transparent-expression-wrappers@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "@babel/helper-skip-transparent-expression-wrappers@npm:8.0.0"
+  dependencies:
+    "@babel/traverse": "npm:^8.0.0"
+    "@babel/types": "npm:^8.0.0"
+  checksum: 10/198db8c4b3edad40ff9712c537229ff8db8095b6a693ace916a50b9c94fdf7c61e795f848034ef47ef03c2c8a92c2e9dbce929511d5a5d2c69e61557f399ed84
   languageName: node
   linkType: hard
 
@@ -208,6 +315,13 @@ __metadata:
   version: 7.29.7
   resolution: "@babel/helper-string-parser@npm:7.29.7"
   checksum: 10/4d8ef0ef7105f3d9fe4361137c8f42e5b4c7a52b5380b962762f2a528a1ba89064e2c6236090716ce34b63707b886ae0ebf36b2c2fcc2851f27e652febfc3648
+  languageName: node
+  linkType: hard
+
+"@babel/helper-string-parser@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "@babel/helper-string-parser@npm:8.0.0"
+  checksum: 10/3c38887284b8bd76d2c5865b4a4a37f75a0dd2740d34169e3f140f1c35c5efff5682e50cbd38c47b0f143a38c145b93864a7a156a203a234317824083ec742cc
   languageName: node
   linkType: hard
 
@@ -225,10 +339,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-validator-identifier@npm:^8.0.0, @babel/helper-validator-identifier@npm:^8.0.4":
+  version: 8.0.4
+  resolution: "@babel/helper-validator-identifier@npm:8.0.4"
+  checksum: 10/4b9d741e990a62d49d138e0b7205cd8d1bf9df87afdc20243a2053f411ae22cf327b00a06c4a1119a2d839c148f809500c04036e45ec8a382f0876a26556ee3d
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-option@npm:^7.29.7":
   version: 7.29.7
   resolution: "@babel/helper-validator-option@npm:7.29.7"
   checksum: 10/aeb6aa966f59300d3cc2fea7c68e1dfd7ad011fc10e535c8e2b2de3094b27c859428dc7220f16420350f8b1cde99da120b673be04bcb0c2f37b56258c96bed58
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-option@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "@babel/helper-validator-option@npm:8.0.0"
+  checksum: 10/12c2bf5457fbe1ff0701321b4e471420d46a94a2b10858042c7a96134894212ba04224021345c8572ed3eb7b536890deb842ccd7e5f655aa56de594529ec64d0
   languageName: node
   linkType: hard
 
@@ -242,7 +370,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.16.4, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.22.0, @babel/parser@npm:^7.24.4, @babel/parser@npm:^7.29.0, @babel/parser@npm:^7.29.2, @babel/parser@npm:^7.29.7":
+"@babel/helpers@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "@babel/helpers@npm:8.0.0"
+  dependencies:
+    "@babel/template": "npm:^8.0.0"
+    "@babel/types": "npm:^8.0.0"
+  checksum: 10/129fca6e339022059028b7189c9cb6907ed813233ef335d8636a82b927282fea022970fc4da33bc575d6dbb8900ca550c5dcaaae84f7265c4808e8514ec81339
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.16.4, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.24.4, @babel/parser@npm:^7.29.0, @babel/parser@npm:^7.29.7":
   version: 7.29.7
   resolution: "@babel/parser@npm:7.29.7"
   dependencies:
@@ -253,7 +391,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-syntax-jsx@npm:^7.16.7, @babel/plugin-syntax-jsx@npm:^7.18.6, @babel/plugin-syntax-jsx@npm:^7.28.6, @babel/plugin-syntax-jsx@npm:^7.29.7":
+"@babel/parser@npm:^8.0.0, @babel/parser@npm:^8.0.4":
+  version: 8.0.4
+  resolution: "@babel/parser@npm:8.0.4"
+  dependencies:
+    "@babel/types": "npm:^8.0.4"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 10/230554794a2c296ce1fb60f57459d94903802369e14e1d83c3ea266b64a4f88ab292eadf5213823d87c04541c9c43b8b6daaae919f25551d3637800663fb25bf
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-jsx@npm:^7.16.7, @babel/plugin-syntax-jsx@npm:^7.18.6":
   version: 7.29.7
   resolution: "@babel/plugin-syntax-jsx@npm:7.29.7"
   dependencies:
@@ -261,6 +410,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 10/84150d27c553a1d3d921354437f6725ca1d63b49514c25591bfcaaafa6ea4d6c10715b66fe7245e4ad7ab7c6cf4b6e1de7373defd3df00877ab12638170d7772
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-jsx@npm:^8.0.0":
+  version: 8.0.1
+  resolution: "@babel/plugin-syntax-jsx@npm:8.0.1"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^8.0.1"
+  peerDependencies:
+    "@babel/core": ^8.0.0
+  checksum: 10/4fb08ac3c298be374750e2fb13b939183e117d1ecfc2191c3bf86831d347893cf445d9dd5620b258e47819c117d342449fe13ac27f6c3a07feabe107af32644c
   languageName: node
   linkType: hard
 
@@ -275,56 +435,55 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-syntax-typescript@npm:^7.29.7":
-  version: 7.29.7
-  resolution: "@babel/plugin-syntax-typescript@npm:7.29.7"
+"@babel/plugin-syntax-typescript@npm:^8.0.1":
+  version: 8.0.3
+  resolution: "@babel/plugin-syntax-typescript@npm:8.0.3"
   dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.29.7"
+    "@babel/helper-plugin-utils": "npm:^8.0.1"
   peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10/ef454d2a7a6209dd4255361c072c94ab1293e7ad4b06e7e744d08bb308065d4d6544964eae9b2357c3b33d8d939f9e32d4aa95905bc464407cd8f7101dee4443
+    "@babel/core": ^8.0.0
+  checksum: 10/557fe5227c6a283732ea45f37b498f597c64de0ac85625b61211d38c000ffd8c75894f25c198e41439e553d0153606d155dfb7f1a11918baf3ca33d4ae5af22d
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-modules-commonjs@npm:^7.29.7":
-  version: 7.29.7
-  resolution: "@babel/plugin-transform-modules-commonjs@npm:7.29.7"
+"@babel/plugin-transform-modules-commonjs@npm:^8.0.1":
+  version: 8.0.1
+  resolution: "@babel/plugin-transform-modules-commonjs@npm:8.0.1"
   dependencies:
-    "@babel/helper-module-transforms": "npm:^7.29.7"
-    "@babel/helper-plugin-utils": "npm:^7.29.7"
+    "@babel/helper-module-transforms": "npm:^8.0.1"
+    "@babel/helper-plugin-utils": "npm:^8.0.1"
   peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10/7d816febde2d65bde5607ef355d751ba6c5a2d68ffe47c37b809e3ed2f829603751d4b5a5506f4299936d95fc73909243f9074f98dd32201277ec4131fc3ff33
+    "@babel/core": ^8.0.0
+  checksum: 10/245e3f6488f1c138a9783ebf32f74660cd7e013652b107ce4452864370c2f27b0bed27ba69179708fcb92878d6842dd18f53dbe2fe6feb38fc82c0d6a38e0546
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-typescript@npm:^7.29.7":
-  version: 7.29.7
-  resolution: "@babel/plugin-transform-typescript@npm:7.29.7"
+"@babel/plugin-transform-typescript@npm:^8.0.1":
+  version: 8.0.1
+  resolution: "@babel/plugin-transform-typescript@npm:8.0.1"
   dependencies:
-    "@babel/helper-annotate-as-pure": "npm:^7.29.7"
-    "@babel/helper-create-class-features-plugin": "npm:^7.29.7"
-    "@babel/helper-plugin-utils": "npm:^7.29.7"
-    "@babel/helper-skip-transparent-expression-wrappers": "npm:^7.29.7"
-    "@babel/plugin-syntax-typescript": "npm:^7.29.7"
+    "@babel/helper-annotate-as-pure": "npm:^8.0.0"
+    "@babel/helper-create-class-features-plugin": "npm:^8.0.1"
+    "@babel/helper-plugin-utils": "npm:^8.0.1"
+    "@babel/helper-skip-transparent-expression-wrappers": "npm:^8.0.0"
+    "@babel/plugin-syntax-typescript": "npm:^8.0.1"
   peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10/88d39bcdfee418795ad65097fff88f491e87793b958fe334273a20f74693b64369456a6d666eb0f1e98c9ecb633c99bcccf90562593e64eb92cc9dd040f25c1c
+    "@babel/core": ^8.0.0
+  checksum: 10/146e56d1285b7673e4491ee46366fca87962ba348cee3851bf68b52e2d7f470f12c9b75e8be8112bba0a8067e785e3de4ea7d4cd010fe17bf24a4039813a5b7d
   languageName: node
   linkType: hard
 
-"@babel/preset-typescript@npm:^7.18.6":
-  version: 7.29.7
-  resolution: "@babel/preset-typescript@npm:7.29.7"
+"@babel/preset-typescript@npm:^8.0.0":
+  version: 8.0.1
+  resolution: "@babel/preset-typescript@npm:8.0.1"
   dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.29.7"
-    "@babel/helper-validator-option": "npm:^7.29.7"
-    "@babel/plugin-syntax-jsx": "npm:^7.29.7"
-    "@babel/plugin-transform-modules-commonjs": "npm:^7.29.7"
-    "@babel/plugin-transform-typescript": "npm:^7.29.7"
+    "@babel/helper-plugin-utils": "npm:^8.0.1"
+    "@babel/helper-validator-option": "npm:^8.0.0"
+    "@babel/plugin-transform-modules-commonjs": "npm:^8.0.1"
+    "@babel/plugin-transform-typescript": "npm:^8.0.1"
   peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10/487c5b5ee80afd656a8e6254c0638559fa4cd8d11b8d9ef9328cd5c403b8dfd1003690246910681de0f12e879d38fdf91aa2592f51ab9761e5197a3b36508919
+    "@babel/core": ^8.0.0
+  checksum: 10/1844864626dda003d6fca960f1fe584cd62deee43d115225d51848460dc8e39a9c9d7e59c0d15bf458612790de1b88f4bc1840be94e080ab108e16b43a6a2933
   languageName: node
   linkType: hard
 
@@ -348,7 +507,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/traverse@npm:^7.20.12, @babel/traverse@npm:^7.29.0, @babel/traverse@npm:^7.29.7":
+"@babel/template@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "@babel/template@npm:8.0.0"
+  dependencies:
+    "@babel/code-frame": "npm:^8.0.0"
+    "@babel/parser": "npm:^8.0.0"
+    "@babel/types": "npm:^8.0.0"
+  checksum: 10/7ff1d1634cd071d58998f931dfb8c79c297038b965bd9a9704160d9fb2e0a469eac01d86b2c38c713d158dc0ea86f9ef95ebe4baceab546a8319fe3fbad5940e
+  languageName: node
+  linkType: hard
+
+"@babel/traverse@npm:^7.29.7":
   version: 7.29.7
   resolution: "@babel/traverse@npm:7.29.7"
   dependencies:
@@ -363,13 +533,38 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.0.0, @babel/types@npm:^7.18.6, @babel/types@npm:^7.20.7, @babel/types@npm:^7.21.2, @babel/types@npm:^7.23.6, @babel/types@npm:^7.26.0, @babel/types@npm:^7.29.0, @babel/types@npm:^7.29.7, @babel/types@npm:^7.3.0":
+"@babel/traverse@npm:^8.0.0":
+  version: 8.0.4
+  resolution: "@babel/traverse@npm:8.0.4"
+  dependencies:
+    "@babel/code-frame": "npm:^8.0.0"
+    "@babel/generator": "npm:^8.0.0"
+    "@babel/helper-globals": "npm:^8.0.0"
+    "@babel/parser": "npm:^8.0.4"
+    "@babel/template": "npm:^8.0.0"
+    "@babel/types": "npm:^8.0.4"
+    obug: "npm:^2.1.1"
+  checksum: 10/234bc16c8c14af13e9471141bfd371186bb7fd2c347b1b416c46040e6fc1995242e3852d36181fa7a0240543b8d642a91d33261f942880584c87a7420df7247d
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.0.0, @babel/types@npm:^7.18.6, @babel/types@npm:^7.20.7, @babel/types@npm:^7.23.6, @babel/types@npm:^7.26.0, @babel/types@npm:^7.29.0, @babel/types@npm:^7.29.7, @babel/types@npm:^7.3.0":
   version: 7.29.7
   resolution: "@babel/types@npm:7.29.7"
   dependencies:
     "@babel/helper-string-parser": "npm:^7.29.7"
     "@babel/helper-validator-identifier": "npm:^7.29.7"
   checksum: 10/bd4f5635db1057bd0abeebf93eb3ae38399e152271cea8dce8288350f0afa13ed3e2db2e16e22bd3303068890eec18965a83420539afbe0dde31432b4cf9636d
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^8.0.0, @babel/types@npm:^8.0.4":
+  version: 8.0.4
+  resolution: "@babel/types@npm:8.0.4"
+  dependencies:
+    "@babel/helper-string-parser": "npm:^8.0.0"
+    "@babel/helper-validator-identifier": "npm:^8.0.4"
+  checksum: 10/7b58bdb4c9149fb5ea6a272912f8cd8af082939a9fc97c6de126299b38f258dd9f78717f7cad3c7fe8bfa7d1fce4cff5fa26b0e80885935255fd3a062e9296ad
   languageName: node
   linkType: hard
 
@@ -1462,9 +1657,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@lingui/babel-plugin-extract-messages@workspace:packages/babel-plugin-extract-messages"
   dependencies:
-    "@babel/core": "npm:^7.29.0"
-    "@babel/traverse": "npm:^7.29.0"
-    "@babel/types": "npm:^7.29.0"
+    "@babel/core": "npm:^8.0.0"
+    "@babel/traverse": "npm:^8.0.0"
+    "@babel/types": "npm:^8.0.0"
     "@lingui/babel-plugin-lingui-macro": "workspace:*"
     "@lingui/conf": "workspace:*"
     "@lingui/test-utils": "workspace:*"
@@ -1478,12 +1673,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@lingui/babel-plugin-lingui-macro@workspace:packages/babel-plugin-lingui-macro"
   dependencies:
-    "@babel/core": "npm:^7.29.0"
-    "@babel/parser": "npm:^7.29.2"
-    "@babel/plugin-syntax-jsx": "npm:^7.28.6"
-    "@babel/preset-typescript": "npm:^7.18.6"
-    "@babel/traverse": "npm:^7.20.12"
-    "@babel/types": "npm:^7.29.0"
+    "@babel/core": "npm:^8.0.0"
+    "@babel/parser": "npm:^8.0.0"
+    "@babel/plugin-syntax-jsx": "npm:^8.0.0"
+    "@babel/preset-typescript": "npm:^8.0.0"
+    "@babel/traverse": "npm:^8.0.0"
+    "@babel/types": "npm:^8.0.0"
     "@lingui/conf": "workspace:*"
     "@lingui/message-utils": "workspace:*"
     babel-plugin-macros: "npm:^3.1.0"
@@ -1507,10 +1702,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@lingui/cli@workspace:packages/cli"
   dependencies:
-    "@babel/core": "npm:^7.21.0"
-    "@babel/generator": "npm:^7.28.5"
-    "@babel/parser": "npm:^7.22.0"
-    "@babel/types": "npm:^7.21.2"
+    "@babel/core": "npm:^8.0.0"
+    "@babel/generator": "npm:^8.0.0"
+    "@babel/parser": "npm:^8.0.0"
+    "@babel/types": "npm:^8.0.0"
     "@lingui/babel-plugin-extract-messages": "workspace:*"
     "@lingui/babel-plugin-lingui-macro": "workspace:*"
     "@lingui/conf": "workspace:*"
@@ -1767,7 +1962,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@lingui/solid@workspace:packages/solid"
   dependencies:
-    "@babel/core": "npm:7.29.7"
+    "@babel/core": "npm:8.0.1"
     "@lingui/babel-plugin-lingui-macro": "workspace:*"
     "@lingui/conf": "workspace:*"
     "@lingui/core": "workspace:*"
@@ -1804,7 +1999,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@lingui/vite-plugin@workspace:packages/vite-plugin"
   dependencies:
-    "@babel/core": "npm:7.29.7"
+    "@babel/core": "npm:8.0.1"
     "@lingui/babel-plugin-lingui-macro": "workspace:^"
     "@lingui/cli": "workspace:*"
     "@lingui/conf": "workspace:*"
@@ -3568,6 +3763,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/gensync@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "@types/gensync@npm:1.0.5"
+  checksum: 10/1b417012a1249c60d2a5d3a646c208710473f31ab91ee702d4a0bf742d4d20a04c4296efcf6f42b7c1b38536ff732c3aa00dd5afc8fa138c70d1905a0521a5c3
+  languageName: node
+  linkType: hard
+
 "@types/istanbul-lib-coverage@npm:*, @types/istanbul-lib-coverage@npm:^2.0.0":
   version: 2.0.4
   resolution: "@types/istanbul-lib-coverage@npm:2.0.4"
@@ -3590,6 +3792,13 @@ __metadata:
   dependencies:
     "@types/istanbul-lib-report": "npm:*"
   checksum: 10/f1ad54bc68f37f60b30c7915886b92f86b847033e597f9b34f2415acdbe5ed742fa559a0a40050d74cdba3b6a63c342cac1f3a64dba5b68b66a6941f4abd7903
+  languageName: node
+  linkType: hard
+
+"@types/jsesc@npm:^2.5.0":
+  version: 2.5.1
+  resolution: "@types/jsesc@npm:2.5.1"
+  checksum: 10/25407775ed621790d2eec0cc51e194bd0d67a82e39204fd9748899c249ef965e17d9e6560f6c658773714f6d45a259465f3639790bb55750ebb168ee23801596
   languageName: node
   linkType: hard
 
@@ -6390,6 +6599,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"empathic@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "empathic@npm:2.0.1"
+  checksum: 10/c5a37b78926e722c38779e5026342350098771fa1cacb52cb808e5329896ab39abb88cd2f1374671d6e5c98aa24cba2534f00da2938d04f11de1a2d012ee75c3
+  languageName: node
+  linkType: hard
+
 "encoding@npm:^0.1.13":
   version: 0.1.13
   resolution: "encoding@npm:0.1.13"
@@ -8277,6 +8493,13 @@ __metadata:
   bin:
     import-local-fixture: fixtures/cli.js
   checksum: 10/bfcdb63b5e3c0e245e347f3107564035b128a414c4da1172a20dc67db2504e05ede4ac2eee1252359f78b0bfd7b19ef180aec427c2fce6493ae782d73a04cddd
+  languageName: node
+  linkType: hard
+
+"import-meta-resolve@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "import-meta-resolve@npm:4.2.0"
+  checksum: 10/3499ee8b7eddb79be77067b368bcdf39e6f144306dea4686d08071ae7e65a2e3bdca3f98f2a0f4babdcd4ba9d9e7d379ae7e27c4b9bf8b08c1e812a28c674bf3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Pull Request

## Description

Follow-up to #2623, which added Babel 8 support to the macro plugin via peer dependencies but deliberately left `@lingui/cli` on fixed Babel 7 direct dependencies — noted there as "a separate, larger change".

That leaves the original goal of #2592 unmet for consumers: because the CLI pins `@babel/core: ^7.21.0` as a real dependency, a project on Babel 8 still ends up with **two Babel majors installed**. This PR moves the CLI's pinned Babel to 8 and makes the surrounding packages type-check against it, so the tree resolves to exactly one `@babel/core`.

This respects the architectural line from #2592 — Babel stays a *fixed direct dependency* of the CLI (an internal implementation detail), not a peer. Only the pinned major moves. The plugins' peer ranges are untouched and still advertise `^7 || ^8`.

One thing worth flagging: the macro plugin's `^7 || ^8` peer range shipped in 6.6.0 without ever being type-checked against Babel 8, since its devDependencies stayed on `^7`. Several of the fixes below are in that package — they are latent breakages the peer range already implies, surfaced now that the repo actually resolves Babel 8.

## Babel 8 changes handled

| Change | Fix |
|---|---|
| `@babel/core` no longer re-exports `ParserOptions` | Import from `@babel/parser`, next to the existing `ParserPlugin` import |
| `importAttributes` and `explicitResourceManagement` are enabled by default and rejected as parser plugin names | Removed from `getBabelParserOptions` |
| `t.jsxElement` dropped its 4th `selfClosing` argument | Removed at both call sites |
| `PluginObj` renamed to `PluginObject` | Plugin shape declared structurally from `Visitor`/`PluginPass`, which both majors export |
| `PluginTarget` / `PresetTarget` no longer admit bare objects | Two inline test plugins become factories; the rolldown preset is cast, as Babel still accepts an object preset at runtime |
| `@babel/traverse` stopped exporting `VisitNodeObject` | Declared locally |
| `transformAsync`'s source map has readonly array fields, which rolldown's `ExistingRawSourceMap` rejects | Copied before returning |
| `file.hub` is `HubInterface`, not the `Hub` class | Parameter types widened to `HubInterface` (exported by both majors) |

Where a Babel 8 type name would have locked the source to one major, I declared the shape locally instead, so the plugins keep type-checking under either — consistent with their peer ranges.

The parser-plugin removal is the one change that could regress silently, so I verified it rather than trusting the release notes. On `@babel/core` 8.0.1, both syntaxes parse **without** the plugins listed:

```js
parseSync(`import x from "./a.json" with { type: "json" };`)   // OK
parseSync(`async function f(){ await using r = getR(); }`)      // OK
```

`decoratorAutoAccessors` and `deferredImportEvaluation` are still required and are kept.

## Verification

On this branch, with a single `@babel/core@8.0.1` resolved across the workspace (confirmed — no nested copies remain):

- `yarn release:build` — clean
- `yarn lint:types` — clean
- `yarn lint:eslint` — clean
- `yarn test` — **1414 passed, 2 skipped, 88 files**
- `yarn prettier:check` — clean

One note on running the suite locally: `extract-messages`' `expectNoConsole` helper fails on a fresh clone because Browserslist warns that its bundled `caniuse-lite` data is stale, and that warning trips `expect(console.warn).not.toBeCalled()`. It is unrelated to Babel; `BROWSERSLIST_IGNORE_OLD_DATA=1` (or refreshing the DB) makes the suite green. Happy to send that as a separate hardening PR if it is worth insulating the helper from Browserslist.

`packages/solid` and `packages/vite-plugin` had exact `@babel/core: 7.29.7` devDependencies; those move to `8.0.1` too, otherwise the workspace keeps three Babel copies and type resolution mixes majors between the hoisted and nested ones.

## Scope note

I kept this to the dependency move plus the minimum needed to make it type-check and pass. If you would rather see the plugin-side type fixes split out from the CLI dependency bump, I am happy to break it into two PRs.

Refs #2592, #2623.

---

*AI disclosure: this PR was drafted with Claude Code (AI-assisted). I verified it by running build, types, eslint, prettier and the full test suite on a single-major Babel 8 install, and by parse-testing the removed parser plugins against @babel/core 8.0.1.*
