### PR TITLE
feat(cli,conf): add RTL pseudolocale and allow multiple pseudolocales

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,13 @@ This project uses [yarn][yarninstall] package manager. Please follow [official][
    yarn
    ```
 
-3. Run tests
+3. Build packages. Several integration tests and packages depend on compiled distribution files (`dist/`) of workspace packages, so you must build them before running tests.
+
+   ```sh
+   yarn release:build
+   ```
+
+4. Run tests
 
    ```sh
    # Watch mode
@@ -141,9 +147,10 @@ The process is described in the [React Native example](./examples/react-native) 
 
 Please make sure that all tests pass and linter doesn't report any error before submitting a PR (Don't worry though! If you can't figure out the problem, create a PR anyway, and we'll help you).
 
+- `yarn release:build` - Build all packages (required before running `yarn test`)
 - `yarn lint:all` - Linting & Type testing
 - `yarn test` - Quick test suite (sufficient)
-- `yarn release:test` - Full test suite (recommended)
+- `yarn release:test` - Full test suite: builds packages, runs unit tests, e2e tests, and type tests (recommended)
 
 `yarn release:test` builds all packages, simulates creating packages for NPM, runs unit tests and finally runs integration tests using production build.
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -68,7 +68,7 @@
     "ms": "^2.1.3",
     "normalize-path": "^3.0.0",
     "ora": "^9.1.0",
-    "pseudolocale": "^2.3.0",
+    "pseudolocale": "^3.1.0",
     "source-map": "^0.7.6",
     "tinypool": "^2.1.0"
   },

--- a/packages/cli/src/api/compile/compileLocale.ts
+++ b/packages/cli/src/api/compile/compileLocale.ts
@@ -29,9 +29,13 @@ export async function compileLocale(
         sourceLocale: config.sourceLocale,
       })
 
