### PR TITLE
feat(core): add default global variables support to i18n instance

### DIFF
--- a/packages/core/__typetests__/index.tst.ts
+++ b/packages/core/__typetests__/index.tst.ts
@@ -1,5 +1,5 @@
-import { i18n } from "@lingui/core"
-import type { MessageId } from "@lingui/core"
+import { i18n, setupI18n } from "@lingui/core"
+import type { I18n, MessageId, Values } from "@lingui/core"
 import { expect } from "tstyche"
 
 // MessageId resolves to string when Register is not augmented
@@ -58,3 +58,15 @@ expect(i18n.t).type.not.toBeCallableWith(
 expect(i18n.load).type.toBeCallableWith("cs", {})
 expect(i18n.load).type.toBeCallableWith({ cs: {} })
 expect(i18n.load).type.not.toBeCallableWith({ cs: {} }, {})
+
+expect(i18n.variables).type.toBe<Values>()
+expect(setupI18n({ variables: { gender: "female" } })).type.toBe<I18n>()
+expect(i18n.setVariable("gender", "male")).type.toBe<I18n>()
+expect(i18n.setVariable("gender", () => "male")).type.toBe<I18n>()
+expect(i18n.setVariables({ gender: "male" })).type.toBe<I18n>()
+expect(
+  i18n.setVariables((prev) => ({
+    ...prev,
+    gender: "female",
+  })),
+).type.toBe<I18n>()

--- a/packages/core/src/i18n.test.ts
+++ b/packages/core/src/i18n.test.ts
@@ -694,4 +694,273 @@ describe("I18n", () => {
       ).toMatchInlineSnapshot(`"It starts on 5:40:00 PM UTC"`)
     })
   })
