### PR TITLE
fix(core): prevent prototype pollution via __proto__ locale key in i18n.load

### DIFF
--- a/packages/core/src/i18n.test.ts
+++ b/packages/core/src/i18n.test.ts
@@ -55,6 +55,38 @@ describe("I18n", () => {
       i18n.activate("fr")
       expect(i18n.messages).toEqual(frMessages)
     })
+
+    describe("prototype pollution", () => {
+      afterEach(() => {
+        delete (Object.prototype as any).polluted
+      })
+
+      it("should not pollute Object.prototype via __proto__ locale key", () => {
+        const i18n = setupI18n()
+        i18n.load(JSON.parse('{"__proto__":{"polluted":"yes"}}'))
+        expect(({} as any).polluted).toBeUndefined()
+      })
+
+      it("should not pollute Object.prototype via __proto__ string locale", () => {
+        const i18n = setupI18n()
+        i18n.load("__proto__", { polluted: "yes" })
+        expect(({} as any).polluted).toBeUndefined()
+      })
+
+      it("should not pollute Object.prototype via __proto__ message key", () => {
+        const i18n = setupI18n()
+        i18n.load("en", JSON.parse('{"__proto__":"yes"}'))
+        expect(({} as any).polluted).toBeUndefined()
+      })
+
+      it("should still load and merge a normal locale", () => {
+        const i18n = setupI18n()
+        i18n.load({ en: { Hello: "Hello" } })
+        i18n.load({ en: { World: "World" } })
+        i18n.activate("en")
+        expect(i18n.messages).toEqual({ Hello: "Hello", World: "World" })
+      })
+    })
   })
 
   describe("I18n.activate", () => {

--- a/packages/core/src/i18n.ts
+++ b/packages/core/src/i18n.ts
@@ -151,7 +151,14 @@ export class I18n extends EventEmitter<Events> {
     return this
   }
   private _load(locale: Locale, messages: Messages) {
-    const maybeMessages = this._messages[locale]
+    // Own-property check so a "__proto__" locale key can't resolve to
+    // Object.prototype and get merged into (prototype pollution).
+    const maybeMessages = Object.prototype.hasOwnProperty.call(
+      this._messages,
+      locale,
+    )
+      ? this._messages[locale]
+      : undefined
     if (!maybeMessages) {
       this._messages[locale] = messages
     } else {


### PR DESCRIPTION
# Description

`_load` looked up the locale with plain bracket access, so a `__proto__` key resolved to `Object.prototype` and the merge branch copied the messages onto it.

Check for an own property before merging so such keys never reach the prototype chain. This is hardening rather than a fix for a practical exploit: it only matters when an app passes unvalidated input as locale keys to `load`, which catalogs compiled at build time never do.

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
