### PR TITLE
 docs: clarify jsxPlaceholderDefaults collision behavior

### DIFF
--- a/website/docs/ref/conf.md
+++ b/website/docs/ref/conf.md
@@ -663,6 +663,11 @@ A mapping of JSX element tag names to default placeholder names. When a JSX elem
 ```
 
 Explicit attributes (via `jsxPlaceholderAttribute`) take priority over defaults.
+> **Important:** Default placeholder names are used as-is and are not automatically made unique.
+>
+> If multiple JSX elements use the same default placeholder name, Lingui reports a placeholder collision instead of generating unique names such as `<link1>`, `<link2>`, etc.
+>
+> To use different placeholder names for multiple elements, assign them explicitly with `jsxPlaceholderAttribute`.
 
 ## macro.idPrefixLeader
 


### PR DESCRIPTION
## Description

Clarifies the documented behavior of `macro.jsxPlaceholderDefaults`.

Default placeholder names are used as-is and are not automatically made unique. Reusing the same default placeholder name can result in a placeholder collision, rather than automatically generating names such as `<link1>`, `<link2>`, etc.

Users who need distinct placeholder names should assign them explicitly with `jsxPlaceholderAttribute`.

Fixes #2640

## Types of changes

- [x] Documentation update

## Checklist

- [x] I have read the CONTRIBUTING and CODE_OF_CONDUCT docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)