+    const pseudoLocaleConfig = config.pseudoLocale.find(
+      (item) => item.locale === locale,
+    )
+
     if (
       !options.allowEmpty &&
-      locale !== config.pseudoLocale.locale &&
+      !pseudoLocaleConfig &&
       missingMessages.length > 0
     ) {
       logger.error(
@@ -105,6 +109,9 @@ async function compileAndWrite(
   const namespace = options.typescript
     ? "ts"
     : options.namespace || config.compileNamespace
+  const pseudoLocaleConfig = config.pseudoLocale.find(
+    (item) => item.locale === locale,
+  )
   const { source: compiledCatalog, errors } = createCompiledCatalog(
     locale,
     messages,
@@ -112,8 +119,8 @@ async function compileAndWrite(
       strict: false,
       namespace,
       outputPrefix: options.outputPrefix,
-      pseudoLocale: config.pseudoLocale.locale,
-      pseudoLocaleOptions: config.pseudoLocale.options,
+      pseudoLocale: pseudoLocaleConfig?.locale,
+      pseudoLocaleOptions: pseudoLocaleConfig?.options,
       compilerBabelOptions: config.compilerBabelOptions,
     },
   )

--- a/packages/cli/src/api/pseudoLocalize.test.ts
+++ b/packages/cli/src/api/pseudoLocalize.test.ts
@@ -128,6 +128,12 @@ describe("PseudoLocalization", () => {
       ).toEqual("..Ĥēĺĺō..")
     })
 
+    it("should emulate right-to-left languages", () => {
+      expect(pseudoLocalize("Hello", { rightToLeft: true })).toEqual(
+        "\u202EHǝʅʅo\u202C",
+      )
+    })
+
     it("should ignore an attempt to override the internal delimiter", () => {
       expect(
         pseudoLocalize("Martin <span>Černý</span>", {

--- a/packages/cli/src/api/stats.test.ts
+++ b/packages/cli/src/api/stats.test.ts
@@ -37,4 +37,45 @@ describe("PrintStats", () => {
       └─────────────┴─────────────┴─────────┘
     `)
   })
+
+  it("should print correct stats for a setup with multiple pseudolocales", async () => {
+    const config = makeConfig({
+      locales: ["en", "cs", "pseudo-en", "pseudo-ar"],
+      sourceLocale: "en",
+      pseudoLocale: [
+        { locale: "pseudo-en", prepend: "⟦ ", append: " ⟧" },
+        { locale: "pseudo-ar", rightToLeft: true },
+      ],
+    })
+
+    const prevCatalogs: AllCatalogsType = {
+      en: {},
+      cs: {},
+      "pseudo-en": {},
+      "pseudo-ar": {},
+    }
+    const nextCatalog = {
+      "custom.id": makeNextMessage({
+        message: "Message with custom ID",
+      }),
+      "Message with <0>auto-generated</0> ID": makeNextMessage(),
+    }
+
+    const catalogs = (await makeCatalog(config)).merge(
+      prevCatalogs,
+      nextCatalog,
+      defaultMergeOptions,
+    )
+
+    const table = printStats(config, catalogs)
+
+    expect(table.toString()).toMatchInlineSnapshot(`
+      ┌─────────────┬─────────────┬─────────┐
+      │ Language    │ Total count │ Missing │
+      ├─────────────┼─────────────┼─────────┤
+      │ en (source) │      2      │    -    │
+      │ cs          │      2      │    2    │
+      └─────────────┴─────────────┴─────────┘
+    `)
+  })
 })

--- a/packages/cli/src/api/stats.ts
+++ b/packages/cli/src/api/stats.ts
@@ -35,7 +35,8 @@ export function printStats(
       return a.localeCompare(b)
     })
     .forEach((locale) => {
-      if (locale === config.pseudoLocale.locale) return // skip pseudo locale
+      // skip pseudo locale
+      if (config.pseudoLocale.some((item) => item.locale === locale)) return
 
       const catalog = catalogs[locale]
       // catalog is null if no catalog exists on disk and the locale

--- a/packages/cli/src/services/translationIO.ts
+++ b/packages/cli/src/services/translationIO.ts
@@ -20,9 +20,9 @@ import path from "node:path"
 
 const getTargetLocales = (config: LinguiConfigNormalized) => {
   const sourceLocale = config.sourceLocale || "en"
-  const pseudoLocale = config.pseudoLocale.locale || "pseudo"
+  const pseudoLocales = new Set(config.pseudoLocale.map((item) => item.locale))
   return config.locales.filter(
-    (value) => value != sourceLocale && value != pseudoLocale,
+    (value: string) => value != sourceLocale && !pseudoLocales.has(value),
   )
 }
 

--- a/packages/cli/src/test/compile.test.ts
+++ b/packages/cli/src/test/compile.test.ts
@@ -4,9 +4,13 @@ import { getConsoleMockCalls, mockConsole } from "@lingui/test-utils"
 import { createFixtures, readFsToListing } from "../tests.js"
 
 describe("CLI Command: Compile", () => {
-  function getTestConfig(rootDir: string, pseudoLocale?: string) {
+  function getTestConfig(
+    rootDir: string,
+    pseudoLocale?: LinguiConfig["pseudoLocale"],
+    locales: string[] = ["en", "pl"],
+  ) {
     return makeConfig({
-      locales: ["en", "pl"],
+      locales,
       sourceLocale: "en",
       pseudoLocale: pseudoLocale,
       rootDir: rootDir,
@@ -120,6 +124,52 @@ msgstr ""
 
         expect(actualFiles["pl.js"]).toBeTruthy()
         expect(actualFiles["en.js"]).toBeTruthy()
+
+        const log = getConsoleMockCalls(console.error)
+        expect(log).toBeUndefined()
+        expect(result).toBeTruthy()
+      })
+    })
+
+    it("Should compile multiple pseudolocales with different options without failing when allowEmpty = false", async () => {
+      expect.assertions(6)
+      const rootDir = await createFixtures({
+        "en.po": `
+msgid "Hello World"
+msgstr "Hello World"
+        `,
+        "pseudo-en.po": `
+msgid "Hello World"
+msgstr ""
+        `,
+        "pseudo-ar.po": `
+msgid "Hello World"
+msgstr ""
+        `,
+      })
+
+      const config = getTestConfig(
+        rootDir,
+        [
+          { locale: "pseudo-en", prepend: "⟦ ", append: " ⟧" },
+          { locale: "pseudo-ar", rightToLeft: true },
+        ],
+        ["en", "pseudo-en", "pseudo-ar"],
+      )
+
+      await mockConsole(async (console) => {
+        const result = await command(config, {
+          allowEmpty: false,
+          workersOptions: {
+            poolSize: 0,
+          },
+        })
+        const actualFiles = readFsToListing(config.rootDir)
+
+        expect(actualFiles["pseudo-en.js"]).toContain("⟦")
+        expect(actualFiles["pseudo-en.js"]).toContain("⟧")
+        expect(actualFiles["pseudo-ar.js"]).toContain("\u202E") // RLO marker.
+        expect(actualFiles["pseudo-ar.js"]).toContain("\u202C") // PDF marker.
 
         const log = getConsoleMockCalls(console.error)
         expect(log).toBeUndefined()

--- a/packages/conf/__typetests__/index.tst.ts
+++ b/packages/conf/__typetests__/index.tst.ts
@@ -28,6 +28,8 @@ expect({
     append: " ⟧",
     extend: 0.4,
     extendCharacter: ".",
+    override: "_",
+    rightToLeft: true,
   },
 }).type.toBeAssignableTo<LinguiConfig>()
 

--- a/packages/conf/__typetests__/index.tst.ts
+++ b/packages/conf/__typetests__/index.tst.ts
@@ -33,6 +33,23 @@ expect({
   },
 }).type.toBeAssignableTo<LinguiConfig>()
 
+// pseudoLocale as an array of objects with pseudolocale options
+expect({
+  locales: ["en", "pseudo-en", "pseudo-ar"],
+  pseudoLocale: [
+    {
+      locale: "pseudo-en",
+      prepend: "⟦ ",
+      append: " ⟧",
+      extend: 0.4,
+    },
+    {
+      locale: "pseudo-ar",
+      rightToLeft: true,
+    },
+  ],
+}).type.toBeAssignableTo<LinguiConfig>()
+
 // all props
 expect({
   catalogs: [

--- a/packages/conf/src/__snapshots__/getConfig.test.ts.snap
+++ b/packages/conf/src/__snapshots__/getConfig.test.ts.snap
@@ -36,10 +36,7 @@ exports[`getConfig > default config and snapshots > should return default config
     ],
   },
   "orderBy": "message",
-  "pseudoLocale": {
-    "locale": "",
-    "options": {},
-  },
+  "pseudoLocale": [],
   "resolvedConfigPath": StringContaining ".linguirc",
   "rootDir": ".",
   "runtimeConfigModule": {

--- a/packages/conf/src/__snapshots__/index.test.ts.snap
+++ b/packages/conf/src/__snapshots__/index.test.ts.snap
@@ -32,10 +32,7 @@ exports[`@lingui/conf > should return default config 1`] = `
     ],
   },
   "orderBy": "message",
-  "pseudoLocale": {
-    "locale": "",
-    "options": {},
-  },
+  "pseudoLocale": [],
   "resolvedConfigPath": StringContaining "lingui.config.js",
   "rootDir": StringContaining "fixtures/valid",
   "runtimeConfigModule": {

--- a/packages/conf/src/index.test.ts
+++ b/packages/conf/src/index.test.ts
@@ -69,9 +69,9 @@ describe("@lingui/conf", () => {
       }),
     ).toThrowErrorMatchingInlineSnapshot(`
       [Error: String formats like \`{format: po}\` are no longer supported.
-            
+
       Formatters must now be installed as separate packages and provided via format in lingui config:
-              
+
       import { formatter } from "@lingui/format-po"
 
       export default {
@@ -111,17 +111,27 @@ describe("@lingui/conf", () => {
   })
 
   describe("normalize pseudoLocale", () => {
-    it("defaults to an empty locale with no options", () => {
+    it("defaults to an empty array", () => {
       const config = makeConfig({ locales: ["en"] })
-      expect(config.pseudoLocale).toEqual({ locale: "", options: {} })
+      expect(config.pseudoLocale).toEqual([])
     })
 
-    it("expands the string form into locale + empty options", () => {
+    it("handles empty string", () => {
+      const config = makeConfig({ locales: ["en"], pseudoLocale: "" })
+      expect(config.pseudoLocale).toEqual([])
+    })
+
+    it("handles empty array", () => {
+      const config = makeConfig({ locales: ["en"], pseudoLocale: [] })
+      expect(config.pseudoLocale).toEqual([])
+    })
+
+    it("expands the string form into array with empty options", () => {
       const config = makeConfig({ locales: ["en"], pseudoLocale: "pseudo" })
-      expect(config.pseudoLocale).toEqual({ locale: "pseudo", options: {} })
+      expect(config.pseudoLocale).toEqual([{ locale: "pseudo", options: {} }])
     })
 
-    it("splits the object form into locale + options", () => {
+    it("splits the object form into array with options", () => {
       const config = makeConfig({
         locales: ["en"],
         pseudoLocale: {
@@ -131,10 +141,40 @@ describe("@lingui/conf", () => {
           extend: 0.4,
         },
       })
-      expect(config.pseudoLocale).toEqual({
-        locale: "pseudo",
-        options: { prepend: "⟦ ", append: " ⟧", extend: 0.4 },
+      expect(config.pseudoLocale).toEqual([
+        {
+          locale: "pseudo",
+          options: { prepend: "⟦ ", append: " ⟧", extend: 0.4 },
+        },
+      ])
+    })
+
+    it("normalizes an array of pseudolocale objects", () => {
+      const config = makeConfig({
+        locales: ["en", "ar"],
+        pseudoLocale: [
+          {
+            locale: "en-pseudo",
+            prepend: "⟦ ",
+            append: " ⟧",
+            extend: 0.4,
+          },
+          {
+            locale: "ar-pseudo",
+            rightToLeft: true,
+          },
+        ],
       })
+      expect(config.pseudoLocale).toEqual([
+        {
+          locale: "en-pseudo",
+          options: { prepend: "⟦ ", append: " ⟧", extend: 0.4 },
+        },
+        {
+          locale: "ar-pseudo",
+          options: { rightToLeft: true },
+        },
+      ])
     })
   })
 

--- a/packages/conf/src/makeConfig.ts
+++ b/packages/conf/src/makeConfig.ts
@@ -1,4 +1,5 @@
 import type {
+  DeprecatedPseudoLocaleString,
   FallbackLocales,
   LinguiConfig,
   LinguiConfigNormalized,
@@ -56,17 +57,27 @@ export function makeConfig(
 }
 
 /**
- * Expands the `pseudoLocale` config (a plain string or a {@link PseudoLocaleConfig}
- * object) into a normalized shape with the locale and its options separated.
+ * Expands the `pseudoLocale` config (a plain string, a {@link PseudoLocaleConfig}
+ * object, or an array of objects) into a normalized array shape with each locale
+ * and its options separated.
  */
 function normalizePseudoLocale(
   pseudoLocale: LinguiConfig["pseudoLocale"],
-): PseudoLocaleConfigNormalized {
-  if (!pseudoLocale || typeof pseudoLocale === "string") {
-    return { locale: pseudoLocale ?? "", options: {} }
-  }
-  const { locale, ...options } = pseudoLocale
-  return { locale, options }
+): PseudoLocaleConfigNormalized[] {
+  if (!pseudoLocale) return []
+  const rawList = Array.isArray(pseudoLocale) ? pseudoLocale : [pseudoLocale]
+  return rawList
+    .map((item) => {
+      if (typeof item === "string") {
+        return item ? { locale: item, options: {} } : null
+      }
+      if (item?.locale) {
+        const { locale, ...options } = item
+        return { locale, options }
+      }
+      return null
+    })
+    .filter((item): item is NonNullable<typeof item> => !!item)
 }
 
 export const defaultConfig = {
@@ -88,7 +99,10 @@ export const defaultConfig = {
   fallbackLocales: {} as FallbackLocales,
   locales: [],
   orderBy: "message",
-  pseudoLocale: "" as string | PseudoLocaleConfig,
+  pseudoLocale: "" as
+    | DeprecatedPseudoLocaleString
+    | PseudoLocaleConfig
+    | PseudoLocaleConfig[],
   rootDir: ".",
   runtimeConfigModule: ["@lingui/core", "i18n"],
   macro: {
@@ -111,13 +125,27 @@ export const exampleConfig = {
     jsxRuntime: multipleValidOptions("react", "solid"),
   },
   format: multipleValidOptions({}, {}),
-  pseudoLocale: multipleValidOptions("", {
-    locale: "",
-    prepend: "",
-    append: "",
-    extend: 0,
-    override: "",
-  }),
+  pseudoLocale: multipleValidOptions(
+    "",
+    {
+      locale: "",
+      prepend: "",
+      append: "",
+      extend: 0,
+      override: "",
+      rightToLeft: false,
+    },
+    [
+      {
+        locale: "",
+        prepend: "",
+        append: "",
+        extend: 0,
+        override: "",
+        rightToLeft: false,
+      },
+    ],
+  ),
   extractors: multipleValidOptions([], ["babel"], [Object]),
   runtimeConfigModule: multipleValidOptions(
     { i18n: ["@lingui/core", "i18n"], Trans: ["@lingui/react", "Trans"] },
@@ -160,9 +188,9 @@ function deprecateParserOptions(config: LinguiConfig) {
   if (config.extractorParserOptions) {
     console.error(
       `\`extractorParserOptions\` config option is deprecated.
-      
+
 Please pass options directly to the extractor implementation:
-      
+
 import { createBabelExtractor } from '@lingui/cli/api/extractors/babel'
 
 export default {
@@ -178,9 +206,9 @@ function validateFormat(config: LinguiConfig) {
   if (typeof config.format === "string") {
     throw new Error(
       `String formats like \`{format: ${config.format}}\` are no longer supported.
-      
+
 Formatters must now be installed as separate packages and provided via format in lingui config:
-        
+
 import { formatter } from "@lingui/format-po"
 
 export default {

--- a/packages/conf/src/types.ts
+++ b/packages/conf/src/types.ts
@@ -587,6 +587,12 @@ export type PseudoLocaleOptions = {
    * @default undefined
    */
   override?: string
+  /**
+   * Emulates right-to-left languages by inserting Unicode RTL override marks.
+   *
+   * @default false
+   */
+  rightToLeft?: boolean
 }
 
 /**

--- a/packages/conf/src/types.ts
+++ b/packages/conf/src/types.ts
@@ -388,12 +388,13 @@ export type LinguiConfig = {
    * Locale used for pseudolocalization. For example, when you set `pseudoLocale: "en"`, all messages in the en catalog will be pseudo-localized.
    * The locale must be included in the locales config.
    *
-   * You can either pass the locale as a string, or an object to additionally
+   * You can pass a single locale as a string (deprecated), an object to additionally
    * configure the underlying [`pseudolocale`](https://github.com/MartinCerny-awin/pseudolocale)
-   * library (e.g. to customize the prepended/appended markers or extend the string length).
+   * library (e.g. to customize the prepended/appended markers or extend the string length),
+   * or an array of objects to define multiple pseudolocales with different parameters.
    *
    * The string form is deprecated and will be removed in a future major release.
-   * Use the object form (`{ locale: "pseudo" }`) instead.
+   * Use the object form (`{ locale: "pseudo" }`) or array of objects instead.
    *
    * @example
    *
@@ -403,11 +404,18 @@ export type LinguiConfig = {
    *
    * // Extended form
    * pseudoLocale: { locale: "pseudo", prepend: "⟦ ", append: " ⟧", extend: 0.4 }
+   *
+   * // Multiple pseudolocales
+   * pseudoLocale: [
+   *   { locale: "pseudo-en", prepend: "⟦ ", append: " ⟧" },
+   *   { locale: "pseudo-ar", rightToLeft: true }
+   * ]
    * ```
    *
    * https://lingui.dev/guides/pseudolocalization
    */
-  pseudoLocale?: DeprecatedPseudoLocaleString | PseudoLocaleConfig
+  pseudoLocale?:
+    DeprecatedPseudoLocaleString | PseudoLocaleConfig | PseudoLocaleConfig[]
   /**
    * This is the directory where the Lingui CLI scans for messages in your source files during the extraction process.
    *
@@ -632,7 +640,7 @@ export type LinguiConfigNormalized = Omit<
   "runtimeConfigModule" | "pseudoLocale"
 > & {
   resolvedConfigPath?: string
-  pseudoLocale: PseudoLocaleConfigNormalized
+  pseudoLocale: PseudoLocaleConfigNormalized[]
   runtimeConfigModule: {
     i18n: ModuleSourceNormalized
     useLingui: ModuleSourceNormalized

--- a/packages/loader/src/webpackLoader.ts
+++ b/packages/loader/src/webpackLoader.ts
@@ -50,7 +50,7 @@ Resource: ${this.resourcePath}
 Your catalogs:
 ${config.catalogs.map((c) => c.path).join("\n")}
 
-Working dir is: 
+Working dir is:
 ${process.cwd()}
 
 Please check that \`catalogs.path\` is filled properly.\n`,
@@ -69,9 +69,13 @@ Please check that \`catalogs.path\` is filled properly.\n`,
     },
   )
 
+  const pseudoLocaleConfig = config.pseudoLocale.find(
+    (item) => item.locale === locale,
+  )
+
   if (
     options.failOnMissing &&
-    locale !== config.pseudoLocale.locale &&
+    !pseudoLocaleConfig &&
     missingMessages.length > 0
   ) {
     const message = createMissingErrorMessage(locale, missingMessages, "loader")
@@ -89,8 +93,8 @@ Please check that \`catalogs.path\` is filled properly.\n`,
   const { source: code, errors } = createCompiledCatalog(locale, messages, {
     strict,
     namespace: this._module!.type === "json" ? "json" : "es",
-    pseudoLocale: config.pseudoLocale.locale,
-    pseudoLocaleOptions: config.pseudoLocale.options,
+    pseudoLocale: pseudoLocaleConfig?.locale,
+    pseudoLocaleOptions: pseudoLocaleConfig?.options,
   })
 
   if (errors.length) {

--- a/packages/metro-transformer/src/metroTransformer.ts
+++ b/packages/metro-transformer/src/metroTransformer.ts
@@ -59,7 +59,7 @@ export async function transformFile(
 Your catalogs:
 ${config.catalogs.map((c) => c.path).join("\n")}
 
-Working dir is: 
+Working dir is:
 ${process.cwd()}
 
 Please check that \`catalogs.path\` is filled properly and restart the Metro server.\n`,
@@ -75,11 +75,15 @@ Please check that \`catalogs.path\` is filled properly and restart the Metro ser
 
   const strict = process.env.NODE_ENV !== "production"
 
+  const pseudoLocaleConfig = config.pseudoLocale.find(
+    (item) => item.locale === locale,
+  )
+
   const { source } = createCompiledCatalog(locale, messages, {
     strict,
     namespace: "es",
-    pseudoLocale: config.pseudoLocale.locale,
-    pseudoLocaleOptions: config.pseudoLocale.options,
+    pseudoLocale: pseudoLocaleConfig?.locale,
+    pseudoLocaleOptions: pseudoLocaleConfig?.options,
   })
 
   return source

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -88,9 +88,13 @@ Please check that catalogs.path is filled properly.\n`,
               sourceLocale: config.sourceLocale,
             })
 
+          const pseudoLocaleConfig = config.pseudoLocale.find(
+            (item) => item.locale === locale,
+          )
+
           if (
             failOnMissing &&
-            locale !== config.pseudoLocale.locale &&
+            !pseudoLocaleConfig &&
             missingMessages.length > 0
           ) {
             const message = createMissingErrorMessage(
@@ -108,8 +112,8 @@ Please check that catalogs.path is filled properly.\n`,
             messages,
             {
               namespace: "es",
-              pseudoLocale: config.pseudoLocale.locale,
-              pseudoLocaleOptions: config.pseudoLocale.options,
+              pseudoLocale: pseudoLocaleConfig?.locale,
+              pseudoLocaleOptions: pseudoLocaleConfig?.options,
             },
           )
 

--- a/website/docs/guides/pseudolocalization.md
+++ b/website/docs/guides/pseudolocalization.md
@@ -21,8 +21,14 @@ import { defineConfig } from "@lingui/cli";
 export default defineConfig({
   locales: ["en", "pseudo-LOCALE"],
   pseudoLocale: { locale: "pseudo-LOCALE" },
+  locales: ["en", "pseudo-LOCALE", "pseudo-RTL"],
+  pseudoLocale: [
+    { locale: "pseudo-LOCALE" },
+    { locale: "pseudo-RTL", rightToLeft: true },
+  ],
   fallbackLocales: {
     "pseudo-LOCALE": "en",
+    "pseudo-RTL": "en",
   },
 });
 ```
@@ -30,10 +36,10 @@ export default defineConfig({
 The `pseudoLocale.locale` option must be set to any string that matches a value in the [`locales`](/ref/conf#locales) configuration. If this is not set correctly, no folder or pseudolocalization will be created.
 
 :::caution
-`pseudoLocale` also accepts a plain string (e.g. `pseudoLocale: "pseudo-LOCALE"`), but this form is deprecated and will be removed in a future major release. Use the object form instead.
+`pseudoLocale` also accepts a plain string (e.g. `pseudoLocale: "pseudo-LOCALE"`), but this form is deprecated and will be removed in a future major release. Use the object or array form instead.
 :::
 
-The object form also lets you configure the underlying pseudolocalization library (markers, string length, and more). See the [`pseudoLocale`](/ref/conf#pseudolocale) reference for all available options.
+The object form also lets you configure the underlying pseudolocalization library (markers, string length, and more). You can also provide an array of objects to configure multiple pseudolocales with different options. See the [`pseudoLocale`](/ref/conf#pseudolocale) reference for all available options.
 
 If the `fallbackLocales` is configured, the pseudolocalization will be generated from the translated fallback locale instead.
 

--- a/website/docs/ref/conf.md
+++ b/website/docs/ref/conf.md
@@ -215,10 +215,10 @@ Default value: `""`
 
 Locale used for pseudolocalization. For example, when you set `pseudoLocale: "en"`, all messages in the `en` catalog will be pseudo-localized. The locale must be included in the `locales` config.
 
-It can be provided either as a string, or as an object to additionally configure the underlying [`pseudolocale`](https://github.com/MartinCerny-awin/pseudolocale) library. The token delimiter is managed internally by Lingui (to keep HTML tags, ICU macros and variables intact) and therefore cannot be configured.
+It can be provided as a string (deprecated), an object to additionally configure the underlying [`pseudolocale`](https://github.com/MartinCerny-awin/pseudolocale) library, or an array of objects to define multiple pseudolocales with different parameters. The token delimiter is managed internally by Lingui (to keep HTML tags, ICU macros and variables intact) and therefore cannot be configured.
 
 :::caution
-The string form (`pseudoLocale: "pseudo"`) is deprecated and will be removed in a future major release. Use the object form (`pseudoLocale: { locale: "pseudo" }`) instead.
+The string form (`pseudoLocale: "pseudo"`) is deprecated and will be removed in a future major release. Use the object form (`pseudoLocale: { locale: "pseudo" }`) or an array of objects instead.
 :::
 
 | Option            | Type      | Default     | Description                                                                                         |
@@ -253,6 +253,17 @@ export default defineConfig({
     extend: 0.4,
     extendCharacter: ".",
   },
+  catalogs: [],
+});
+
+// Multiple pseudolocales
+export default defineConfig({
+  locales: ["en", "pseudo-en", "pseudo-ar"],
+  sourceLocale: "en",
+  pseudoLocale: [
+    { locale: "pseudo-en", prepend: "⟦ ", append: " ⟧", extend: 0.4 },
+    { locale: "pseudo-ar", rightToLeft: true },
+  ],
   catalogs: [],
 });
 ```

--- a/website/docs/ref/conf.md
+++ b/website/docs/ref/conf.md
@@ -221,14 +221,15 @@ It can be provided either as a string, or as an object to additionally configure
 The string form (`pseudoLocale: "pseudo"`) is deprecated and will be removed in a future major release. Use the object form (`pseudoLocale: { locale: "pseudo" }`) instead.
 :::
 
-| Option            | Type     | Default     | Description                                                                                         |
-| ----------------- | -------- | ----------- | --------------------------------------------------------------------------------------------------- |
-| `locale`          | `string` | —           | Locale used for pseudolocalization (required in the object form)                                    |
-| `prepend`         | `string` | `""`        | String prepended to the beginning of every pseudo-localized message                                 |
-| `append`          | `string` | `""`        | String appended to the end of every pseudo-localized message                                        |
-| `extend`          | `number` | `0`         | Extends the width of the string by the given percentage (e.g. `0.3` adds 30%)                       |
-| `extendCharacter` | `string` | `" "`       | Character used to pad messages when `extend` is set                                                 |
-| `override`        | `string` | `undefined` | Replaces every (non-token) character with the given one. Handy to quickly spot untranslated strings |
+| Option            | Type      | Default     | Description                                                                                         |
+| ------------------| --------- | ----------- | --------------------------------------------------------------------------------------------------- |
+| `locale`          | `string`  | —           | Locale used for pseudolocalization (required in the object form)                                    |
+| `prepend`         | `string`  | `""`        | String prepended to the beginning of every pseudo-localized message                                 |
+| `append`          | `string`  | `""`        | String appended to the end of every pseudo-localized message                                        |
+| `extend`          | `number`  | `0`         | Extends the width of the string by the given percentage (e.g. `0.3` adds 30%)                       |
+| `extendCharacter` | `string`  | `" "`       | Character used to pad messages when `extend` is set                                                 |
+| `override`        | `string`  | `undefined` | Replaces every (non-token) character with the given one. Handy to quickly spot untranslated strings |
+| `rightToLeft`     | `boolean` | `false`     | Emulates right-to-left languages by inserting Unicode RTL override marks                            |
 
 ```ts title="lingui.config.{js,ts}"
 import { defineConfig } from "@lingui/cli";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1553,7 +1553,7 @@ __metadata:
     msw: "npm:^2.12.7"
     normalize-path: "npm:^3.0.0"
     ora: "npm:^9.1.0"
-    pseudolocale: "npm:^2.3.0"
+    pseudolocale: "npm:^3.1.0"
     rolldown: "npm:^1.1.1"
     source-map: "npm:^0.7.6"
     tinypool: "npm:^2.1.0"
@@ -5482,17 +5482,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander@npm:^10.0.0":
-  version: 10.0.0
-  resolution: "commander@npm:10.0.0"
-  checksum: 10/a4fc6d79b44fd87f6c5fbbdfc8d10fa8b33e1676ae170356419b9e06faf802899fae03a3b151c2e6a18047885ca42d2b70e0a94d4e5042edb948100848d43f91
-  languageName: node
-  linkType: hard
-
 "commander@npm:^11.1.0":
   version: 11.1.0
   resolution: "commander@npm:11.1.0"
   checksum: 10/66bd2d8a0547f6cb1d34022efb25f348e433b0e04ad76a65279b1b09da108f59a4d3001ca539c60a7a46ea38bcf399fc17d91adad76a8cf43845d8dcbaf5cda1
+  languageName: node
+  linkType: hard
+
+"commander@npm:^13.1.0":
+  version: 13.1.0
+  resolution: "commander@npm:13.1.0"
+  checksum: 10/d3b4b79e6be8471ddadacbb8cd441fe82154d7da7393b50e76165a9e29ccdb74fa911a186437b9a211d0fc071db6051915c94fb8ef16d77511d898e9dbabc6af
   languageName: node
   linkType: hard
 
@@ -11852,14 +11852,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pseudolocale@npm:^2.3.0":
-  version: 2.3.0
-  resolution: "pseudolocale@npm:2.3.0"
+"pseudolocale@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "pseudolocale@npm:3.1.0"
   dependencies:
-    commander: "npm:^10.0.0"
+    commander: "npm:^13.1.0"
   bin:
     pseudolocale: dist/cli.mjs
-  checksum: 10/72049611bd9f81e6e5e64c5ce9216479a1a136c2c70d52d711642ba3f19994da349d060bc56ef7293b427cc468a25b848bdb01971848bc958e76d32de8ed083f
+  checksum: 10/2ecd3776a8fdd110b50c18a26eeec5b65843b5f93409990b219103872a43ca2419f57b82be3f41a369befafb48e9ff880958b54c9045f9869bacccc2c841b5c3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- feat(cli): add rightToLeft option to pseudoLocale
- feat(conf): support array of pseudolocales in pseudoLocale config
- docs: Updated CONTRIBUTING.md to the actual linting and formatting commands

Fixes #2641