+
+  describe("variables", () => {
+    it("should initialize default variables via setupI18n", () => {
+      const i18n = setupI18n({
+        locale: "en",
+        messages: {
+          en: {
+            welcome:
+              "{gender, select, female {[F] Welcome} male {[M] Welcome} other {[N] Welcome}}",
+            brand: "Powered by {appName}",
+          },
+        },
+        variables: {
+          gender: "female",
+          appName: "LinguiApp",
+        },
+      })
+
+      expect(i18n.variables).toEqual({
+        gender: "female",
+        appName: "LinguiApp",
+      })
+
+      expect(i18n._("welcome")).toEqual("[F] Welcome")
+      expect(i18n._("brand")).toEqual("Powered by LinguiApp")
+    })
+
+    it("should allow updating variables via setVariables and emit change event", () => {
+      const i18n = setupI18n({
+        locale: "en",
+        messages: {
+          en: {
+            welcome:
+              "{gender, select, female {[F] Welcome} male {[M] Welcome} other {[N] Welcome}}",
+          },
+        },
+        variables: {
+          gender: "female",
+        },
+      })
+
+      const onChange = vi.fn()
+      i18n.on("change", onChange)
+
+      expect(i18n._("welcome")).toEqual("[F] Welcome")
+
+      const result = i18n.setVariables({ gender: "male" })
+      expect(result).toBe(i18n)
+      expect(onChange).toHaveBeenCalledTimes(1)
+      expect(i18n.variables).toEqual({ gender: "male" })
+      expect(i18n._("welcome")).toEqual("[M] Welcome")
+    })
+
+    it("should support functional updates with previous variables", () => {
+      const i18n = setupI18n({
+        locale: "en",
+        messages: {
+          en: {
+            info: "{appName} version {version} for {gender}",
+          },
+        },
+        variables: {
+          appName: "LinguiApp",
+          gender: "female",
+        },
+      })
+
+      i18n.setVariables((prev) => ({
+        ...prev,
+        version: "6.0",
+      }))
+
+      expect(i18n.variables).toEqual({
+        appName: "LinguiApp",
+        gender: "female",
+        version: "6.0",
+      })
+      expect(i18n._("info")).toEqual("LinguiApp version 6.0 for female")
+    })
+
+    it("should allow setting or updating a single variable via setVariable without clobbering", () => {
+      const i18n = setupI18n({
+        locale: "en",
+        messages: {
+          en: {
+            info: "{appName} version {version} for {gender}",
+          },
+        },
+        variables: {
+          appName: "LinguiApp",
+          gender: "female",
+        },
+      })
+
+      const onChange = vi.fn()
+      i18n.on("change", onChange)
+
+      const result = i18n.setVariable("version", "6.0")
+      expect(result).toBe(i18n)
+      expect(onChange).toHaveBeenCalledTimes(1)
+
+      expect(i18n.variables).toEqual({
+        appName: "LinguiApp",
+        gender: "female",
+        version: "6.0",
+      })
+      expect(i18n._("info")).toEqual("LinguiApp version 6.0 for female")
+
+      i18n.setVariable("version", "6.1")
+      expect(i18n.variables.version).toEqual("6.1")
+      expect(i18n._("info")).toEqual("LinguiApp version 6.1 for female")
+
+      i18n.setVariable("version", undefined)
+      expect("version" in i18n.variables).toBe(false)
+      expect(i18n._("info")).toEqual("LinguiApp version  for female")
+    })
+
+    it("should support setting computed getter function via setVariable", () => {
+      let currentGender = "female"
+      const user = {
+        get gender() {
+          return currentGender
+        },
+      }
+
+      const i18n = setupI18n({
+        locale: "en",
+        messages: {
+          en: {
+            welcome:
+              "{gender, select, female {[F] Welcome} male {[M] Welcome} other {[N] Welcome}}",
+          },
+        },
+      })
+
+      i18n.setVariable("gender", () => user.gender)
+      expect(i18n._("welcome")).toEqual("[F] Welcome")
+
+      currentGender = "male"
+      expect(i18n._("welcome")).toEqual("[M] Welcome")
+    })
+
+    it("should prioritize caller-supplied values over default variables", () => {
+      const i18n = setupI18n({
+        locale: "en",
+        messages: {
+          en: {
+            info: "{appName} greeting: Hello {name}, gender {gender}!",
+          },
+        },
+        variables: {
+          appName: "LinguiApp",
+          gender: "neutral",
+        },
+      })
+
+      expect(
+        i18n._("info", {
+          name: "Alex",
+          gender: "female",
+        }),
+      ).toEqual("LinguiApp greeting: Hello Alex, gender female!")
+
+      expect(
+        i18n._("info", {
+          name: "Sam",
+          gender: undefined,
+        }),
+      ).toEqual("LinguiApp greeting: Hello Sam, gender neutral!")
+    })
+
+    it("should work with message descriptors and i18n.t alias", () => {
+      const i18n = setupI18n({
+        locale: "en",
+        messages: { en: {} },
+        variables: {
+          appName: "LinguiApp",
+        },
+      })
+
+      expect(
+        i18n._({
+          id: "brand",
+          message: "Welcome to {appName}!",
+        }),
+      ).toEqual("Welcome to LinguiApp!")
+
+      expect(
+        i18n.t({
+          id: "brand",
+          message: "Welcome to {appName}!",
+        }),
+      ).toEqual("Welcome to LinguiApp!")
+    })
+
+    it("should support computed properties (getters) and evaluate them dynamically", () => {
+      let currentGender = "female"
+      const user = {
+        get gender() {
+          return currentGender
+        },
+      }
+
+      const i18n = setupI18n({
+        locale: "en",
+        messages: {
+          en: {
+            welcome:
+              "{gender, select, female {[F] Welcome} male {[M] Welcome} other {[N] Welcome}}",
+          },
+        },
+        variables: {
+          get gender() {
+            return user.gender
+          },
+        },
+      })
+
+      expect(i18n._("welcome")).toEqual("[F] Welcome")
+
+      currentGender = "male"
+      expect(i18n._("welcome")).toEqual("[M] Welcome")
+    })
+
+    it("should not evaluate getters if variable is not referenced in the message", () => {
+      let getterCalls = 0
+      const i18n = setupI18n({
+        locale: "en",
+        messages: {
+          en: {
+            simple: "Just a simple message",
+          },
+        },
+        variables: {
+          get expensive() {
+            getterCalls++
+            return "computed"
+          },
+        },
+      })
+
+      expect(i18n._("simple")).toEqual("Just a simple message")
+      expect(getterCalls).toEqual(0)
+    })
+
+    it("should preserve variables across locale changes", () => {
+      const i18n = setupI18n({
+        locale: "en",
+        messages: {
+          en: {
+            welcome:
+              "{gender, select, female {[F] Welcome} male {[M] Welcome} other {[N] Welcome}}",
+          },
+          es: {
+            welcome:
+              "{gender, select, female {[F] Bienvenida} male {[M] Bienvenido} other {[N] Bienvenidx}}",
+          },
+        },
+        variables: {
+          gender: "female",
+        },
+      })
+
+      expect(i18n._("welcome")).toEqual("[F] Welcome")
+
+      i18n.activate("es")
+      expect(i18n._("welcome")).toEqual("[F] Bienvenida")
+    })
+  })
 })

