### PR TITLE
feat(conf): support pseudolocale extend character

### DIFF
--- a/packages/cli/src/api/pseudoLocalize.test.ts
+++ b/packages/cli/src/api/pseudoLocalize.test.ts
@@ -122,6 +122,12 @@ describe("PseudoLocalization", () => {
       )
     })
 
+    it("should use the configured character when extending a message", () => {
+      expect(
+        pseudoLocalize("Hello", { extend: 1, extendCharacter: "." }),
+      ).toEqual("..Ĥēĺĺō..")
+    })
+
     it("should ignore an attempt to override the internal delimiter", () => {
       expect(
         pseudoLocalize("Martin <span>Černý</span>", {

--- a/packages/conf/__typetests__/index.tst.ts
+++ b/packages/conf/__typetests__/index.tst.ts
@@ -22,7 +22,13 @@ expect({
 // pseudoLocale as an object with pseudolocale options
 expect({
   locales: ["en", "pseudo"],
-  pseudoLocale: { locale: "pseudo", prepend: "⟦ ", append: " ⟧", extend: 0.4 },
+  pseudoLocale: {
+    locale: "pseudo",
+    prepend: "⟦ ",
+    append: " ⟧",
+    extend: 0.4,
+    extendCharacter: ".",
+  },
 }).type.toBeAssignableTo<LinguiConfig>()
 
 // all props

--- a/packages/conf/src/types.ts
+++ b/packages/conf/src/types.ts
@@ -575,6 +575,12 @@ export type PseudoLocaleOptions = {
    */
   extend?: number
   /**
+   * Character used to pad pseudo-localized messages when `extend` is set.
+   *
+   * @default " "
+   */
+  extendCharacter?: string
+  /**
    * Replaces every (non-token) character with the given one. Handy to quickly
    * spot strings that were not extracted/translated.
    *

--- a/website/docs/ref/conf.md
+++ b/website/docs/ref/conf.md
@@ -221,13 +221,13 @@ It can be provided either as a string, or as an object to additionally configure
 The string form (`pseudoLocale: "pseudo"`) is deprecated and will be removed in a future major release. Use the object form (`pseudoLocale: { locale: "pseudo" }`) instead.
 :::
 
-| Option             | Type     | Default     | Description                                                                                         |
-| ------------------ | -------- | ----------- | --------------------------------------------------------------------------------------------------- |
-| `locale`           | `string` | —           | Locale used for pseudolocalization (required in the object form)                                    |
+| Option            | Type     | Default     | Description                                                                                         |
+| ----------------- | -------- | ----------- | --------------------------------------------------------------------------------------------------- |
+| `locale`          | `string` | —           | Locale used for pseudolocalization (required in the object form)                                    |
 | `prepend`         | `string` | `""`        | String prepended to the beginning of every pseudo-localized message                                 |
 | `append`          | `string` | `""`        | String appended to the end of every pseudo-localized message                                        |
 | `extend`          | `number` | `0`         | Extends the width of the string by the given percentage (e.g. `0.3` adds 30%)                       |
-| `extendCharacter` | `string` | `" "`       | Character used to pad messages when `extend` is set                                                  |
+| `extendCharacter` | `string` | `" "`       | Character used to pad messages when `extend` is set                                                 |
 | `override`        | `string` | `undefined` | Replaces every (non-token) character with the given one. Handy to quickly spot untranslated strings |
 
 ```ts title="lingui.config.{js,ts}"

--- a/website/docs/ref/conf.md
+++ b/website/docs/ref/conf.md
@@ -224,11 +224,11 @@ The string form (`pseudoLocale: "pseudo"`) is deprecated and will be removed in 
 | Option     | Type     | Default     | Description                                                                                         |
 | ---------- | -------- | ----------- | --------------------------------------------------------------------------------------------------- |
 | `locale`   | `string` | —           | Locale used for pseudolocalization (required in the object form)                                    |
-| `prepend`  | `string` | `""`        | String prepended to the beginning of every pseudo-localized message                                 |
-| `append`   | `string` | `""`        | String appended to the end of every pseudo-localized message                                        |
-| `extend`   | `number` | `0`         | Extends the width of the string by the given percentage (e.g. `0.3` adds 30%)                       |
-| `extendCharacter` | `string` | `" "` | Character used to pad messages when `extend` is set                                                  |
-| `override` | `string` | `undefined` | Replaces every (non-token) character with the given one. Handy to quickly spot untranslated strings |
+| `prepend`         | `string` | `""`        | String prepended to the beginning of every pseudo-localized message                                 |
+| `append`          | `string` | `""`        | String appended to the end of every pseudo-localized message                                        |
+| `extend`          | `number` | `0`         | Extends the width of the string by the given percentage (e.g. `0.3` adds 30%)                       |
+| `extendCharacter` | `string` | `" "`       | Character used to pad messages when `extend` is set                                                  |
+| `override`        | `string` | `undefined` | Replaces every (non-token) character with the given one. Handy to quickly spot untranslated strings |
 
 ```ts title="lingui.config.{js,ts}"
 import { defineConfig } from "@lingui/cli";

--- a/website/docs/ref/conf.md
+++ b/website/docs/ref/conf.md
@@ -227,6 +227,7 @@ The string form (`pseudoLocale: "pseudo"`) is deprecated and will be removed in 
 | `prepend`  | `string` | `""`        | String prepended to the beginning of every pseudo-localized message                                 |
 | `append`   | `string` | `""`        | String appended to the end of every pseudo-localized message                                        |
 | `extend`   | `number` | `0`         | Extends the width of the string by the given percentage (e.g. `0.3` adds 30%)                       |
+| `extendCharacter` | `string` | `" "` | Character used to pad messages when `extend` is set                                                  |
 | `override` | `string` | `undefined` | Replaces every (non-token) character with the given one. Handy to quickly spot untranslated strings |
 
 ```ts title="lingui.config.{js,ts}"
@@ -244,7 +245,13 @@ export default defineConfig({
 export default defineConfig({
   locales: ["en", "pseudo"],
   sourceLocale: "en",
-  pseudoLocale: { locale: "pseudo", prepend: "⟦ ", append: " ⟧", extend: 0.4 },
+  pseudoLocale: {
+    locale: "pseudo",
+    prepend: "⟦ ",
+    append: " ⟧",
+    extend: 0.4,
+    extendCharacter: ".",
+  },
   catalogs: [],
 });
 ```

--- a/website/docs/ref/conf.md
+++ b/website/docs/ref/conf.md
@@ -221,9 +221,9 @@ It can be provided either as a string, or as an object to additionally configure
 The string form (`pseudoLocale: "pseudo"`) is deprecated and will be removed in a future major release. Use the object form (`pseudoLocale: { locale: "pseudo" }`) instead.
 :::
 
-| Option     | Type     | Default     | Description                                                                                         |
-| ---------- | -------- | ----------- | --------------------------------------------------------------------------------------------------- |
-| `locale`   | `string` | —           | Locale used for pseudolocalization (required in the object form)                                    |
+| Option             | Type     | Default     | Description                                                                                         |
+| ------------------ | -------- | ----------- | --------------------------------------------------------------------------------------------------- |
+| `locale`           | `string` | —           | Locale used for pseudolocalization (required in the object form)                                    |
 | `prepend`         | `string` | `""`        | String prepended to the beginning of every pseudo-localized message                                 |
 | `append`          | `string` | `""`        | String appended to the end of every pseudo-localized message                                        |
 | `extend`          | `number` | `0`         | Extends the width of the string by the given percentage (e.g. `0.3` adds 30%)                       |


### PR DESCRIPTION
Fixes #2642.

Expose the underlying pseudolocale library's xtendCharacter option through Lingui's public configuration type. The option already passes through at runtime; this adds type support, reference documentation, and regression coverage for custom padding.

Validation: git diff --check. Full Yarn tests could not run locally because dependencies are not installed; CI will validate the TypeScript and documentation changes.