--- a/packages/core/src/i18n.ts
+++ b/packages/core/src/i18n.ts
@@ -81,6 +81,7 @@ export type I18nProps = {
   locales?: Locales
   messages?: AllMessages
   missing?: MissingHandler
+  variables?: Values
 }
 
 type Events = {
@@ -103,6 +104,7 @@ export class I18n extends EventEmitter<Events> {
   private _locale: Locale = ""
   private _locales?: Locales
   private _messages: AllMessages = {}
+  private _variables: Values = {}
   private _missing?: MissingHandler
   private _messageCompiler?: MessageCompiler
 
@@ -115,6 +117,7 @@ export class I18n extends EventEmitter<Events> {
 
     if (params.missing != null) this._missing = params.missing
     if (params.messages != null) this.load(params.messages)
+    if (params.variables != null) this._variables = params.variables
     if (typeof params.locale === "string" || params.locales) {
       this.activate(params.locale ?? defaultLocale, params.locales)
     }
@@ -130,6 +133,29 @@ export class I18n extends EventEmitter<Events> {
 
   get messages(): Messages {
     return this._messages[this._locale] ?? {}
+  }
+
+  get variables(): Values {
+    return this._variables
+  }
+
+  setVariable(name: string, value: unknown | (() => unknown)): this {
+    if (value === undefined) {
+      delete this._variables[name]
+    } else {
+      this._variables[name] = value
+    }
+    this.emit("change")
+    return this
+  }
+
+  setVariables(variables: Values | ((prev: Values) => Values)): this {
+    this._variables = isFunction(variables)
+      ? variables(this._variables)
+      : variables
+
+    this.emit("change")
+    return this
   }
   /**
    * Registers a `MessageCompiler` to enable the use of uncompiled catalogs at runtime.
@@ -273,11 +299,11 @@ Please compile your catalog first.
       return decodeEscapeSequences(translation)
     if (isString(translation)) return translation
 
-    return interpolate(
-      translation,
-      this._locale,
-      this._locales,
-    )(values, options?.formats)
+    return interpolate(translation, this._locale, this._locales)(
+      values,
+      options?.formats,
+      this._variables,
+    )
   }
 
   /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,7 @@ export { setupI18n, I18n } from "./i18n"
 
 export type {
   AllMessages,
+  I18nProps,
   MessageDescriptor,
   MessageId,
   Messages,
@@ -9,6 +10,7 @@ export type {
   Locales,
   MessageOptions,
   Register,
+  Values,
 } from "./i18n"
 
 // Default i18n object

--- a/packages/core/src/interpolate.test.ts
+++ b/packages/core/src/interpolate.test.ts
@@ -197,4 +197,49 @@ describe("interpolate", () => {
       "Hey Joeª!",
     )
   })
+
+  describe("default variables", () => {
+    it("should interpolate default variables when values are not provided", () => {
+      const cache = compile("Hello {name} from {appName}!")
+      expect(
+        interpolate(cache, "en", [])({}, undefined, {
+          name: "World",
+          appName: "Lingui",
+        }),
+      ).toEqual("Hello World from Lingui!")
+    })
+
+    it("should prioritize caller-provided values over default variables", () => {
+      const cache = compile("Hello {name}!")
+      expect(
+        interpolate(cache, "en", [])({ name: "Alice" }, undefined, {
+          name: "Bob",
+        }),
+      ).toEqual("Hello Alice!")
+
+      expect(
+        interpolate(cache, "en", [])({ name: undefined }, undefined, {
+          name: "Bob",
+        }),
+      ).toEqual("Hello Bob!")
+    })
+
+    it("should evaluate function/getter variables on demand", () => {
+      let callCount = 0
+      const cache = compile("Hello {name}!")
+      const format = interpolate(cache, "en", [])
+      const variables = {
+        name: () => {
+          callCount++
+          return "Dynamic"
+        },
+        get unused() {
+          throw new Error("should not be called")
+        },
+      }
+
+      expect(format({}, undefined, variables)).toEqual("Hello Dynamic!")
+      expect(callCount).toEqual(1)
+    })
+  })
 })

--- a/packages/core/src/interpolate.ts
+++ b/packages/core/src/interpolate.ts
@@ -9,7 +9,7 @@ import {
   type PluralOptions,
   time,
 } from "./formats"
-import { isString } from "./essentials"
+import { isString, isFunction } from "./essentials"
 import { CompiledIcuChoices } from "@lingui/message-utils/compileMessage"
 import { decodeEscapeSequences, ESCAPE_SEQUENCE_REGEX } from "./escapeSequences"
 
@@ -86,11 +86,21 @@ export function interpolate(
   locales?: Locales,
 ) {
   /**
-   * @param values  - Parameters for variable interpolation
-   * @param formats - Custom format styles
+   * @param values    - Parameters for variable interpolation
+   * @param formats   - Custom format styles
+   * @param variables - Default variables configured in the i18n instance
    */
-  return (values: Values = {}, formats?: Formats): string => {
+  return (
+    values: Values = {},
+    formats?: Formats,
+    variables?: Values,
+  ): string => {
     const formatters = getDefaultFormats(locale, locales, formats)
+
+    const getValue = (name: string): unknown => {
+      const value = values[name] ?? variables?.[name]
+      return isFunction(value) ? value() : value
+    }
 
     const formatMessage = (
       tokens: CompiledMessage | number | undefined,
@@ -133,10 +143,10 @@ export function interpolate(
         if (type) {
           // run formatter, such as plural, number, etc.
           const formatter = (formatters as any)[type]
-          value = formatter(values[name], interpolatedFormat)
+          value = formatter(getValue(name), interpolatedFormat)
         } else {
           // simple placeholder variable interpolation eq {variableName}
-          value = values[name]
+          value = getValue(name)
         }
 
         if (value == null) {

--- a/packages/react/src/I18nProvider.test.tsx
+++ b/packages/react/src/I18nProvider.test.tsx
@@ -2,6 +2,7 @@ import * as React from "react"
 import { act, render } from "@testing-library/react"
 
 import { I18nProvider, useLingui } from "./I18nProvider"
+import { Trans } from "./Trans"
 import { I18n, setupI18n } from "@lingui/core"
 import { useMemo, useCallback } from "react"
 import type { TransRenderProps } from "./TransNoContext"
@@ -335,5 +336,141 @@ describe("I18nProvider", () => {
     })
 
     expect(getByTestId("locale").textContent).toBe("cs")
+  })
+
+  describe("variables", () => {
+    it("renders default variables in Trans and updates on setVariables", () => {
+      const i18n = setupI18n({
+        locale: "en",
+        messages: {
+          en: {
+            welcome:
+              "{gender, select, female {[F] Welcome} male {[M] Welcome} other {[N] Welcome}}",
+          },
+        },
+        variables: {
+          gender: "female",
+        },
+      })
+
+      const { getByTestId } = render(
+        <I18nProvider i18n={i18n}>
+          <div data-testid="msg">
+            <Trans id="welcome" />
+          </div>
+        </I18nProvider>,
+      )
+
+      expect(getByTestId("msg").textContent).toBe("[F] Welcome")
+
+      act(() => {
+        i18n.setVariables({ gender: "male" })
+      })
+
+      expect(getByTestId("msg").textContent).toBe("[M] Welcome")
+    })
+
+    it("updates single variable via setVariable in Trans without clobbering", () => {
+      const i18n = setupI18n({
+        locale: "en",
+        messages: {
+          en: {
+            greeting: "Welcome {gender} to {appName}",
+          },
+        },
+        variables: {
+          gender: "female",
+          appName: "LinguiApp",
+        },
+      })
+
+      const { getByTestId } = render(
+        <I18nProvider i18n={i18n}>
+          <div data-testid="msg">
+            <Trans id="greeting" />
+          </div>
+        </I18nProvider>,
+      )
+
+      expect(getByTestId("msg").textContent).toBe("Welcome female to LinguiApp")
+
+      act(() => {
+        i18n.setVariable("gender", "male")
+      })
+
+      expect(getByTestId("msg").textContent).toBe("Welcome male to LinguiApp")
+    })
+
+    it("prioritizes call-site values in Trans over default variables", () => {
+      const i18n = setupI18n({
+        locale: "en",
+        messages: {
+          en: {
+            greeting: "Hello {name}, your role is {role} ({appName})",
+          },
+        },
+        variables: {
+          appName: "LinguiApp",
+          role: "User",
+        },
+      })
+
+      const { getByTestId } = render(
+        <I18nProvider i18n={i18n}>
+          <div data-testid="msg">
+            <Trans id="greeting" values={{ name: "Alice", role: "Admin" }} />
+          </div>
+        </I18nProvider>,
+      )
+
+      expect(getByTestId("msg").textContent).toBe(
+        "Hello Alice, your role is Admin (LinguiApp)",
+      )
+    })
+
+    it("evaluates computed getter variables in Trans", () => {
+      let currentGender = "female"
+      const user = {
+        get gender() {
+          return currentGender
+        },
+      }
+
+      const i18n = setupI18n({
+        locale: "en",
+        messages: {
+          en: {
+            welcome:
+              "{gender, select, female {[F] Welcome} male {[M] Welcome} other {[N] Welcome}}",
+          },
+        },
+        variables: {
+          get gender() {
+            return user.gender
+          },
+        },
+      })
+
+      const Consumer = () => {
+        const { _ } = useLingui()
+        return <div data-testid="msg">{_("welcome")}</div>
+      }
+
+      const { getByTestId, rerender } = render(
+        <I18nProvider i18n={i18n}>
+          <Consumer />
+        </I18nProvider>,
+      )
+
+      expect(getByTestId("msg").textContent).toBe("[F] Welcome")
+
+      currentGender = "male"
+      rerender(
+        <I18nProvider i18n={i18n}>
+          <Consumer />
+        </I18nProvider>,
+      )
+      expect(getByTestId("msg").textContent).toBe("[M] Welcome")
+    })
   })
 })

--- a/packages/solid/src/I18nProvider.test.tsx
+++ b/packages/solid/src/I18nProvider.test.tsx
@@ -252,4 +252,68 @@ describe("I18nProvider", () => {
 
     expect(getByTestId("locale").textContent).toBe("cs")
   })
+
+  it("updates computations when variables change via setVariables", () => {
+    const i18n = setupI18n({
+      locale: "en",
+      messages: {
+        en: {
+          welcome:
+            "{gender, select, female {[F] Welcome} male {[M] Welcome} other {[N] Welcome}}",
+        },
+      },
+      variables: {
+        gender: "female",
+      },
+    })
+
+    const Component = () => {
+      const { _ } = useLingui()
+      return <div data-testid="msg">{_("welcome")}</div>
+    }
+
+    const { getByTestId } = render(() => (
+      <I18nProvider i18n={i18n}>
+        <Component />
+      </I18nProvider>
+    ))
+
+    expect(getByTestId("msg").textContent).toBe("[F] Welcome")
+
+    i18n.setVariables({ gender: "male" })
+
+    expect(getByTestId("msg").textContent).toBe("[M] Welcome")
+  })
+
+  it("updates computations when single variable changes via setVariable", () => {
+    const i18n = setupI18n({
+      locale: "en",
+      messages: {
+        en: {
+          greeting: "Hello {gender} from {appName}",
+        },
+      },
+      variables: {
+        gender: "female",
+        appName: "LinguiApp",
+      },
+    })
+
+    const Component = () => {
+      const { _ } = useLingui()
+      return <div data-testid="msg">{_("greeting")}</div>
+    }
+
+    const { getByTestId } = render(() => (
+      <I18nProvider i18n={i18n}>
+        <Component />
+      </I18nProvider>
+    ))
+
+    expect(getByTestId("msg").textContent).toBe("Hello female from LinguiApp")
+
+    i18n.setVariable("gender", "male")
+
+    expect(getByTestId("msg").textContent).toBe("Hello male from LinguiApp")
+  })
 })


### PR DESCRIPTION
- Add `variables` option to `setupI18n({ variables })` and `I18nProps`
- Add `i18n.variables` getter to inspect current variables
- Add `i18n.setVariable(name, value)` and `i18n.setVariables(variables)` to update variables
- Lazily resolving referenced variables
- Prioritize values explicitly supplied at the call site

Fixes https://github.com/lingui/js-lingui/discussions/2646