### PR TITLE
docs: improve how the README, website and npm packages present Lingui to search and AI assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
 <h1>Lingui<sub>js</sub></h1>
 
-Lingui is a lightweight, open-source internationalization (i18n) library for JavaScript and TypeScript. Your source text stays in the code: compile-time macros turn it into ICU MessageFormat, and a CLI extracts and compiles the message catalogs. It works with React (including React Server Components and React Native), SolidJS, Vue, Node.js, and vanilla JS.
+Lingui is a lightweight, open-source internationalization (i18n) library for JavaScript and TypeScript. It brings compile-time macros and a CLI for message extraction to React, React Native, Vue, SolidJS, Astro, Svelte, and Node.js.
 
 About 2 kB gzipped core · 6M+ npm downloads a month · MIT licensed
 
@@ -89,7 +89,7 @@ On top of that:
 
 - **One library for the whole stack.** `@lingui/core` works in any JavaScript project. `@lingui/react` adds components and hooks, including React Server Components support, and `@lingui/solid` brings native SolidJS bindings. React Native uses the same extract-and-compile workflow, Vue single-file components are supported through `@lingui/extractor-vue`, and Astro and Svelte work through community packages.
 
-- **Standard formats and real tooling.** Translations live in PO files by default, which every translation tool understands, or in JSON, CSV, or a custom format. Messages carry comments and context for translators and machine translation. The [CLI](https://lingui.dev/ref/cli) extracts, compiles and validates, the [Vite plugin](https://lingui.dev/ref/vite-plugin) compiles catalogs on the fly, the [SWC plugin](https://lingui.dev/ref/swc-plugin) replaces Babel, and the [ESLint plugin](https://lingui.dev/ref/eslint-plugin) catches common mistakes.
+- **Standard formats and real tooling.** Translations live in PO files by default, which almost every translation tool understands, or in JSON, CSV, or a custom format. Messages carry comments and context for translators and machine translation. The [CLI](https://lingui.dev/ref/cli) extracts, compiles and validates, the [Vite plugin](https://lingui.dev/ref/vite-plugin) compiles catalogs on the fly, the [SWC plugin](https://lingui.dev/ref/swc-plugin) replaces Babel, and the [ESLint plugin](https://lingui.dev/ref/eslint-plugin) catches common mistakes.
 
 ## Who Uses Lingui
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <div align="center">
 <h1>Lingui<sub>js</sub></h1>
 
-🌍📖 A readable, automated, and optimized (2 kb) internationalization for JavaScript
+Lingui is a lightweight, open-source internationalization (i18n) library for JavaScript and TypeScript. Your source text stays in the code: compile-time macros turn it into ICU MessageFormat, and a CLI extracts and compiles the message catalogs. It works with React (including React Server Components and React Native), SolidJS, Vue, Node.js, and vanilla JS.
 
-🎉 **Lingui v6 is now available!** [Read the release announcement →](https://lingui.dev/blog/2026/04/22/announcing-lingui-6.0)
+About 2 kB gzipped core · 6M+ npm downloads a month · MIT licensed
 
 <hr />
 
@@ -13,64 +13,103 @@
 [![PRs Welcome][Badge-PRWelcome]][PRWelcome]
 [![Join the community on Discord][Badge-Discord]][Discord]
 
-[**Documentation**][Documentation] · [**Example**](#example) · [**Support**](#support) · [**Contribute**](#contribute) · [**License**](#license)
+[**Documentation**][Documentation] · [**Quick Start**](#quick-start) · [**Why Lingui**](#why-lingui) · [**Support**](#support) · [**Contribute**](#contribute) · [**License**](#license)
 
 </div>
 
-> Internationalization is the design and development of a product, application or document content that enables easy localization for target audiences that vary in culture, region, or language.
->
-> --- [ W3C Web Internationalization FAQ](https://www.w3.org/International/questions/qa-i18n)
+## Quick Start
 
-Lingui is an easy yet powerful internationalization (i18n) framework for global projects.
+```bash
+npm install @lingui/core @lingui/react
+npm install --save-dev @lingui/cli
+```
 
-## Key Features
+Lingui macros run at build time, so add the macro plugin for your transpiler and create a `lingui.config.js`. The [installation guide](https://lingui.dev/installation) covers both in a few minutes.
 
-- **Clean and readable** - Keep your code clean and readable, while the library uses battle-tested and powerful **ICU MessageFormat** under the hood.
+Then wrap the text you want to translate in the `Trans` macro. There are no message IDs to invent and no separate JSON file to keep in sync:
 
-- **Universal** - Use it everywhere. `@lingui/core` provides the essential intl functionality which works in any JavaScript project, while `@lingui/react` offers components to leverage React rendering, including React Server Components (RSC) support, and `@lingui/solid` brings native SolidJS bindings. The same extract-and-compile workflow applies to React Native. Astro and Svelte work through community-supported packages.
-
-- **Full rich-text support** - Use React components inside localized messages without any limitation. Writing rich-text messages is as easy as writing JSX. That helps keep message catalogs in sync with your source code.
-
-- **Powerful tooling** - Manage your intl workflow with the Lingui [CLI](https://lingui.dev/ref/cli), [Vite Plugin](https://lingui.dev/ref/vite-plugin), and [ESLint Plugin](https://lingui.dev/ref/eslint-plugin). The CLI extracts, compiles and validates messages, while the Vite plugin compiles catalogs on the fly, and the ESLint plugin helps catch common usage errors.
-
-- **Unopinionated** - Integrate Lingui into your existing workflow. It supports explicit message keys as well as auto-generated ones. Translations are stored in a standard PO file, which is supported in almost all translation tools. You can also use CSV or JSON, or add a custom formatter of your own.
-
-- **Lightweight and optimized** - Core library [![@lingui/core](https://deno.bundlejs.com/?q=%40lingui%2Fcore&treeshake=%5B%7Bi18n%7D%5D&badge=)](https://bundlejs.com/?q=%40lingui%2Fcore), React components [![@lingui/react](https://deno.bundlejs.com/?q=%40lingui%2Freact&config=%7B%22esbuild%22%3A%7B%22external%22%3A%5B%22react%22%2C%22%40lingui%2Fcore%22%5D%7D%7D&badge=)](https://bundlejs.com/?q=%40lingui%2Freact&config=%7B%22esbuild%22%3A%7B%22external%22%3A%5B%22react%22%2C%22%40lingui%2Fcore%22%5D%7D%7D).
-
-- **Built for AI-assisted workflows** - Good translations need context, especially for short UI strings. Lingui's localization formats let you describe where and how keys are used. Install [`lingui/skills`](https://github.com/lingui/skills) to help your AI assistant apply Lingui patterns consistently, and see [i18n with AI](https://lingui.dev/ai-tools) for MCP setup and more.
-
-- **Active community** - Join the growing [community of developers](https://lingui.dev/community) who are using Lingui to build global products.
-
-- **Compatible with react-intl** - Low-level React API is very similar to react-intl and the message format is the same. It's easy to migrate an existing project.
-
-## Example
-
-Short example how i18n looks with JSX:
-
-```js
+```jsx
+import { i18n } from "@lingui/core"
+import { I18nProvider } from "@lingui/react"
 import { Trans } from "@lingui/react/macro"
+import { messages } from "./locales/en/messages"
 
-function App() {
+i18n.load("en", messages)
+i18n.activate("en")
+
+export function App() {
   return (
-    <Trans
-      id="msg.docs" // Optional message id
-      comment="Docs link on the website" // Comment for translators, optional
-    >
-      Read the <a href="https://lingui.dev">documentation</a>
-      for more info.
-    </Trans>
+    <I18nProvider i18n={i18n}>
+      <Trans>
+        Read the <a href="https://lingui.dev">documentation</a> for more info.
+      </Trans>
+    </I18nProvider>
   )
 }
 ```
 
-Message from this component will be extracted in following format:
+Extract the messages into PO catalogs, translate them, then compile the catalogs into optimized runtime output:
 
-```po
-msgid "msg.docs"
-msgstr "Read the <0>documentation</0> for more info."
+```bash
+npx lingui extract
+npx lingui compile
 ```
 
-For more example see the [Examples](https://github.com/lingui/js-lingui/tree/main/examples) directory.
+After translation, the Czech catalog in `src/locales/cs/messages.po` looks like this. The `<0>` tag stands for the `<a>` element, so translators never touch your markup:
+
+```po
+#: src/App.jsx:12
+msgid "Read the <0>documentation</0> for more info."
+msgstr "Přečtěte si <0>dokumentaci</0> pro více informací."
+```
+
+Continue with the [React tutorial](https://lingui.dev/tutorials/react), or jump to [React Server Components](https://lingui.dev/tutorials/react-rsc), [React Native](https://lingui.dev/tutorials/react-native), [SolidJS](https://lingui.dev/tutorials/solid), or [plain JavaScript](https://lingui.dev/tutorials/javascript). Working projects for Vite, Next.js, Remix, TanStack Start, React Native and more live in the [examples](https://github.com/lingui/js-lingui/tree/main/examples) directory.
+
+## Why Lingui
+
+In key-based i18n libraries you invent a key, put the text in a JSON file, and reference the key from the code. With Lingui, the text stays where it is read:
+
+```jsx
+// Key-based i18n: the code holds a key, the text lives somewhere else
+<h1>{t("dashboard.welcome.title")}</h1>
+
+// Lingui: the text is the source of truth, the catalog is generated from it
+<h1>
+  <Trans>Welcome back, {name}</Trans>
+</h1>
+```
+
+The code reads like the UI it renders, and reviewers see the actual copy in the diff. Nobody has to name keys or look up what a key means. Running `lingui extract` regenerates the catalog from the source, so new messages are added and removed ones are marked obsolete without any manual bookkeeping. Translators get the real sentence with named placeholders, plus any comments and context you add. Message IDs are stable hashes generated at build time, and [explicit IDs](https://lingui.dev/guides/explicit-vs-generated-ids) are available when you need them.
+
+On top of that:
+
+- **Rich text without workarounds.** React components inside a message are as easy as writing JSX. Translators see numbered tags, and the catalog stays in sync with your components.
+
+- **Compiled, not parsed at runtime.** Catalogs are compiled ahead of time, so the runtime ships without a MessageFormat parser. Core [![@lingui/core](https://deno.bundlejs.com/?q=%40lingui%2Fcore&treeshake=%5B%7Bi18n%7D%5D&badge=)](https://bundlejs.com/?q=%40lingui%2Fcore), React bindings [![@lingui/react](https://deno.bundlejs.com/?q=%40lingui%2Freact&config=%7B%22esbuild%22%3A%7B%22external%22%3A%5B%22react%22%2C%22%40lingui%2Fcore%22%5D%7D%7D&badge=)](https://bundlejs.com/?q=%40lingui%2Freact&config=%7B%22esbuild%22%3A%7B%22external%22%3A%5B%22react%22%2C%22%40lingui%2Fcore%22%5D%7D%7D).
+
+- **One library for the whole stack.** `@lingui/core` works in any JavaScript project. `@lingui/react` adds components and hooks, including React Server Components support, and `@lingui/solid` brings native SolidJS bindings. React Native uses the same extract-and-compile workflow, Vue single-file components are supported through `@lingui/extractor-vue`, and Astro and Svelte work through community packages.
+
+- **Standard formats and real tooling.** Translations live in PO files by default, which every translation tool understands, or in JSON, CSV, or a custom format. Messages carry comments and context for translators and machine translation. The [CLI](https://lingui.dev/ref/cli) extracts, compiles and validates, the [Vite plugin](https://lingui.dev/ref/vite-plugin) compiles catalogs on the fly, the [SWC plugin](https://lingui.dev/ref/swc-plugin) replaces Babel, and the [ESLint plugin](https://lingui.dev/ref/eslint-plugin) catches common mistakes.
+
+## Who Uses Lingui
+
+Lingui runs in production at Bluesky, ElevenLabs, Linkerd, GDevelop, Documenso, Gamma, Twenty, Superset, Notesnook, Inkeep and many more. See the [showroom](https://lingui.dev/misc/showroom) for the full list, and add your project if it is missing.
+
+## Requirements
+
+- Node.js 22.19 or newer.
+- Lingui 6 packages are ESM-only. Modern bundlers and Node.js versions with `require(esm)` handle this transparently. See the [migration guide](https://lingui.dev/releases/migration-6).
+- Macros need Babel with `@lingui/babel-plugin-lingui-macro` or SWC with `@lingui/swc-plugin`.
+- `@lingui/react` supports React 16.14 and newer, including React 19.
+
+## Docs for AI Agents
+
+- Every documentation page is available as Markdown by appending `.md` to its URL, for example [lingui.dev/installation.md](https://lingui.dev/installation.md).
+- [lingui.dev/llms.txt](https://lingui.dev/llms.txt) indexes the docs and [lingui.dev/llms-full.txt](https://lingui.dev/llms-full.txt) contains them in full.
+- [Context7](https://context7.com/lingui/js-lingui) serves the latest docs over MCP. Add `use context7` to a prompt.
+- [`lingui/skills`](https://github.com/lingui/skills) packages Lingui best practices as Agent Skills for Claude Code, Cursor, Codex, Gemini CLI, GitHub Copilot and other compatible agents. Install with `npx skills add lingui/skills`.
+
+See [i18n with AI](https://lingui.dev/ai-tools) for the details.
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -93,12 +93,12 @@ On top of that:
 
 ## Who Uses Lingui
 
-Lingui runs in production at Bluesky, ElevenLabs, Linkerd, GDevelop, Documenso, Gamma, Twenty, Superset, Notesnook, Inkeep and many more. See the [showroom](https://lingui.dev/misc/showroom) for the full list, and add your project if it is missing.
+Lingui runs in production at Bluesky, ElevenLabs, Linkerd, GDevelop, Documenso, Gamma, Twenty, Superset, Notesnook, Inkeep and many more. See the [showroom](https://lingui.dev/misc/showroom) for more, and add your project if it is missing.
 
 ## Requirements
 
 - Node.js 22.19 or newer.
-- Lingui 6 packages are ESM-only. Modern bundlers and Node.js versions with `require(esm)` handle this transparently. See the [migration guide](https://lingui.dev/releases/migration-6).
+- Lingui 6 packages are ESM-only, except `@lingui/metro-transformer`, which stays CommonJS. Modern bundlers and Node.js versions with `require(esm)` handle this transparently. See the [migration guide](https://lingui.dev/releases/migration-6).
 - Macros need Babel with `@lingui/babel-plugin-lingui-macro` or SWC with `@lingui/swc-plugin`.
 - `@lingui/react` supports React 16.14 and newer, including React 19.
 

--- a/context7.json
+++ b/context7.json
@@ -8,10 +8,11 @@
   "rules": [
     "Import macros from @lingui/core/macro (t, plural, select, msg) and @lingui/react/macro (Trans, Plural, Select, useLingui). The i18n object comes from @lingui/core and I18nProvider from @lingui/react.",
     "Do not import from the deprecated @lingui/macro package and do not rely on babel-plugin-macros; use the per-package macro entry points.",
-    "Macros are expanded at build time: register @lingui/babel-plugin-lingui-macro in the Babel config or @lingui/swc-plugin in the SWC config (for example in next.config.js). Macros cannot be called at module level.",
+    "Macros are expanded at build time: register @lingui/babel-plugin-lingui-macro in the Babel config or @lingui/swc-plugin in the SWC config (for example in next.config.js).",
+    "Do not call t, plural or select at module level, they return a fixed string once. Use msg or defineMessage for module-level constants and translate them with i18n._ where rendered.",
     "Wrap the React tree in I18nProvider with an i18n instance that has a catalog loaded and a locale activated (i18n.load then i18n.activate, or i18n.loadAndActivate).",
     "In React components, use Trans for text with markup and the t returned by the useLingui macro for strings outside JSX such as attributes, so the component re-renders when the locale changes.",
-    "Message IDs are generated from the source text by default; do not invent keys. Use explicit ids only for strings whose text changes often.",
+    "Message IDs are generated from the source text by default; do not invent keys. If the project uses explicit ids, follow its convention.",
     "After adding or changing messages run lingui extract to update the PO catalogs, then lingui compile to produce the runtime catalogs before building. Configuration lives in lingui.config.js or lingui.config.ts.",
     "In React Server Components, call setI18n from @lingui/react/server in every page and layout; Trans and useLingui from @lingui/react/macro then work in both server and client components.",
     "Catalogs are PO files by default. Translators edit the .po files; the compiled catalogs are build output and should not be edited by hand.",

--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://context7.com/schema/context7.json",
+  "projectTitle": "Lingui",
+  "description": "Lingui is a lightweight, open-source internationalization (i18n) library for JavaScript and TypeScript.",
+  "folders": ["website/docs"],
+  "excludeFolders": [],
+  "excludeFiles": ["CHANGELOG.md"],
+  "rules": [
+    "Import macros from @lingui/core/macro (t, plural, select, msg) and @lingui/react/macro (Trans, Plural, Select, useLingui). The i18n object comes from @lingui/core and I18nProvider from @lingui/react.",
+    "Do not import from the deprecated @lingui/macro package and do not rely on babel-plugin-macros; use the per-package macro entry points.",
+    "Macros are expanded at build time: register @lingui/babel-plugin-lingui-macro in the Babel config or @lingui/swc-plugin in the SWC config (for example in next.config.js). Macros cannot be called at module level.",
+    "Wrap the React tree in I18nProvider with an i18n instance that has a catalog loaded and a locale activated (i18n.load then i18n.activate, or i18n.loadAndActivate).",
+    "In React components, use Trans for text with markup and the t returned by the useLingui macro for strings outside JSX such as attributes, so the component re-renders when the locale changes.",
+    "Message IDs are generated from the source text by default; do not invent keys. Use explicit ids only for strings whose text changes often.",
+    "After adding or changing messages run lingui extract to update the PO catalogs, then lingui compile to produce the runtime catalogs before building. Configuration lives in lingui.config.js or lingui.config.ts.",
+    "In React Server Components, call setI18n from @lingui/react/server in every page and layout; Trans and useLingui from @lingui/react/macro then work in both server and client components.",
+    "Catalogs are PO files by default. Translators edit the .po files; the compiled catalogs are build output and should not be edited by hand.",
+    "Lingui 6 requires Node.js 22.19 or newer and ships ESM-only packages."
+  ],
+  "previousVersions": [
+    {
+      "tag": "v5.9.5"
+    }
+  ]
+}

--- a/packages/babel-plugin-extract-messages/README.md
+++ b/packages/babel-plugin-extract-messages/README.md
@@ -4,50 +4,19 @@
 
 # @lingui/babel-plugin-extract-messages
 
-> Babel plugin which extracts messages for translation from source files
+> Babel plugin to extract translatable messages from source code into Lingui catalogs
 
-`@lingui/babel-plugin-extract-messages` is part of [LinguiJS][linguijs]. See the [documentation][documentation] for all information, tutorials and examples.
+`@lingui/babel-plugin-extract-messages` is part of [Lingui][documentation]. Lingui is a lightweight, open-source internationalization (i18n) library for JavaScript and TypeScript. It brings compile-time macros and a CLI for message extraction to React, React Native, Vue, SolidJS, Astro, Svelte, and Node.js.
 
-## Installation
-
-```sh
-npm install --save-dev @lingui/babel-plugin-extract-messages
-# yarn add --dev @lingui/babel-plugin-extract-messages
-```
-
-## Usage
-
-### Via `.babelrc` (Recommended)
-
-**.babelrc**
-
-```json
-{
-  "plugins": ["@lingui/babel-plugin-extract-messages"]
-}
-```
-
-### Via CLI
-
-```bash
-babel --plugins @lingui/babel-plugin-extract-messages script.js
-```
-
-### Via Node API
-
-```js
-require("@babel/core").transform("code", {
-  plugins: ["@lingui/babel-plugin-extract-messages"]
-})
-```
+**Internal package.** `@lingui/cli` runs this plugin during `lingui extract` to collect the messages that go into the catalogs. You do not need to install it or add it to your Babel config. See the [message extraction guide][extraction] for what the extractor recognizes.
 
 ## License
 
-[MIT][license]
+This package is licensed under the [MIT][license] license.
 
 [license]: https://github.com/lingui/js-lingui/blob/main/LICENSE
-[linguijs]: https://github.com/lingui/js-lingui
 [documentation]: https://lingui.dev
+[extraction]: https://lingui.dev/guides/message-extraction
 [package]: https://www.npmjs.com/package/@lingui/babel-plugin-extract-messages
 [badge-downloads]: https://img.shields.io/npm/dw/@lingui/babel-plugin-extract-messages.svg
 [badge-version]: https://img.shields.io/npm/v/@lingui/babel-plugin-extract-messages.svg

--- a/packages/babel-plugin-lingui-macro/README.md
+++ b/packages/babel-plugin-lingui-macro/README.md
@@ -8,7 +8,7 @@
 
 `@lingui/babel-plugin-lingui-macro` is part of [Lingui][documentation]. Lingui is a lightweight, open-source internationalization (i18n) library for JavaScript and TypeScript. It brings compile-time macros and a CLI for message extraction to React, React Native, Vue, SolidJS, Astro, Svelte, and Node.js.
 
-The plugin expands the macros from `@lingui/core/macro` and `@lingui/react/macro` at build time into ICU messages and calls to the Lingui runtime. Projects that compile with SWC use [`@lingui/swc-plugin`][swc-plugin] instead.
+The plugin expands the macros from `@lingui/core/macro`, `@lingui/react/macro` and `@lingui/solid/macro` at build time into ICU messages and calls to the Lingui runtime. Projects that compile with SWC use [`@lingui/swc-plugin`][swc-plugin] instead.
 
 ## Installation
 

--- a/packages/babel-plugin-lingui-macro/README.md
+++ b/packages/babel-plugin-lingui-macro/README.md
@@ -4,36 +4,30 @@
 
 # @lingui/babel-plugin-lingui-macro
 
-> Babel plugin that does actual transforms of Lingui's Macros
+> Babel plugin that transforms Lingui compile-time macros into optimized runtime calls
 
-`@lingui/babel-plugin-lingui-macro` is part of [LinguiJS][linguijs]. See the [documentation][documentation] for all information, tutorials and examples.
+`@lingui/babel-plugin-lingui-macro` is part of [Lingui][documentation]. Lingui is a lightweight, open-source internationalization (i18n) library for JavaScript and TypeScript. It brings compile-time macros and a CLI for message extraction to React, React Native, Vue, SolidJS, Astro, Svelte, and Node.js.
+
+The plugin expands the macros from `@lingui/core/macro` and `@lingui/react/macro` at build time into ICU messages and calls to the Lingui runtime. Projects that compile with SWC use [`@lingui/swc-plugin`][swc-plugin] instead.
 
 ## Installation
 
 ```sh
 npm install --save-dev @lingui/babel-plugin-lingui-macro
-# yarn add --dev @lingui/babel-plugin-lingui-macro
 ```
 
 ## Usage
 
-### Via `.babelrc`
-
-**.babelrc**
-
-```json
-{
-  "plugins": ["@lingui/babel-plugin-lingui-macro"]
-}
-```
+See the [Babel setup][installation] in the installation guide.
 
 ## License
 
-[MIT][license]
+This package is licensed under the [MIT][license] license.
 
 [license]: https://github.com/lingui/js-lingui/blob/main/LICENSE
-[linguijs]: https://github.com/lingui/js-lingui
 [documentation]: https://lingui.dev
+[installation]: https://lingui.dev/installation#choosing-a-transpiler
+[swc-plugin]: https://lingui.dev/ref/swc-plugin
 [package]: https://www.npmjs.com/package/@lingui/babel-plugin-lingui-macro
 [badge-downloads]: https://img.shields.io/npm/dw/@lingui/babel-plugin-lingui-macro.svg
 [badge-version]: https://img.shields.io/npm/v/@lingui/babel-plugin-lingui-macro.svg

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -4,22 +4,43 @@
 
 # @lingui/cli
 
-> lingui command line library for manipulating message catalogues
+> Lingui CLI: extracts i18n messages from source code into catalogs and compiles the translated catalogs for the runtime
 
-`@lingui/cli` is part of [LinguiJS][linguijs]. See the [documentation][documentation] for all information, tutorials and examples.
+`@lingui/cli` is part of [Lingui][documentation]. Lingui is a lightweight, open-source internationalization (i18n) library for JavaScript and TypeScript. It brings compile-time macros and a CLI for message extraction to React, React Native, Vue, SolidJS, Astro, Svelte, and Node.js.
 
-## Installation & Usage
+The `lingui` command reads `lingui.config.js` (or `.ts`) from the project root: the source locale, the target locales and where the catalogs live. The [installation guide][installation] shows the minimal file, the [configuration reference][conf] every option.
 
-See the [reference][reference] documentation.
+## Installation
+
+```sh
+npm install --save-dev @lingui/cli
+```
+
+## Usage
+
+- `lingui extract` finds the messages in the source, merges them into one catalog per locale, keeps existing translations and marks removed messages as obsolete.
+- `lingui compile` compiles the translated catalogs into JavaScript modules for the runtime and reports messages with invalid ICU syntax.
+- `lingui extract-template` writes a single `.pot` template with the source messages, for translation platforms that create the locale files themselves.
+- `lingui extract-experimental` follows the imports from each entry point instead of a glob, so a multi-page app gets one catalog per page.
+
+Extraction parses JavaScript and TypeScript out of the box; Vue single-file components need [`@lingui/extractor-vue`][extractor-vue]. Catalogs are PO files by default, with [other formats][catalog-formats] available as separate packages. To let the bundler compile catalogs instead of running `lingui compile`, use [`@lingui/vite-plugin`][vite-plugin], [`@lingui/loader`][loader] or [`@lingui/metro-transformer`][metro-transformer].
+
+See the [CLI reference][reference] for all commands and options.
 
 ## License
 
-This package is licensed under [MIT][license] license.
+This package is licensed under the [MIT][license] license.
 
 [license]: https://github.com/lingui/js-lingui/blob/main/LICENSE
-[linguijs]: https://github.com/lingui/js-lingui
 [documentation]: https://lingui.dev
+[installation]: https://lingui.dev/installation
+[conf]: https://lingui.dev/ref/conf
 [reference]: https://lingui.dev/ref/cli
+[catalog-formats]: https://lingui.dev/ref/catalog-formats
+[extractor-vue]: https://lingui.dev/ref/extractor-vue
+[vite-plugin]: https://lingui.dev/ref/vite-plugin
+[loader]: https://lingui.dev/ref/loader
+[metro-transformer]: https://lingui.dev/ref/metro-transformer
 [package]: https://www.npmjs.com/package/@lingui/cli
 [badge-downloads]: https://img.shields.io/npm/dw/@lingui/cli.svg
 [badge-version]: https://img.shields.io/npm/v/@lingui/cli.svg

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -8,7 +8,7 @@
 
 `@lingui/cli` is part of [Lingui][documentation]. Lingui is a lightweight, open-source internationalization (i18n) library for JavaScript and TypeScript. It brings compile-time macros and a CLI for message extraction to React, React Native, Vue, SolidJS, Astro, Svelte, and Node.js.
 
-The `lingui` command reads `lingui.config.js` (or `.ts`) from the project root: the source locale, the target locales and where the catalogs live. The [installation guide][installation] shows the minimal file, the [configuration reference][conf] every option.
+The `lingui` command reads `lingui.config.js` (or `.ts`) from the project root: the source locale, the target locales and where the catalogs live. The [installation guide][installation] shows the minimal file and the [configuration reference][conf] lists every option.
 
 ## Installation
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lingui/cli",
   "version": "6.6.0",
-  "description": "Lingui CLI to extract messages, compile catalogs, and manage translation workflows",
+  "description": "Lingui CLI: extracts i18n messages from source code into catalogs and compiles the translated catalogs for the runtime",
   "type": "module",
   "keywords": [
     "lingui",

--- a/packages/conf/README.md
+++ b/packages/conf/README.md
@@ -4,24 +4,17 @@
 
 # @lingui/conf
 
-> Get lingui configuration from package.json
+> Resolve and validate Lingui configuration
 
-**⚠️ Internal package: You probably don't need this.**
+`@lingui/conf` is part of [Lingui][documentation]. Lingui is a lightweight, open-source internationalization (i18n) library for JavaScript and TypeScript. It brings compile-time macros and a CLI for message extraction to React, React Native, Vue, SolidJS, Astro, Svelte, and Node.js.
 
-`@lingui/conf` is part of [LinguiJS][linguijs]. See the [documentation][documentation] for all information, tutorials and examples.
-
-Package finds nearest package.json starting from current directory, reads `lingui` configuration, provides defaults for all options and `<rootDir>` with current working directory.
-
-## Usage
-
-See the [reference][reference] documentation.
+**Internal package.** `@lingui/conf` locates `lingui.config.js`, fills in the defaults and validates the options for the Lingui CLI and the bundler plugins. Application code does not need it; `defineConfig` is available from `@lingui/cli`. See the [configuration reference][reference] for all options.
 
 ## License
 
-This package is licensed under [MIT][license] license.
+This package is licensed under the [MIT][license] license.
 
 [license]: https://github.com/lingui/js-lingui/blob/main/LICENSE
-[linguijs]: https://github.com/lingui/js-lingui
 [documentation]: https://lingui.dev
 [reference]: https://lingui.dev/ref/conf
 [package]: https://www.npmjs.com/package/@lingui/conf

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -8,7 +8,7 @@
 
 `@lingui/core` is part of [Lingui][documentation]. Lingui is a lightweight, open-source internationalization (i18n) library for JavaScript and TypeScript. It brings compile-time macros and a CLI for message extraction to React, React Native, Vue, SolidJS, Astro, Svelte, and Node.js.
 
-The package is framework-agnostic and behaves the same in the browser, in Node.js and inside any UI framework. `@lingui/core` exports the `i18n` instance, which loads catalogs, activates a locale and translates messages. `@lingui/core/macro` exports the `t`, `plural`, `select` and related macros, which turn template literals into ICU messages at build time and need the [Babel][babel-plugin] or [SWC][swc-plugin] plugin.
+The package is framework-agnostic and behaves the same in the browser, in Node.js and inside any UI framework. `@lingui/core` exports the `i18n` instance, which loads catalogs, activates a locale and translates messages. `@lingui/core/macro` exports the `t`, `plural`, `select` and related macros, which are compiled into ICU messages at build time and need the [Babel][babel-plugin] or [SWC][swc-plugin] plugin.
 
 ## Usage
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -4,23 +4,46 @@
 
 # @lingui/core
 
-> Internationalization API for JavaScript apps
+> The Lingui i18n runtime: loads compiled message catalogs, tracks the active locale and formats ICU MessageFormat messages
 
-`@lingui/core` is part of [LinguiJS][linguijs]. See the [documentation][documentation] for all information, tutorials and examples.
+`@lingui/core` is part of [Lingui][documentation]. Lingui is a lightweight, open-source internationalization (i18n) library for JavaScript and TypeScript. It brings compile-time macros and a CLI for message extraction to React, React Native, Vue, SolidJS, Astro, Svelte, and Node.js.
 
-## Installation & Usage
+The package is framework-agnostic and behaves the same in the browser, in Node.js and inside any UI framework. `@lingui/core` exports the `i18n` instance, which loads catalogs, activates a locale and translates messages. `@lingui/core/macro` exports the `t`, `plural`, `select` and related macros, which turn template literals into ICU messages at build time and need the [Babel][babel-plugin] or [SWC][swc-plugin] plugin.
 
-See the [tutorial][tutorial] or [reference][reference] documentation.
+## Usage
+
+```js
+import { i18n } from "@lingui/core"
+import { t } from "@lingui/core/macro"
+import { messages } from "./locales/cs/messages"
+
+i18n.load("cs", messages)
+i18n.activate("cs")
+
+function greeting(name) {
+  return t`Hello ${name}`
+}
+
+greeting("Fred") // "Ahoj Fred"
+```
+
+The `messages` module is produced by `lingui extract` and `lingui compile` from [`@lingui/cli`][cli]. Catalogs are compiled ahead of time, so the runtime ships without a MessageFormat parser.
+
+The [JavaScript tutorial][tutorial] walks through this setup. React projects use [`@lingui/react`][react] on top of this package. See the [core reference][reference] and the [macro reference][macro] for the full API.
 
 ## License
 
-This package is licensed under [MIT][license] license.
+This package is licensed under the [MIT][license] license.
 
 [license]: https://github.com/lingui/js-lingui/blob/main/LICENSE
-[linguijs]: https://github.com/lingui/js-lingui
 [documentation]: https://lingui.dev
 [tutorial]: https://lingui.dev/tutorials/javascript
 [reference]: https://lingui.dev/ref/core
+[macro]: https://lingui.dev/ref/macro
+[cli]: https://www.npmjs.com/package/@lingui/cli
+[react]: https://www.npmjs.com/package/@lingui/react
+[babel-plugin]: https://lingui.dev/installation#choosing-a-transpiler
+[swc-plugin]: https://lingui.dev/ref/swc-plugin
 [package]: https://www.npmjs.com/package/@lingui/core
 [badge-downloads]: https://img.shields.io/npm/dw/@lingui/core.svg
 [badge-version]: https://img.shields.io/npm/v/@lingui/core.svg

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,7 +2,7 @@
   "name": "@lingui/core",
   "version": "6.6.0",
   "sideEffects": false,
-  "description": "Internationalization (i18n) tools for JavaScript",
+  "description": "The Lingui i18n runtime: loads compiled message catalogs, tracks the active locale and formats ICU MessageFormat messages",
   "type": "module",
   "author": {
     "name": "Tomáš Ehrlich",

--- a/packages/detect-locale/README.md
+++ b/packages/detect-locale/README.md
@@ -4,20 +4,21 @@
 
 # @lingui/detect-locale
 
-> Detect the user's locale based on different strategies
+> Detects the user's locale from the URL, a cookie, storage, the browser settings or the HTML lang attribute
 
-`@lingui/detect-locale` is part of [LinguiJS][linguijs]. See the [documentation][documentation] for all information, tutorials and examples.
+`@lingui/detect-locale` is part of [Lingui][documentation]. Lingui is a lightweight, open-source internationalization (i18n) library for JavaScript and TypeScript. It brings compile-time macros and a CLI for message extraction to React, React Native, Vue, SolidJS, Astro, Svelte, and Node.js.
 
-## Installation & Usage
+The package has no dependency on the rest of Lingui and works with any i18n library.
 
-See the [reference][reference] documentation.
+## Usage
+
+See the [locale detection reference][reference].
 
 ## License
 
-This package is licensed under [MIT][license] license.
+This package is licensed under the [MIT][license] license.
 
 [license]: https://github.com/lingui/js-lingui/blob/main/LICENSE
-[linguijs]: https://github.com/lingui/js-lingui
 [documentation]: https://lingui.dev
 [reference]: https://lingui.dev/ref/locale-detector
 [package]: https://www.npmjs.com/package/@lingui/detect-locale

--- a/packages/detect-locale/package.json
+++ b/packages/detect-locale/package.json
@@ -3,7 +3,7 @@
   "version": "6.6.0",
   "type": "module",
   "sideEffects": false,
-  "description": "Locale detection utilities for Lingui apps across browser, server, and common runtimes",
+  "description": "Detects the user's locale from the URL, a cookie, storage, the browser settings or the HTML lang attribute",
   "license": "MIT",
   "keywords": [
     "lingui",

--- a/packages/extractor-vue/README.md
+++ b/packages/extractor-vue/README.md
@@ -4,21 +4,22 @@
 
 # @lingui/extractor-vue
 
-> This package contains a custom extractor that handles Vue.js files. It supports extracting messages from script and setup scripts as well as Vue templates.
+> Extractor for the Lingui CLI that finds i18n messages in Vue single-file components
 
-`@lingui/extractor-vue` is part of [LinguiJS][linguijs]. See the [documentation][documentation] for all information, tutorials and examples.
+`@lingui/extractor-vue` is part of [Lingui][documentation]. Lingui is a lightweight, open-source internationalization (i18n) library for JavaScript and TypeScript. It brings compile-time macros and a CLI for message extraction to React, React Native, Vue, SolidJS, Astro, Svelte, and Node.js.
 
-## Installation & Usage
+`lingui extract` handles JavaScript and TypeScript out of the box. This package adds `.vue` files, including the template and the script parts.
 
-See the [reference][reference] documentation.
+## Usage
+
+See the [Vue.js extractor reference][reference].
 
 ## License
 
-This package is licensed under [MIT][license] license.
+This package is licensed under the [MIT][license] license.
 
 [license]: https://github.com/lingui/js-lingui/blob/main/LICENSE
-[linguijs]: https://github.com/lingui/js-lingui
-[documentation]: https://lingui.dev/ref/extractor-vue
+[documentation]: https://lingui.dev
 [reference]: https://lingui.dev/ref/extractor-vue
 [package]: https://www.npmjs.com/package/@lingui/extractor-vue
 [badge-downloads]: https://img.shields.io/npm/dw/@lingui/extractor-vue.svg

--- a/packages/extractor-vue/package.json
+++ b/packages/extractor-vue/package.json
@@ -2,7 +2,7 @@
   "name": "@lingui/extractor-vue",
   "version": "6.6.0",
   "type": "module",
-  "description": "Vue single-file component extractor for the Lingui CLI",
+  "description": "Extractor for the Lingui CLI that finds i18n messages in Vue single-file components",
   "keywords": [
     "lingui",
     "vue",

--- a/packages/format-csv/README.md
+++ b/packages/format-csv/README.md
@@ -4,20 +4,21 @@
 
 # @lingui/format-csv
 
-> Read and write message catalogs in CSV 
+> Reads and writes Lingui message catalogs as two-column CSV files for spreadsheets and other CSV tools
 
-`@lingui/format-csv` is part of [LinguiJS][linguijs]. See the [documentation][documentation] for all information, tutorials and examples.
+`@lingui/format-csv` is part of [Lingui][documentation]. Lingui is a lightweight, open-source internationalization (i18n) library for JavaScript and TypeScript. It brings compile-time macros and a CLI for message extraction to React, React Native, Vue, SolidJS, Astro, Svelte, and Node.js.
 
-## Installation & Usage
+Each row holds a message ID and the source message or translation. The format has no options.
 
-See the [reference][reference] documentation.
+## Usage
+
+See the [catalog formats reference][reference].
 
 ## License
 
-This package is licensed under [MIT][license] license.
+This package is licensed under the [MIT][license] license.
 
 [license]: https://github.com/lingui/js-lingui/blob/main/LICENSE
-[linguijs]: https://github.com/lingui/js-lingui
 [documentation]: https://lingui.dev
 [reference]: https://lingui.dev/ref/catalog-formats#csv
 [package]: https://www.npmjs.com/package/@lingui/format-csv

--- a/packages/format-csv/package.json
+++ b/packages/format-csv/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lingui/format-csv",
   "version": "6.6.0",
-  "description": "CSV formatter for Lingui message catalogs",
+  "description": "Reads and writes Lingui message catalogs as two-column CSV files for spreadsheets and other CSV tools",
   "type": "module",
   "exports": {
     ".": "./dist/csv.mjs"

--- a/packages/format-json/README.md
+++ b/packages/format-json/README.md
@@ -4,20 +4,21 @@
 
 # @lingui/format-json
 
-> Read and write message catalogs in JSON 
+> Reads and writes Lingui message catalogs as JSON, either minimal key-value files or files with full message metadata
 
-`@lingui/format-json` is part of [LinguiJS][linguijs]. See the [documentation][documentation] for all information, tutorials and examples.
+`@lingui/format-json` is part of [Lingui][documentation]. Lingui is a lightweight, open-source internationalization (i18n) library for JavaScript and TypeScript. It brings compile-time macros and a CLI for message extraction to React, React Native, Vue, SolidJS, Astro, Svelte, and Node.js.
 
-## Installation & Usage
+The `minimal` style is a flat object of message IDs and translations. The `lingui` style keeps the source message, comments and origins alongside each translation.
 
-See the [reference][reference] documentation.
+## Usage
+
+See the [catalog formats reference][reference].
 
 ## License
 
-This package is licensed under [MIT][license] license.
+This package is licensed under the [MIT][license] license.
 
 [license]: https://github.com/lingui/js-lingui/blob/main/LICENSE
-[linguijs]: https://github.com/lingui/js-lingui
 [documentation]: https://lingui.dev
 [reference]: https://lingui.dev/ref/catalog-formats#json
 [package]: https://www.npmjs.com/package/@lingui/format-json

--- a/packages/format-json/package.json
+++ b/packages/format-json/package.json
@@ -2,7 +2,7 @@
   "name": "@lingui/format-json",
   "version": "6.6.0",
   "type": "module",
-  "description": "JSON formatter for Lingui message catalogs",
+  "description": "Reads and writes Lingui message catalogs as JSON, either minimal key-value files or files with full message metadata",
   "exports": {
     ".": "./dist/json.mjs"
   },

--- a/packages/format-po-gettext/README.md
+++ b/packages/format-po-gettext/README.md
@@ -4,27 +4,21 @@
 
 # @lingui/format-po-gettext
 
-> Read and write message catalogs in Gettext PO format with gettext-style plurals
->
-> Converts ICU Plural expressions into native gettext plurals
+> Reads and writes Lingui message catalogs as gettext PO files with native gettext plurals instead of ICU plurals
 
-`@lingui/format-po-gettext` is part of [LinguiJS][linguijs]. See the [documentation][documentation] for all information, tutorials and examples.
+`@lingui/format-po-gettext` is part of [Lingui][documentation]. Lingui is a lightweight, open-source internationalization (i18n) library for JavaScript and TypeScript. It brings compile-time macros and a CLI for message extraction to React, React Native, Vue, SolidJS, Astro, Svelte, and Node.js.
 
-## Installation & Usage
+Use this formatter when your translation platform does not understand ICU plural syntax in PO files. It converts ICU plurals to `msgid_plural` and `msgstr[n]` entries and back. Because gettext plurals are less expressive than ICU, nested plurals are not supported and `select` stays in ICU syntax, so prefer the default `@lingui/format-po` whenever your tools accept it.
 
-See the [reference][reference] documentation.
+## Usage
 
-> **Warning**
-> This formatter is made for compatibility with translation management systems, which do not support ICU expressions in PO files.
->
-> It does not support all features of LinguiJS and should be carefully considered over other formats.
+See the [catalog formats reference][reference].
 
 ## License
 
-This package is licensed under [MIT][license] license.
+This package is licensed under the [MIT][license] license.
 
 [license]: https://github.com/lingui/js-lingui/blob/main/LICENSE
-[linguijs]: https://github.com/lingui/js-lingui
 [documentation]: https://lingui.dev
 [reference]: https://lingui.dev/ref/catalog-formats#po-gettext
 [package]: https://www.npmjs.com/package/@lingui/format-po-gettext

--- a/packages/format-po-gettext/package.json
+++ b/packages/format-po-gettext/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lingui/format-po-gettext",
   "version": "6.6.0",
-  "description": "Gettext PO formatter for Lingui message catalogs using gettext-style plural rules",
+  "description": "Reads and writes Lingui message catalogs as gettext PO files with native gettext plurals instead of ICU plurals",
   "type": "module",
   "sideEffects": false,
   "license": "MIT",

--- a/packages/format-po/README.md
+++ b/packages/format-po/README.md
@@ -4,20 +4,21 @@
 
 # @lingui/format-po
 
-> Read and write message catalogs in Gettext PO format with ICU plurals
+> Reads and writes Lingui message catalogs as gettext PO files with ICU plurals, the default catalog format
 
-`@lingui/format-po` is part of [LinguiJS][linguijs]. See the [documentation][documentation] for all information, tutorials and examples.
+`@lingui/format-po` is part of [Lingui][documentation]. Lingui is a lightweight, open-source internationalization (i18n) library for JavaScript and TypeScript. It brings compile-time macros and a CLI for message extraction to React, React Native, Vue, SolidJS, Astro, Svelte, and Node.js.
 
-## Installation & Usage
+PO is the default and recommended catalog format: readable, supported by almost every translation tool, and it carries comments, source locations and context for translators. The formatter ships with `@lingui/cli`, so install this package only to pass options.
 
-See the [reference][reference] documentation.
+## Usage
+
+See the [catalog formats reference][reference].
 
 ## License
 
-This package is licensed under [MIT][license] license.
+This package is licensed under the [MIT][license] license.
 
 [license]: https://github.com/lingui/js-lingui/blob/main/LICENSE
-[linguijs]: https://github.com/lingui/js-lingui
 [documentation]: https://lingui.dev
 [reference]: https://lingui.dev/ref/catalog-formats#po
 [package]: https://www.npmjs.com/package/@lingui/format-po

--- a/packages/format-po/README.md
+++ b/packages/format-po/README.md
@@ -8,7 +8,7 @@
 
 `@lingui/format-po` is part of [Lingui][documentation]. Lingui is a lightweight, open-source internationalization (i18n) library for JavaScript and TypeScript. It brings compile-time macros and a CLI for message extraction to React, React Native, Vue, SolidJS, Astro, Svelte, and Node.js.
 
-PO is the default and recommended catalog format: readable, supported by almost every translation tool, and it carries comments, source locations and context for translators. The formatter ships with `@lingui/cli`, so install this package only to pass options.
+PO is the default and recommended catalog format: it is readable, almost every translation tool supports it, and it carries comments, source locations and context for translators. The formatter ships with `@lingui/cli`, so install this package only to pass options.
 
 ## Usage
 

--- a/packages/format-po/package.json
+++ b/packages/format-po/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lingui/format-po",
   "version": "6.6.0",
-  "description": "Gettext PO formatter for Lingui message catalogs",
+  "description": "Reads and writes Lingui message catalogs as gettext PO files with ICU plurals, the default catalog format",
   "type": "module",
   "sideEffects": false,
   "license": "MIT",

--- a/packages/loader/README.md
+++ b/packages/loader/README.md
@@ -4,20 +4,21 @@
 
 # @lingui/loader
 
-> webpack loader for compiling message catalog on the fly
+> Webpack-compatible loader that compiles Lingui message catalogs on the fly, so .po files can be imported directly
 
-`@lingui/loader` is part of [LinguiJS][linguijs]. See the [documentation][documentation] for all information, tutorials and examples.
+`@lingui/loader` is part of [Lingui][documentation]. Lingui is a lightweight, open-source internationalization (i18n) library for JavaScript and TypeScript. It brings compile-time macros and a CLI for message extraction to React, React Native, Vue, SolidJS, Astro, Svelte, and Node.js.
 
-## Installation & Usage
+The loader works with Webpack, Rspack and Rsbuild and replaces the `lingui compile` step.
 
-See the [reference][reference] documentation.
+## Usage
+
+See the [loader reference][reference].
 
 ## License
 
-This package is licensed under [MIT][license] license.
+This package is licensed under the [MIT][license] license.
 
 [license]: https://github.com/lingui/js-lingui/blob/main/LICENSE
-[linguijs]: https://github.com/lingui/js-lingui
 [documentation]: https://lingui.dev
 [reference]: https://lingui.dev/ref/loader
 [package]: https://www.npmjs.com/package/@lingui/loader

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -2,7 +2,7 @@
   "name": "@lingui/loader",
   "version": "6.6.0",
   "type": "module",
-  "description": "A webpack-compatible loader to load and compile Lingui message catalogs at build time",
+  "description": "Webpack-compatible loader that compiles Lingui message catalogs on the fly, so .po files can be imported directly",
   "exports": {
     ".": "./dist/index.cjs"
   },

--- a/packages/message-utils/README.md
+++ b/packages/message-utils/README.md
@@ -4,16 +4,17 @@
 
 # @lingui/message-utils
 
-> Internal package. You probably don't need to use it directly.
+> Low-level Lingui utilities to compile ICU MessageFormat messages and generate stable message IDs
 
-`@lingui/message-utils` is part of [LinguiJS][linguijs]. See the [documentation][documentation] for all information, tutorials and examples.
+`@lingui/message-utils` is part of [Lingui][documentation]. Lingui is a lightweight, open-source internationalization (i18n) library for JavaScript and TypeScript. It brings compile-time macros and a CLI for message extraction to React, React Native, Vue, SolidJS, Astro, Svelte, and Node.js.
+
+**Internal package.** `@lingui/message-utils` is used by the Lingui CLI, plugins and runtime to compile ICU MessageFormat messages and to generate message IDs. Application code does not need it.
 
 ## License
 
-[MIT][license]
+This package is licensed under the [MIT][license] license.
 
 [license]: https://github.com/lingui/js-lingui/blob/main/LICENSE
-[linguijs]: https://github.com/lingui/js-lingui
 [documentation]: https://lingui.dev
 [package]: https://www.npmjs.com/package/@lingui/message-utils
 [badge-downloads]: https://img.shields.io/npm/dw/@lingui/message-utils.svg

--- a/packages/metro-transformer/README.md
+++ b/packages/metro-transformer/README.md
@@ -4,21 +4,23 @@
 
 # @lingui/metro-transformer
 
-> Metro bundler transformer for LinguiJS catalogs
+> Metro transformer that compiles Lingui message catalogs on the fly in React Native and Expo apps
 
-`@lingui/metro-transformer` is part of [LinguiJS][linguijs]. See the [documentation][documentation] for all information, tutorials and examples.
+`@lingui/metro-transformer` is part of [Lingui][documentation]. Lingui is a lightweight, open-source internationalization (i18n) library for JavaScript and TypeScript. It brings compile-time macros and a CLI for message extraction to React, React Native, Vue, SolidJS, Astro, Svelte, and Node.js.
 
-## Installation & Usage
+The transformer lets a React Native or Expo app import `.po` files directly instead of running `lingui compile`.
 
-See the [reference][reference] documentation.
+## Usage
+
+See the [React Native tutorial][tutorial] and the [Metro transformer reference][reference].
 
 ## License
 
-This package is licensed under [MIT][license] license.
+This package is licensed under the [MIT][license] license.
 
 [license]: https://github.com/lingui/js-lingui/blob/main/LICENSE
-[linguijs]: https://github.com/lingui/js-lingui
 [documentation]: https://lingui.dev
+[tutorial]: https://lingui.dev/tutorials/react-native
 [reference]: https://lingui.dev/ref/metro-transformer
 [package]: https://www.npmjs.com/package/@lingui/metro-transformer
 [badge-downloads]: https://img.shields.io/npm/dw/@lingui/metro-transformer.svg

--- a/packages/metro-transformer/package.json
+++ b/packages/metro-transformer/package.json
@@ -2,7 +2,7 @@
   "name": "@lingui/metro-transformer",
   "version": "6.6.0",
   "type": "commonjs",
-  "description": "Metro transformer for Lingui catalogs in React Native and Expo projects",
+  "description": "Metro transformer that compiles Lingui message catalogs on the fly in React Native and Expo apps",
   "exports": {
     "./expo": {
       "require": "./dist/expo/index.cjs",

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -4,23 +4,75 @@
 
 # @lingui/react
 
-> React components for internationalization
+> React bindings for Lingui i18n: I18nProvider, Trans and useLingui, with compile-time macros and React Server Components support
 
-`@lingui/react` is part of [LinguiJS][linguijs]. See the [documentation][documentation] for all information, tutorials and examples.
+`@lingui/react` is part of [Lingui][documentation]. Lingui is a lightweight, open-source internationalization (i18n) library for JavaScript and TypeScript. It brings compile-time macros and a CLI for message extraction to React, React Native, Vue, SolidJS, Astro, Svelte, and Node.js.
 
-## Installation & Usage
+The package has three entry points:
 
-See the [tutorial][tutorial] or [reference][reference] documentation.
+- `@lingui/react` exports `I18nProvider`, the `Trans` component and the `useLingui` hook. The provider puts an `i18n` instance from `@lingui/core` into React context.
+- `@lingui/react/macro` exports the `Trans`, `Plural`, `Select` and related macros, which generate the ICU message and its ID from JSX at build time, and a `useLingui` macro whose `t` translates strings outside JSX. Macros need the [Babel][babel-plugin] or [SWC][swc-plugin] plugin.
+- `@lingui/react/server` exports `setI18n` for React Server Components, where `Trans` and `useLingui` read that instance instead of context. The same component renders on the server and on the client.
+
+## Installation
+
+```sh
+npm install @lingui/core @lingui/react
+```
+
+`@lingui/core` provides the `i18n` instance passed to the provider. The [installation guide][installation] covers the macro plugin and the `lingui.config.js` file.
+
+## Usage
+
+```jsx
+import { i18n } from "@lingui/core"
+import { I18nProvider } from "@lingui/react"
+import { Trans, useLingui } from "@lingui/react/macro"
+import { messages } from "./locales/en/messages"
+
+i18n.load("en", messages)
+i18n.activate("en")
+
+function Welcome({ name }) {
+  const { t } = useLingui()
+  return (
+    <>
+      <img src="/logo.svg" alt={t`Lingui logo`} />
+      <Trans>
+        Welcome back, {name}. Read the <a href="/docs">documentation</a>.
+      </Trans>
+    </>
+  )
+}
+
+export function App() {
+  return (
+    <I18nProvider i18n={i18n}>
+      <Welcome name="Fred" />
+    </I18nProvider>
+  )
+}
+```
+
+The translator receives one message, `Welcome back, {name}. Read the <0>documentation</0>.`, where `<0>` stands for the link. `lingui extract` from [`@lingui/cli`][cli] writes the messages into the catalogs and `lingui compile` produces the `messages` module imported above.
+
+Continue with the [React tutorial][tutorial], the [Next.js App Router tutorial][tutorial-rsc] for Server Components or the [React Native tutorial][tutorial-rn]. See the [React reference][reference] and the [macro reference][macro] for the full API.
 
 ## License
 
-[MIT][license]
+This package is licensed under the [MIT][license] license.
 
 [license]: https://github.com/lingui/js-lingui/blob/main/LICENSE
-[linguijs]: https://github.com/lingui/js-lingui
 [documentation]: https://lingui.dev
+[installation]: https://lingui.dev/installation
 [tutorial]: https://lingui.dev/tutorials/react
+[tutorial-rsc]: https://lingui.dev/tutorials/react-rsc
+[tutorial-rn]: https://lingui.dev/tutorials/react-native
 [reference]: https://lingui.dev/ref/react
+[macro]: https://lingui.dev/ref/macro#react-macros
+[cli]: https://www.npmjs.com/package/@lingui/cli
+[babel-plugin]: https://lingui.dev/installation#choosing-a-transpiler
+[swc-plugin]: https://lingui.dev/ref/swc-plugin
 [package]: https://www.npmjs.com/package/@lingui/react
 [badge-downloads]: https://img.shields.io/npm/dw/@lingui/react.svg
 [badge-version]: https://img.shields.io/npm/v/@lingui/react.svg

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -8,7 +8,7 @@
 
 `@lingui/react` is part of [Lingui][documentation]. Lingui is a lightweight, open-source internationalization (i18n) library for JavaScript and TypeScript. It brings compile-time macros and a CLI for message extraction to React, React Native, Vue, SolidJS, Astro, Svelte, and Node.js.
 
-The package has three entry points:
+The package has the following entry points:
 
 - `@lingui/react` exports `I18nProvider`, the `Trans` component and the `useLingui` hook. The provider puts an `i18n` instance from `@lingui/core` into React context.
 - `@lingui/react/macro` exports the `Trans`, `Plural`, `Select` and related macros, which generate the ICU message and its ID from JSX at build time, and a `useLingui` macro whose `t` translates strings outside JSX. Macros need the [Babel][babel-plugin] or [SWC][swc-plugin] plugin.
@@ -54,7 +54,7 @@ export function App() {
 }
 ```
 
-The translator receives one message, `Welcome back, {name}. Read the <0>documentation</0>.`, where `<0>` stands for the link. `lingui extract` from [`@lingui/cli`][cli] writes the messages into the catalogs and `lingui compile` produces the `messages` module imported above.
+The `Trans` block becomes a single message, `Welcome back, {name}. Read the <0>documentation</0>.`, where `<0>` stands for the link. `lingui extract` from [`@lingui/cli`][cli] writes the messages into the catalogs and `lingui compile` produces the `messages` module imported above.
 
 Continue with the [React tutorial][tutorial], the [Next.js App Router tutorial][tutorial-rsc] for Server Components or the [React Native tutorial][tutorial-rn]. See the [React reference][reference] and the [macro reference][macro] for the full API.
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -2,7 +2,7 @@
   "name": "@lingui/react",
   "version": "6.6.0",
   "sideEffects": false,
-  "description": "React bindings for Lingui with Trans components, providers, and compile-time macros",
+  "description": "React bindings for Lingui i18n: I18nProvider, Trans and useLingui, with compile-time macros and React Server Components support",
   "type": "module",
   "author": {
     "name": "Tomáš Ehrlich",

--- a/packages/solid/README.md
+++ b/packages/solid/README.md
@@ -4,21 +4,32 @@
 
 # @lingui/solid
 
-> SolidJS components for internationalization
+> SolidJS bindings for Lingui i18n: I18nProvider, Trans and useLingui, with compile-time macros
 
-`@lingui/solid` is part of [LinguiJS][linguijs]. See the [documentation][documentation] for all information, tutorials and examples.
+`@lingui/solid` is part of [Lingui][documentation]. Lingui is a lightweight, open-source internationalization (i18n) library for JavaScript and TypeScript. It brings compile-time macros and a CLI for message extraction to React, React Native, Vue, SolidJS, Astro, Svelte, and Node.js.
 
-## Installation & Usage
+The package brings the Lingui workflow to SolidJS with reactive components. `@lingui/solid` exports `I18nProvider`, `Trans` and `useLingui`, `@lingui/solid/macro` exports the macros that generate ICU messages from JSX at build time, and `defineConfig` from `@lingui/solid/config` applies the Solid-specific settings to the Lingui configuration.
 
-See the [documentation][documentation].
+## Installation
+
+```sh
+npm install @lingui/core @lingui/solid
+```
+
+`@lingui/core` provides the `i18n` instance passed to the provider.
+
+## Usage
+
+See the [SolidJS tutorial][tutorial] and the [Solid reference][reference].
 
 ## License
 
-[MIT][license]
+This package is licensed under the [MIT][license] license.
 
 [license]: https://github.com/lingui/js-lingui/blob/main/LICENSE
-[linguijs]: https://github.com/lingui/js-lingui
 [documentation]: https://lingui.dev
+[tutorial]: https://lingui.dev/tutorials/solid
+[reference]: https://lingui.dev/ref/solid
 [package]: https://www.npmjs.com/package/@lingui/solid
 [badge-downloads]: https://img.shields.io/npm/dw/@lingui/solid.svg
 [badge-version]: https://img.shields.io/npm/v/@lingui/solid.svg

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -2,7 +2,7 @@
   "name": "@lingui/solid",
   "version": "6.6.0",
   "sideEffects": false,
-  "description": "SolidJS bindings for Lingui with Trans components, providers, and compile-time macros",
+  "description": "SolidJS bindings for Lingui i18n: I18nProvider, Trans and useLingui, with compile-time macros",
   "type": "module",
   "author": {
     "name": "Huliiiiii",

--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -4,21 +4,23 @@
 
 # @lingui/vite-plugin
 
-> Vite plugin that compiles Lingui catalogs on the fly. In summary, the `lingui compile` command isn't needed when using this plugin.
+> Vite plugin that compiles Lingui message catalogs on the fly, so .po files can be imported directly
 
-`@lingui/vite-plugin` is part of [LinguiJS][linguijs]. See the [documentation][documentation] for all information, tutorials and examples.
+`@lingui/vite-plugin` is part of [Lingui][documentation]. Lingui is a lightweight, open-source internationalization (i18n) library for JavaScript and TypeScript. It brings compile-time macros and a CLI for message extraction to React, React Native, Vue, SolidJS, Astro, Svelte, and Node.js.
 
-## Installation & Usage
+The plugin compiles catalogs when they are imported, so there is no `lingui compile` step to run. Macros are still transformed by the Babel or SWC plugin in your Vite setup.
 
-See the [reference][reference] documentation.
+## Usage
+
+See the [Vite setup][installation] in the installation guide and the [Vite plugin reference][reference].
 
 ## License
 
-[MIT][license]
+This package is licensed under the [MIT][license] license.
 
 [license]: https://github.com/lingui/js-lingui/blob/main/LICENSE
-[linguijs]: https://github.com/lingui/js-lingui
-[documentation]: https://lingui.dev/
+[documentation]: https://lingui.dev
+[installation]: https://lingui.dev/installation#vite
 [reference]: https://lingui.dev/ref/vite-plugin
 [package]: https://www.npmjs.com/package/@lingui/vite-plugin
 [badge-downloads]: https://img.shields.io/npm/dw/@lingui/vite-plugin.svg

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lingui/vite-plugin",
   "version": "6.6.0",
-  "description": "Vite plugin to integrate Lingui message catalogs with the CLI and bundler pipeline",
+  "description": "Vite plugin that compiles Lingui message catalogs on the fly, so .po files can be imported directly",
   "type": "module",
   "exports": {
     ".": "./dist/index.mjs"

--- a/website/docs/ai-tools.md
+++ b/website/docs/ai-tools.md
@@ -58,6 +58,8 @@ Lingui provides [`llms.txt`](https://lingui.dev/llms.txt) and [`llms-full.txt`](
 
 While these files provide a minimal, easy-to-parse version of the documentation, they are large files that will use a lot of tokens if used directly in context and will need to be updated regularly to stay current. They are best used as a fallback when the AI tool does not have access to the latest documentation in other ways. The Context7 MCP server provides more efficient access to the full documentation with real-time search capabilities, making it the preferred option when available.
 
+Every documentation page is also available as plain Markdown: append `.md` to its URL, for example [`https://lingui.dev/ref/macro.md`](https://lingui.dev/ref/macro.md) for the Macros reference. A single page costs a fraction of the tokens of `llms-full.txt`, so when you know which part of the docs the agent needs, give it that URL instead. The links in `llms.txt` already point to these Markdown versions.
+
 Read more about the specification at [llmstxt.org](https://llmstxt.org/).
 
 ## Context7 MCP

--- a/website/docs/guides/message-format.md
+++ b/website/docs/guides/message-format.md
@@ -1,3 +1,8 @@
+---
+title: ICU MessageFormat
+description: The ICU MessageFormat syntax Lingui uses for messages. Variables, plurals, select and ordinals explained with examples
+---
+
 # ICU MessageFormat
 
 ICU MessageFormat is a flexible and powerful syntax designed to express the grammatical nuances of different languages. Its flexibility ensures that your application can handle grammatical variations, making it essential for effective internationalization.

--- a/website/docs/guides/monorepo.md
+++ b/website/docs/guides/monorepo.md
@@ -1,3 +1,8 @@
+---
+title: Monorepo Setup
+description: How to use Lingui in a monorepo with one root Babel and Lingui configuration that each package extends or overrides
+---
+
 # Monorepo
 
 If you're using lingui within a monorepo you need:

--- a/website/docs/guides/optimizing-bundle-size.md
+++ b/website/docs/guides/optimizing-bundle-size.md
@@ -1,3 +1,8 @@
+---
+title: Optimizing Bundle Size
+description: How Lingui keeps your bundle small by compiling messages to compact IDs and dropping the message compiler in production, and how to configure that behavior
+---
+
 # Keeping Your Bundle Small: How Lingui Optimizes for Performance
 
 When you're building a modern app with internationalization (i18n), it's easy to end up with a bloated bundle. The more languages and messages you have, the more it can grow — fast.

--- a/website/docs/guides/testing.md
+++ b/website/docs/guides/testing.md
@@ -1,3 +1,8 @@
+---
+title: Testing Components That Use Lingui
+description: How to test React components that use Trans or useLingui by wrapping them in I18nProvider with React Testing Library
+---
+
 # Testing
 
 In a React application, components that use [`Trans`](/ref/react#trans) or [`useLingui`](/ref/react#uselingui) need access to the context provided by [`I18nProvider`](/ref/react#i18nprovider). How you wrap your component with the I18nProvider depends on the testing library you're using.

--- a/website/docs/installation.mdx
+++ b/website/docs/installation.mdx
@@ -10,11 +10,11 @@ import TabItem from "@theme/TabItem";
 
 Lingui is more than just a package; it's a comprehensive suite of tools designed to simplify internationalization. You have the flexibility to choose the specific tools that best fit your project's needs.
 
-Learn how to install Lingui in your project, whether you use JavaScript, React (including RSC) or React Native. Lingui also supports various transpilers and build tools, such as Babel, SWC, and Vite.
+Learn how to install Lingui in your project, whether you use JavaScript, React (including Next.js and React Server Components) or React Native. Lingui also supports various transpilers and build tools, such as Babel, SWC, and Vite.
 
 ## Prerequisites
 
-- Make sure you have [Node.js](https://nodejs.org/) installed (v20 or higher).
+- Make sure you have [Node.js](https://nodejs.org/) installed (v22.19 or higher).
 - Install [Lingui CLI](/ref/cli) to manage your translations and catalogs.
 
 :::tip
@@ -250,9 +250,26 @@ plugins: [
 
 </Tabs>
 
+### Next.js
+
+Next.js compiles with SWC by default, so Lingui macros need the [`@lingui/swc-plugin`](/ref/swc-plugin) registered in `next.config.js`. If your project has a Babel config, Next.js uses Babel instead and the Babel setup above applies. The Lingui configuration from the [Basic Configuration](#basic-configuration) section works unchanged.
+
+```js title="next.config.js"
+import { linguiMacroSwcPlugin } from "@lingui/swc-plugin/options";
+
+/** @type {import('next').NextConfig} */
+module.exports = {
+  experimental: {
+    swcPlugins: [linguiMacroSwcPlugin()],
+  },
+};
+```
+
+Routing by locale, loading catalogs in server and client components and switching the language are covered in the [Next.js App Router i18n tutorial](/tutorials/react-rsc). The [examples](https://github.com/lingui/js-lingui/tree/main/examples) directory has working Next.js projects for both the SWC and the Babel setup.
+
 ## See Also
 
 - [React i18n Tutorial](/tutorials/react)
-- [React Server Components Tutorial](/tutorials/react-rsc)
+- [Next.js App Router i18n Tutorial](/tutorials/react-rsc)
 - [React Native i18n Tutorial](/tutorials/react-native)
 - [JavaScript i18n Tutorial](/tutorials/javascript)

--- a/website/docs/installation.mdx
+++ b/website/docs/installation.mdx
@@ -252,17 +252,19 @@ plugins: [
 
 ### Next.js
 
-Next.js compiles with SWC by default, so Lingui macros need the [`@lingui/swc-plugin`](/ref/swc-plugin) registered in `next.config.js`. If your project has a Babel config, Next.js uses Babel instead and the Babel setup above applies. The Lingui configuration from the [Basic Configuration](#basic-configuration) section works unchanged.
+Next.js compiles with SWC by default, so Lingui macros need the [`@lingui/swc-plugin`](/ref/swc-plugin) registered in the Next.js config file. If your project has a Babel config, Next.js uses Babel instead and the Babel setup above applies. The Lingui configuration from the [Basic Configuration](#basic-configuration) section works unchanged.
 
-```js title="next.config.js"
+```js title="next.config.mjs"
 import { linguiMacroSwcPlugin } from "@lingui/swc-plugin/options";
 
 /** @type {import('next').NextConfig} */
-module.exports = {
+const nextConfig = {
   experimental: {
     swcPlugins: [linguiMacroSwcPlugin()],
   },
 };
+
+export default nextConfig;
 ```
 
 Routing by locale, loading catalogs in server and client components and switching the language are covered in the [Next.js App Router i18n tutorial](/tutorials/react-rsc). The [examples](https://github.com/lingui/js-lingui/tree/main/examples) directory has working Next.js projects for both the SWC and the Babel setup.

--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -1,11 +1,13 @@
 ---
 title: JavaScript i18n Introduction & Core Concepts
-description: Lingui is a universal, clean and readable, lightweight and powerful internationalization (i18n) framework for global projects
+description: What Lingui is and how it works. A lightweight i18n library for JavaScript and TypeScript with compile-time macros and a message extraction CLI
 ---
 
 # Introduction
 
-📖 A readable, automated, and optimized internationalization for JavaScript
+📖 Lingui is a lightweight, open-source internationalization (i18n) library for JavaScript and TypeScript. It brings compile-time macros and a CLI for message extraction to React, React Native, Vue, SolidJS, Astro, Svelte, and Node.js.
+
+You wrap text in macros like `Trans` and `t`, and the CLI extracts it into PO catalogs that any translation tool can open. Once translated, the catalogs are compiled into small modules that your app loads at runtime.
 
 > **Internationalization** is the design and development of a product, application or document content that enables easy **localization** for target audiences that vary in culture, region, or language.
 >
@@ -13,9 +15,19 @@ description: Lingui is a universal, clean and readable, lightweight and powerful
 
 [![GitHub stars](https://img.shields.io/github/stars/lingui/js-lingui.svg?style=social&label=Stars)](https://github.com/lingui/js-lingui/)
 
-## Key Features
+## Design Decisions
 
-Lingui is an easy yet powerful internationalization framework for global projects.
+Three design decisions shape how Lingui feels to use.
+
+Messages are compiled at build time by a [Babel or SWC plugin](/installation#choosing-a-transpiler). Most frameworks already run one of the two, so setup is usually one line in your Next.js, Vite or Babel config. The runtime stays around 2 kB and ships no message parser.
+
+Message IDs are generated from the source text. You never name a key, duplicate messages are merged, and searching for a UI string leads straight to the code. When the source text changes, the message is treated as new and goes back to translators; for strings that change often, [explicit IDs](/guides/explicit-vs-generated-ids) keep the ID stable.
+
+Catalogs are PO files by default, so any translation tool opens them and comments and context travel with each message. [JSON and CSV formats](/ref/catalog-formats) are available if your team already works with them.
+
+If you are weighing Lingui against a library you already use, see [Lingui vs i18next](/misc/i18next) and [Lingui vs react-intl](/misc/react-intl).
+
+## Key Features
 
 ### Clean and Readable
 

--- a/website/docs/misc/i18next.md
+++ b/website/docs/misc/i18next.md
@@ -1,13 +1,30 @@
 ---
 title: Lingui vs i18next
-description: Comparison of Lingui and i18next internationalization libraries
+description: How Lingui compares with i18next and react-i18next. Message syntax, plurals, extraction tooling, catalog formats, bundle size and React Server Components side by side
 ---
 
-# Comparison with i18next
+# Lingui vs i18next
 
-[i18next](https://www.i18next.com/) is a widely used internationalization framework designed specifically for JavaScript applications. Both i18next and Lingui are popular libraries for translating and localizing JavaScript-based projects, each offering unique strengths and features.
+[i18next](https://www.i18next.com/) is one of the most widely used internationalization frameworks for JavaScript, with bindings for React, Vue, Angular, Svelte and many other frameworks and platforms. Both libraries solve the same problem, but they start from different ideas. With i18next you invent a key for each string, put the text in a JSON file and look the key up at runtime. With Lingui you write the text where it is displayed, the IDs are generated from it and the catalogs are compiled at build time.
 
-The choice between them ultimately depends on the specific needs of your project.
+That difference runs through everything else on this page: how messages are written, what translators receive and what ships to the browser.
+
+## At a Glance
+
+|                    | Lingui                                                                                                                         | i18next                                                                                                                |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------- |
+| Writing messages   | The text stays in the code: `` t`Hello ${name}` ``. The catalog is generated from it                                           | You choose a key, add the text to a JSON file and reference the key: `t("greeting", { name })`                         |
+| Message IDs        | Generated from the source text, so there is nothing to name and duplicates merge on their own. Explicit IDs when you want them | Keys you define and keep unique yourself. Natural-language keys are possible with `keySeparator: false`                |
+| Message syntax     | ICU MessageFormat. Placeholders, plurals and selects stay inside one message                                                   | Own `{{name}}` syntax. Each plural form is a separate key (`key_one`, `key_other`). ICU needs the `i18next-icu` plugin |
+| Extraction         | Built in. `lingui extract` finds every message, merges it into all catalogs and marks removed ones obsolete                    | Separate tools: `i18next-cli` (the successor of `i18next-parser`) or `i18next-scanner`                                 |
+| Translator context | Source locations, comments and context travel with each message in the PO file                                                 | JSON has no comments. Key locations need an `i18next-cli` metadata plugin                                              |
+| Catalog format     | PO by default, which every translation tool opens. JSON, CSV and custom formatters available                                   | JSON, loaded through backend plugins. YAML and JSON5 via `i18next-cli`                                                 |
+| Runtime            | Catalogs are compiled at build time and no message parser ships. Core about 2 kB gzipped                                       | Messages interpolated at runtime. Core about 14 kB gzipped                                                             |
+| React              | `@lingui/react` with macros. React Server Components through `@lingui/react/server`                                            | `react-i18next`. React Server Components need `next-i18next` v16 (`getT` and `useT`)                                   |
+| Other frameworks   | React Native, Vue, SolidJS, Astro, Svelte, Node.js                                                                             | Vue, Angular, Svelte, SolidJS, Astro, Remix, Node.js and more                                                          |
+| TypeScript         | Written in TypeScript. Opt-in typed message IDs via module augmentation                                                        | Ships type definitions. Typed keys and interpolation values via `CustomTypeOptions`                                    |
+
+Bundle sizes were measured with [bundlejs](https://bundlejs.com/) in September 2026 for `@lingui/core` 6.6 and `i18next` 26.4.
 
 ## Basic Comparison
 
@@ -34,7 +51,7 @@ import i18next from "i18next";
 document.getElementById("output").innerHTML = i18next.t("key");
 ```
 
-The equivalent example with Lingui looks like this:
+To know what this line renders, you open the JSON file and look up `key`. The equivalent example with Lingui keeps the text in the code, and the CLI generates the catalog from it:
 
 ```js title="lingui.config.{js,ts}"
 import { defineConfig } from "@lingui/cli";
@@ -80,7 +97,7 @@ i18next sample:
 ```js
 import i18next from "i18next";
 
-i18next.t("My name is {name}", { name: "Tom" });
+i18next.t("My name is {{name}}", { name: "Tom" });
 i18next.t("msg.name", { name: "Tom" });
 ```
 
@@ -94,6 +111,8 @@ const name = "Tom";
 t`My name is ${name}`;
 t({ id: "msg.name", message: `My name is ${name}` });
 ```
+
+Lingui names the placeholder after the variable, so the message and the code cannot drift apart. With i18next, the `{{name}}` in the JSON file and the `{ name }` in the call are matched by hand.
 
 ## Formatting
 
@@ -181,7 +200,7 @@ new Intl.DateTimeFormat(i18n.locale, { dateStyle: "medium", timeStyle: "medium" 
 
 ## Plurals
 
-Lingui uses the [ICU MessageFormat](/guides/message-format) syntax to handle plurals. It provides a simple and translator-friendly approach to plurals localization.
+Lingui uses the [ICU MessageFormat](/guides/message-format) syntax to handle plurals. All forms of a message stay together in one string that the translator sees as a whole.
 
 For example:
 
@@ -209,7 +228,7 @@ When we extract messages from the source code using the [Lingui CLI](/ref/cli), 
 {numBooks, plural, one {# book} other {# books}}
 ```
 
-i18next handles plurals differently. It requires a separate key to be defined for each plural form. This is not translator-friendly, lacks context, and is prone to errors:
+i18next stores each plural form under its own key. The suffixes follow the CLDR plural categories returned by `Intl.PluralRules`, so English uses `_one` and `_other`, while Arabic adds `_zero`, `_two`, `_few` and `_many`:
 
 ```json
 {
@@ -225,6 +244,8 @@ i18next.t("key", { count: 0 }); // -> "items"
 i18next.t("key", { count: 1 }); // -> "item"
 i18next.t("key", { count: 5 }); // -> "items"
 ```
+
+In the catalog, `item` and `items` are two separate entries. Nothing ties them together or shows the translator the sentence they appear in. If you prefer ICU plurals with i18next, the [`i18next-icu`](https://github.com/i18next/i18next-icu) plugin switches the message syntax to ICU MessageFormat, at which point i18next's own interpolation and plural keys no longer apply.
 
 ## Context
 
@@ -250,7 +271,7 @@ msg({
 ```
 
 :::tip
-Lingui automatically provides additional context by including in the `.po` file the locations where each message is used, and `msgctxt` if the context is specified. This is useful for translators to understand the context of the message:
+Lingui also writes the source locations of each message into the `.po` file, together with `msgctxt` when a context is given, so translators can see where a message is used:
 
 ```gettext title="en.po"
 #: src/App.js:5
@@ -259,7 +280,7 @@ msgid "Right"
 msgstr "Right"
 ```
 
-i18next can't do this from its plain JSON files.
+JSON has no comment syntax, so this information is not part of i18next catalogs by default. `i18next-cli` can record key locations through a metadata plugin.
 :::
 
 ## React Integration
@@ -276,6 +297,8 @@ const HelloWorld = () => {
 };
 ```
 
+The translation lives under `welcome` in the JSON file. The children are the fallback when the key is missing.
+
 Lingui sample:
 
 ```jsx
@@ -286,25 +309,25 @@ const HelloWorld = () => {
 };
 ```
 
+Here the children are the message. The ID is derived from them, and `lingui extract` writes the entry to the catalog.
+
 ## Summary
 
-This is a rather brief comparison. Both libraries have quite different concepts, but at the same time the core internationalization approaches are similar and use the same background.
+Both libraries build on the same foundations: the `Intl` API for formatting, CLDR plural rules and one catalog per locale. They differ in how much of the bookkeeping is yours.
 
-**On top of that, Lingui:**
+**Lingui:**
 
-- Supports rich-text messages.
-- Provides macros to simplify writing messages directly in your code.
-- Provides a CLI tool for extracting and compiling messages.
-- Supports a number of [Catalog Formats](/ref/catalog-formats), including [Custom Formatters](/guides/custom-formatter).
-- Is small, fast and flexible. It also has a small bundle footprint by stripping unused messages and loading only necessary catalogs.
-- Works with vanilla JS, React (including RSC), Next.js, Node.js, Vue.js etc.
-- Is actively maintained.
+- Messages are written in the source with macros. There are no keys to invent and no JSON file to keep in sync, because `lingui extract` generates the catalog from the code.
+- Plurals, selects and rich text stay inside one message, and React elements inside a message stay in one translatable string.
+- Catalogs are PO files by default, which every translation tool opens and which carry source locations and comments for translators. JSON, CSV and [custom formatters](/guides/custom-formatter) are available. See [Catalog Formats](/ref/catalog-formats).
+- Catalogs are compiled ahead of time, so the runtime ships without a message parser and stays around 2 kB gzipped.
+- Works with vanilla JS, React (including RSC), React Native, Next.js, Vue, SolidJS, Astro, Svelte and Node.js.
 
-**On the other hand, i18next:**
+**i18next:**
 
-- Uses a key-based approach for translation management.
-- Is mature. Based on how long i18next has been open source, there is no real i18n case that cannot be solved with i18next.
-- Is extensible, with many plugins and tools developed by other contributors, including extractors, locale identifiers, etc.
-- Has a big ecosystem.
+- Messages are looked up by key. Resources are plain JSON and can be loaded from the filesystem, over HTTP or from a translation platform through backend plugins.
+- Has been around for more than a decade and covers nearly every i18n scenario, with an official CLI for extraction, type generation and linting.
+- Has a large plugin ecosystem: language detectors, backends, post processors and alternative message formats such as ICU and Fluent.
+- Has bindings or ports for many frameworks and platforms, including Vue, Angular, Svelte, .NET, Go, iOS and Android.
 
-In conclusion, Lingui is an excellent option for projects that need modern and efficient translation methods, support for popular frameworks, and effective translation management tools. However, the choice between Lingui and i18next ultimately depends on the specific requirements of your project.
+i18next's breadth is real, and if your organization already runs it across several stacks, that continuity counts. For a JavaScript or TypeScript codebase, Lingui covers the same ground with less to maintain by hand: no keys to name, no JSON to keep in sync, and catalogs that open in any translation tool.

--- a/website/docs/misc/i18next.md
+++ b/website/docs/misc/i18next.md
@@ -1,6 +1,6 @@
 ---
 title: Lingui vs i18next
-description: How Lingui compares with i18next and react-i18next. Message syntax, plurals, extraction tooling, catalog formats, bundle size and React Server Components side by side
+description: How Lingui compares with i18next and react-i18next. Message syntax, plurals, extraction tooling, catalog formats, bundle size and React Server Components
 ---
 
 # Lingui vs i18next
@@ -11,18 +11,18 @@ That difference runs through everything else on this page: how messages are writ
 
 ## At a Glance
 
-|                    | Lingui                                                                                                                         | i18next                                                                                                                |
-| ------------------ | ------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------- |
-| Writing messages   | The text stays in the code: `` t`Hello ${name}` ``. The catalog is generated from it                                           | You choose a key, add the text to a JSON file and reference the key: `t("greeting", { name })`                         |
-| Message IDs        | Generated from the source text, so there is nothing to name and duplicates merge on their own. Explicit IDs when you want them | Keys you define and keep unique yourself. Natural-language keys are possible with `keySeparator: false`                |
-| Message syntax     | ICU MessageFormat. Placeholders, plurals and selects stay inside one message                                                   | Own `{{name}}` syntax. Each plural form is a separate key (`key_one`, `key_other`). ICU needs the `i18next-icu` plugin |
-| Extraction         | Built in. `lingui extract` finds every message, merges it into all catalogs and marks removed ones obsolete                    | Separate tools: `i18next-cli` (the successor of `i18next-parser`) or `i18next-scanner`                                 |
-| Translator context | Source locations, comments and context travel with each message in the PO file                                                 | JSON has no comments. Key locations need an `i18next-cli` metadata plugin                                              |
-| Catalog format     | PO by default, which every translation tool opens. JSON, CSV and custom formatters available                                   | JSON, loaded through backend plugins. YAML and JSON5 via `i18next-cli`                                                 |
-| Runtime            | Catalogs are compiled at build time and no message parser ships. Core about 2 kB gzipped                                       | Messages interpolated at runtime. Core about 14 kB gzipped                                                             |
-| React              | `@lingui/react` with macros. React Server Components through `@lingui/react/server`                                            | `react-i18next`. React Server Components need `next-i18next` v16 (`getT` and `useT`)                                   |
-| Other frameworks   | React Native, Vue, SolidJS, Astro, Svelte, Node.js                                                                             | Vue, Angular, Svelte, SolidJS, Astro, Remix, Node.js and more                                                          |
-| TypeScript         | Written in TypeScript. Opt-in typed message IDs via module augmentation                                                        | Ships type definitions. Typed keys and interpolation values via `CustomTypeOptions`                                    |
+|                    | Lingui                                                                                                                         | i18next                                                                                                                                |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
+| Writing messages   | The text stays in the code: `` t`Hello ${name}` ``. The catalog is generated from it                                           | You choose a key, add the text to a JSON file and reference the key: `t("greeting", { name })`                                         |
+| Message IDs        | Generated from the source text, so there is nothing to name and duplicates merge on their own. Explicit IDs when you want them | Keys you define and keep unique yourself. Natural-language keys are possible with `keySeparator: false`                                |
+| Message syntax     | ICU MessageFormat. Placeholders, plurals and selects stay inside one message                                                   | Own `{{name}}` syntax. Each plural form is a separate key (`key_one`, `key_other`). ICU needs the `i18next-icu` plugin                 |
+| Extraction         | Built in. `lingui extract` finds every message, merges it into all catalogs and marks removed ones obsolete                    | Separate tools: `i18next-cli` (the successor of `i18next-parser`) or `i18next-scanner`                                                 |
+| Translator context | Source locations, comments and context travel with each message in the PO file                                                 | JSON has no comments. Key locations need a custom `i18next-cli` metadata plugin                                                        |
+| Catalog format     | PO by default, which every translation tool opens. JSON, CSV and custom formatters available                                   | JSON, bundled inline or loaded through backend plugins. YAML and JSON5 via `i18next-cli`                                               |
+| Runtime            | Catalogs are compiled at build time and no message parser ships. Core about 2 kB gzipped                                       | Messages interpolated at runtime. Core about 14 kB gzipped                                                                             |
+| React              | `@lingui/react` with macros. React Server Components through `@lingui/react/server`                                            | `react-i18next`. For React Server Components, `next-i18next` v16 adds `getT` and `useT`, or you create an i18next instance per request |
+| Other frameworks   | React Native, Vue, SolidJS, Astro, Svelte, Node.js                                                                             | Vue, Angular, Svelte, SolidJS, Astro, Remix, Node.js and more                                                                          |
+| TypeScript         | Written in TypeScript. Opt-in typed message IDs via module augmentation                                                        | Ships type definitions. Typed keys and interpolation values via `CustomTypeOptions`                                                    |
 
 Bundle sizes were measured with [bundlejs](https://bundlejs.com/) in September 2026 for `@lingui/core` 6.6 and `i18next` 26.4.
 
@@ -280,7 +280,7 @@ msgid "Right"
 msgstr "Right"
 ```
 
-JSON has no comment syntax, so this information is not part of i18next catalogs by default. `i18next-cli` can record key locations through a metadata plugin.
+JSON has no comment syntax, so this information is not part of i18next catalogs by default. `i18next-cli` can record key locations through a custom metadata plugin.
 :::
 
 ## React Integration
@@ -321,7 +321,7 @@ Both libraries build on the same foundations: the `Intl` API for formatting, CLD
 - Plurals, selects and rich text stay inside one message, and React elements inside a message stay in one translatable string.
 - Catalogs are PO files by default, which every translation tool opens and which carry source locations and comments for translators. JSON, CSV and [custom formatters](/guides/custom-formatter) are available. See [Catalog Formats](/ref/catalog-formats).
 - Catalogs are compiled ahead of time, so the runtime ships without a message parser and stays around 2 kB gzipped.
-- Works with vanilla JS, React (including RSC), React Native, Next.js, Vue, SolidJS, Astro, Svelte and Node.js.
+- Works with vanilla JS, React (including React Server Components), React Native, Next.js, Vue, SolidJS, Astro, Svelte and Node.js.
 
 **i18next:**
 

--- a/website/docs/misc/react-intl.md
+++ b/website/docs/misc/react-intl.md
@@ -1,6 +1,6 @@
 ---
 title: Lingui vs react-intl
-description: How Lingui compares with react-intl from FormatJS. Both use ICU MessageFormat, the differences are in rich text, macros, extraction tooling, compiled catalogs and bundle size
+description: How Lingui compares with react-intl from FormatJS. Both use ICU MessageFormat, so the differences are in rich text, macros, extraction tooling and bundle size
 ---
 
 # Lingui vs react-intl
@@ -9,17 +9,17 @@ description: How Lingui compares with react-intl from FormatJS. Both use ICU Mes
 
 ## At a Glance
 
-|                   | Lingui                                                                                                                        | react-intl (FormatJS)                                                                                                                                                   |
-| ----------------- | ----------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Writing messages  | Macros generate the ICU message from JSX or a template literal: `<Trans>Hello {name}</Trans>`                                 | You write the ICU string yourself: `<FormattedMessage defaultMessage="Hello {name}" values={{ name }} />`                                                               |
-| Rich text         | Components inside a message are plain JSX. The translator sees `Read the <0>documentation</0>`                                | Each tag maps to a render function in `values`: `link: (chunks) => <a href="/docs">{chunks}</a>`                                                                        |
-| Message IDs       | Generated from the source text by the macro, explicit IDs optional                                                            | Explicit `id`, or a generated hash with the Babel or SWC plugin or the TypeScript transformer                                                                           |
-| Extraction        | `lingui extract` merges new messages into every locale's catalog, keeps existing translations and marks removed ones obsolete | `formatjs extract` writes the source messages to one JSON file. Translated files are handled separately, with formatters for Crowdin, Lokalise, Smartling and Transifex |
-| Catalog format    | PO by default, which every translation tool opens. JSON, CSV and custom formatters available                                  | JSON, in the FormatJS layout or a translation platform's layout                                                                                                         |
-| Runtime           | Catalogs are compiled at build time and no parser ships. Core and React bindings about 4 kB gzipped                           | Messages parsed at runtime unless pre-compiled with `formatjs compile --ast`. About 15 kB gzipped                                                                       |
-| Server Components | `@lingui/react/server`. `Trans` works in server and client components alike                                                   | `react-intl/server` with `createIntl`. `FormattedMessage` and `useIntl` are client-only                                                                                 |
-| Beyond React      | `@lingui/core` for Node.js and plain JS, bindings for React Native, Vue, SolidJS, Astro and Svelte                            | `@formatjs/intl` for plain JS, `vue-intl` for Vue                                                                                                                       |
-| TypeScript        | Written in TypeScript. Opt-in typed message IDs via module augmentation                                                       | Written in TypeScript. Typed message IDs via the `FormatjsIntl` global namespace                                                                                        |
+|                   | Lingui                                                                                                                                | react-intl (FormatJS)                                                                                                                                                   |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Writing messages  | Macros generate the ICU message from JSX or a template literal: `<Trans>Hello {name}</Trans>`                                         | You write the ICU string yourself: `<FormattedMessage defaultMessage="Hello {name}" values={{ name }} />`                                                               |
+| Rich text         | Components inside a message are plain JSX. The translator sees `Read the <0>documentation</0>`                                        | Each tag maps to a render function in `values`: `link: (chunks) => <a href="/docs">{chunks}</a>`                                                                        |
+| Message IDs       | Generated from the source text by the macro, explicit IDs optional                                                                    | Explicit `id`, or a generated hash with the Babel or SWC plugin or the TypeScript transformer                                                                           |
+| Extraction        | `lingui extract` merges new messages into every locale's catalog, keeps existing translations and marks removed ones obsolete         | `formatjs extract` writes the source messages to one JSON file. Translated files are handled separately, with formatters for Crowdin, Lokalise, Smartling and Transifex |
+| Catalog format    | PO by default, which every translation tool opens. JSON, CSV and custom formatters available                                          | JSON, in the FormatJS layout or a translation platform's layout                                                                                                         |
+| Runtime           | Catalogs are compiled at build time and no parser ships. Core and React bindings about 4 kB gzipped                                   | Messages parsed at runtime unless pre-compiled with `formatjs compile --ast`. About 15 kB gzipped                                                                       |
+| Server Components | `@lingui/react/server`. `Trans` works in server and client components alike                                                           | `react-intl/server` with `createIntl`. `FormattedMessage` and `useIntl` are client-only                                                                                 |
+| Beyond React      | `@lingui/core` for Node.js and plain JS, `@lingui/solid` for SolidJS. The same core and CLI serve React Native, Vue, Astro and Svelte | `@formatjs/intl` for plain JS, `vue-intl` for Vue                                                                                                                       |
+| TypeScript        | Written in TypeScript. Opt-in typed message IDs via module augmentation                                                               | Written in TypeScript. Typed message IDs via the `FormatjsIntl` global namespace                                                                                        |
 
 Bundle sizes were measured with [bundlejs](https://bundlejs.com/) in September 2026 for `@lingui/core` and `@lingui/react` 6.6 and `react-intl` 10.1, with `react` excluded.
 
@@ -68,7 +68,7 @@ In react-intl, this would be translated as:
   id="msg.docs"
   defaultMessage="Read the <link>documentation</link>."
   values={{
-    link: (...chunks) => <a href="/docs">{chunks}</a>,
+    link: (chunks) => <a href="/docs">{chunks}</a>,
   }}
 />
 ```
@@ -113,7 +113,7 @@ Let's compare it to the react-intl solution to see the difference:
     id="msg.docs"
     defaultMessage="Read the <link>documentation</link>."
     values={{
-      link: (...chunks) => <a href="/docs">{chunks}</a>,
+      link: (chunks) => <a href="/docs">{chunks}</a>,
     }}
   />
 </p>

--- a/website/docs/misc/react-intl.md
+++ b/website/docs/misc/react-intl.md
@@ -1,11 +1,29 @@
 ---
 title: Lingui vs react-intl
-description: Comparison of Lingui and react-intl internationalization libraries
+description: How Lingui compares with react-intl from FormatJS. Both use ICU MessageFormat, the differences are in rich text, macros, extraction tooling, compiled catalogs and bundle size
 ---
 
-# Comparison with react-intl
+# Lingui vs react-intl
 
-[react-intl](https://github.com/formatjs/formatjs) (Format.js) is a popular and widely used i18n library for React. [Lingui](https://github.com/lingui/js-lingui) is very similar in many ways: both libraries use the same syntax for messages (ICU MessageFormat), and they also have a very similar API.
+[react-intl](https://formatjs.github.io/docs/react-intl/) is the React binding of [FormatJS](https://formatjs.github.io/), a long-standing i18n project that also ships a Vue binding, a CLI and `Intl` polyfills. [Lingui](https://github.com/lingui/js-lingui) is a close relative: both libraries use ICU MessageFormat for messages, and their low-level APIs look almost the same. The differences are in how much of the message syntax you write yourself, how much the tooling does for you, and what ships to the browser.
+
+## At a Glance
+
+|                   | Lingui                                                                                                                        | react-intl (FormatJS)                                                                                                                                                   |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Writing messages  | Macros generate the ICU message from JSX or a template literal: `<Trans>Hello {name}</Trans>`                                 | You write the ICU string yourself: `<FormattedMessage defaultMessage="Hello {name}" values={{ name }} />`                                                               |
+| Rich text         | Components inside a message are plain JSX. The translator sees `Read the <0>documentation</0>`                                | Each tag maps to a render function in `values`: `link: (chunks) => <a href="/docs">{chunks}</a>`                                                                        |
+| Message IDs       | Generated from the source text by the macro, explicit IDs optional                                                            | Explicit `id`, or a generated hash with the Babel or SWC plugin or the TypeScript transformer                                                                           |
+| Extraction        | `lingui extract` merges new messages into every locale's catalog, keeps existing translations and marks removed ones obsolete | `formatjs extract` writes the source messages to one JSON file. Translated files are handled separately, with formatters for Crowdin, Lokalise, Smartling and Transifex |
+| Catalog format    | PO by default, which every translation tool opens. JSON, CSV and custom formatters available                                  | JSON, in the FormatJS layout or a translation platform's layout                                                                                                         |
+| Runtime           | Catalogs are compiled at build time and no parser ships. Core and React bindings about 4 kB gzipped                           | Messages parsed at runtime unless pre-compiled with `formatjs compile --ast`. About 15 kB gzipped                                                                       |
+| Server Components | `@lingui/react/server`. `Trans` works in server and client components alike                                                   | `react-intl/server` with `createIntl`. `FormattedMessage` and `useIntl` are client-only                                                                                 |
+| Beyond React      | `@lingui/core` for Node.js and plain JS, bindings for React Native, Vue, SolidJS, Astro and Svelte                            | `@formatjs/intl` for plain JS, `vue-intl` for Vue                                                                                                                       |
+| TypeScript        | Written in TypeScript. Opt-in typed message IDs via module augmentation                                                       | Written in TypeScript. Typed message IDs via the `FormatjsIntl` global namespace                                                                                        |
+
+Bundle sizes were measured with [bundlejs](https://bundlejs.com/) in September 2026 for `@lingui/core` and `@lingui/react` 6.6 and `react-intl` 10.1, with `react` excluded.
+
+## Basic Comparison
 
 Here's an example from the react-intl docs:
 
@@ -55,13 +73,15 @@ In react-intl, this would be translated as:
 />
 ```
 
+Each tag needs a function that receives the translated chunks and wraps them.
+
 Lingui extends the ICU MessageFormat with tags. The above example would be:
 
 ```jsx
 <Trans id="msg.docs" message="Read the <link>documentation</link>." components={{ link: <a href="/docs" /> }} />
 ```
 
-The translator gets the message in one piece: `Read the <link>documentation</link>`.
+The element is passed as it is, with no wrapper function, and the translator gets the message in one piece: `Read the <link>documentation</link>`.
 
 ## Macros for Component-Based Message Syntax
 
@@ -98,6 +118,8 @@ Let's compare it to the react-intl solution to see the difference:
   />
 </p>
 ```
+
+FormatJS also has Babel and SWC plugins, but they generate message IDs and pre-compile messages. The ICU string in `defaultMessage` is still written by hand.
 
 :::note
 It's also worth mentioning that the message IDs are completely optional. Lingui is unopinionated in this way and perfectly works with messages as IDs as well:
@@ -178,56 +200,60 @@ Even though both variants are syntactically valid in ICU MessageFormat, the seco
 
 ## Text Attributes
 
-Components can't be used in some contexts, e.g. to translate text attributes. While react-intl provides JS methods (e.g. `formatMessage`) that return plain strings, Lingui provides its core library for such translations. And it also provides macros for these use cases!
-
-Here are a few short examples:
+Components can't be used in some contexts, e.g. to translate text attributes. react-intl provides `formatMessage` from the `useIntl` hook for this. Lingui provides the `t` macro, which the [`useLingui`](/ref/macro#uselingui) macro binds to the `i18n` instance from the React context:
 
 ```jsx
-<a title={i18n._(t`The title of ${name}`)}>{name}</a>
-<img alt={i18n._(plural({ value: count, one: "flag", other: "flags" }))} src="..." />
+import { useLingui } from "@lingui/react/macro";
+import { plural } from "@lingui/core/macro";
+
+function Flag({ name, count }) {
+  const { t } = useLingui();
+
+  return (
+    <>
+      <a title={t`The title of ${name}`}>{name}</a>
+      <img alt={t`${plural(count, { one: "flag", other: "flags" })}`} src="..." />
+    </>
+  );
+}
 ```
 
 Custom IDs are supported as well:
 
 ```jsx
-<a title={i18n._(t("link.title")`The title of ${name}`}>{name}</a>
-<img alt={i18n._(plural("img.alt", { value: count, one: "flag", other: "flags" }))} src="..." />
+<a title={t({ id: "link.title", message: `The title of ${name}` })}>{name}</a>
+<img alt={t({ id: "img.alt", message: plural(count, { one: "flag", other: "flags" }) })} src="..." />
 ```
-
-:::note
-To inject `i18n` object into props, you need to use [`useLingui`](/ref/react#uselingui) hook. It's very similar to `useIntl` from [react-intl](https://formatjs.io/docs/react-intl/api/#useintl-hook).
-:::
 
 ## External Message Catalog
 
 Let's say our application has been internationalized and we want to send the messages to the translator.
 
-react-intl comes with the Babel plugin which extracts messages from individual files, but it's up to you to merge them into one file which you can send to translators.
+FormatJS ships a CLI: `formatjs extract` collects the source messages into a single JSON file, and `formatjs compile` turns the translated files you get back into the format react-intl consumes, verifying the ICU syntax on the way. Formatters for Crowdin, Lokalise, Smartling and Transifex are built in. Keeping the translated files in step with the source, and noticing which translations are stale, happens outside the CLI, usually in the translation platform.
 
-Lingui provides a handy [`CLI`](/ref/cli) that extracts messages and merges them with any existing translations. It supports both the Babel and SWC ecosystems for extracting messages.
+Lingui's [CLI](/ref/cli) closes that loop itself. `lingui extract` merges new messages into every locale's catalog, keeps the existing translations and marks removed messages as obsolete, so each PO file always mirrors the current source and stale entries are visible at a glance. It supports both the Babel and SWC ecosystems for extracting messages.
 
 ## Compiling Messages
 
-The largest and slowest part of the i18n libraries are message parsers and formatters. Lingui compiles messages from MessageFormat syntax into JS functions that accept only values for interpolation (e.g. components, variables, etc.). This makes the final bundle smaller and the library faster.
+Parsing and formatting ICU messages is the largest part of an i18n runtime. Lingui compiles each message at build time into a small structure that the runtime fills with values, so neither a parser nor a MessageFormat compiler ships to the browser. This is what `lingui compile` does by default, with nothing to opt into. Plural rules come from `Intl.PluralRules`, so there is no locale data to load by hand.
 
-The compiled catalogs are also bundled with locale data like plurals, so there's no need to load them manually.
+react-intl parses messages at runtime by default. The FormatJS CLI can pre-compile messages to an AST with `formatjs compile --ast`, and pairing that with the parser-free build of `@formatjs/icu-messageformat-parser` cuts the bundle by about 40% according to the FormatJS docs. The formatter itself stays in the bundle.
 
 ## Summary
 
-- both libraries use the same MessageFormat syntax.
-- similar API (easy to port from one to the other).
+Both libraries use ICU MessageFormat and have similar low-level APIs, so porting from one to the other is mostly mechanical. What differs is how much of the work the library takes off your hands.
 
-**On top of that, Lingui:**
+**Lingui:**
 
-- Supports rich-text messages.
-- Provides macros to simplify writing messages using MessageFormat syntax.
-- Provides a CLI tool for extracting and compiling messages.
-- Is very small, fast, flexible, and stable.
-- Works for vanilla JS, Next.js, Vue.js, Node.js etc.
-- Is actively maintained.
+- Macros generate the message syntax from JSX and template literals. Rich text is written as plain JSX, and there is no ICU string to hand-write or keep in step with the code.
+- Extraction and compilation are part of the core toolchain, and the CLI keeps every locale's catalog in step with the source. Catalogs are PO files by default, with JSON, CSV and custom formats available.
+- Catalogs are compiled ahead of time. Core and React bindings together stay around 4 kB gzipped.
+- The same core serves vanilla JS, Node.js, React Native, Vue, SolidJS, Astro and Svelte.
 
-**On the other hand, react-intl:**
+**react-intl:**
 
-- Is the most popular and used i18n lib in React.
-- Is used in many production websites (stability).
+- Is one of the longest-standing i18n libraries for React, used in many production websites.
+- Is part of FormatJS, whose `@formatjs/intl` core also powers `vue-intl` and whose polyfills fill gaps in the `Intl` API.
 - Has lots of resources available online.
+
+Because the message syntax is shared, an existing react-intl codebase can move to Lingui without rewriting its messages. Each `FormattedMessage` becomes a `Trans` with the same message, and from then on the ICU string is generated for you.

--- a/website/docs/misc/resources.md
+++ b/website/docs/misc/resources.md
@@ -1,3 +1,8 @@
+---
+title: Talks and Articles
+description: Talks and articles about Lingui and JavaScript internationalization, collected from the community
+---
+
 # Talks and Articles
 
 Discover a collection of talks and articles on Lingui and the broader topic of internationalization.

--- a/website/docs/misc/showroom.md
+++ b/website/docs/misc/showroom.md
@@ -1,3 +1,8 @@
+---
+title: Projects Using Lingui
+description: Open-source and commercial projects that use Lingui for internationalization, including Bluesky, Twenty, GDevelop, Linkerd and Superset
+---
+
 # Projects Using Lingui
 
 Lingui is used by many projects, from small hobby projects to large enterprise applications.

--- a/website/docs/ref/extractor-vue.md
+++ b/website/docs/ref/extractor-vue.md
@@ -1,3 +1,8 @@
+---
+title: Vue.js Extractor
+description: Extract messages from Vue single-file components with @lingui/extractor-vue. Installation, configuration and options
+---
+
 # Vue.js Extractor
 
 The `@lingui/extractor-vue` package provides a custom extractor that handles Vue.js files.

--- a/website/docs/ref/loader.md
+++ b/website/docs/ref/loader.md
@@ -1,3 +1,8 @@
+---
+title: Webpack-compatible Loader
+description: Import PO catalogs directly and compile them on the fly with @lingui/loader in Webpack, Rspack and Rsbuild, instead of running lingui compile
+---
+
 # Webpack-compatible loader
 
 The `@lingui/loader` is a Webpack-compatible loader for Lingui message catalogs. It can be used with Webpack, Rspack, and Rsbuild. It offers an alternative to the [`lingui compile`](/ref/cli#compile) and compiles catalogs on the fly.

--- a/website/docs/ref/loader.md
+++ b/website/docs/ref/loader.md
@@ -1,5 +1,5 @@
 ---
-title: Webpack-compatible Loader
+title: Webpack-compatible loader
 description: Import PO catalogs directly and compile them on the fly with @lingui/loader in Webpack, Rspack and Rsbuild, instead of running lingui compile
 ---
 

--- a/website/docs/releases/migration-3.md
+++ b/website/docs/releases/migration-3.md
@@ -1,6 +1,6 @@
 ---
 title: Migration guide from 2.x to 3.x
-description: Upgrade Lingui from 2.x to 3.x. Backward incompatible changes across the core, React and CLI packages, new features, and the codemods that automate the migration
+description: Upgrade Lingui from 2.x to 3.x. Breaking changes across the core, React and CLI packages, new features, and the codemods that automate the migration
 ---
 
 # Migration guide from 2.x to 3.x

--- a/website/docs/releases/migration-3.md
+++ b/website/docs/releases/migration-3.md
@@ -1,3 +1,8 @@
+---
+title: Migration guide from 2.x to 3.x
+description: Upgrade Lingui from 2.x to 3.x. Backward incompatible changes across the core, React and CLI packages, new features, and the codemods that automate the migration
+---
+
 # Migration guide from 2.x to 3.x
 
 :::caution Important

--- a/website/docs/releases/migration-4.md
+++ b/website/docs/releases/migration-4.md
@@ -1,3 +1,8 @@
+---
+title: Migration guide from 3.x to 4.x
+description: Upgrade Lingui from 3.x to 4.x. New extractor configuration, hash-based message IDs, the context feature, and the removed APIs to replace
+---
+
 # Migration guide from 3.x to 4.x
 
 ## Backward incompatible changes

--- a/website/docs/releases/migration-5.md
+++ b/website/docs/releases/migration-5.md
@@ -1,3 +1,8 @@
+---
+title: Migration guide from 4.x to 5.x
+description: Upgrade Lingui from 4.x to 5.x. Node.js 20 minimum, React and JS macros split into separate packages, whitespace handling changes and the new useLingui macro
+---
+
 # Migration guide from 4.x to 5.x
 
 This guide will help you migrate from Lingui 4.x to 5.x. It covers the most important changes and breaking changes.

--- a/website/docs/releases/migration-6.md
+++ b/website/docs/releases/migration-6.md
@@ -1,3 +1,8 @@
+---
+title: Migration guide from 5.x to 6.x
+description: Upgrade Lingui from 5.x to 6.x. Node.js 22.19 minimum, ESM-only packages, URL-safe message IDs and the removed format options, with migration steps for each
+---
+
 # Migration guide from 5.x to 6.x
 
 This guide will help you migrate from Lingui 5.x to 6.x. It covers the most important changes and breaking changes.

--- a/website/docs/tools/crowdin.md
+++ b/website/docs/tools/crowdin.md
@@ -1,3 +1,8 @@
+---
+title: Crowdin
+description: Translate a Lingui project with Crowdin. Sync PO catalogs with the Crowdin CLI or the GitHub, GitLab and Bitbucket integrations, and deliver translations over the air
+---
+
 # Crowdin
 
 <p align="center">

--- a/website/docs/tools/crowdin.md
+++ b/website/docs/tools/crowdin.md
@@ -1,6 +1,6 @@
 ---
 title: Crowdin
-description: Translate a Lingui project with Crowdin. Sync PO catalogs with the Crowdin CLI or the GitHub, GitLab and Bitbucket integrations, and deliver translations over the air
+description: Translate a Lingui project with Crowdin. Sync PO catalogs with the Crowdin CLI or the GitHub, GitLab and Bitbucket integrations and deliver them over the air
 ---
 
 # Crowdin

--- a/website/docs/tools/introduction.md
+++ b/website/docs/tools/introduction.md
@@ -1,6 +1,6 @@
 ---
 title: Sync & Collaboration Tools
-description: How to manage translations for a Lingui project with translators. Manual catalog editing versus translation management systems, and the tools that integrate with Lingui
+description: How to manage translations for a Lingui project. Manual catalog editing versus translation management systems, and the tools that integrate with Lingui
 ---
 
 # Sync & Collaboration Tools

--- a/website/docs/tools/introduction.md
+++ b/website/docs/tools/introduction.md
@@ -1,3 +1,8 @@
+---
+title: Sync & Collaboration Tools
+description: How to manage translations for a Lingui project with translators. Manual catalog editing versus translation management systems, and the tools that integrate with Lingui
+---
+
 # Sync & Collaboration Tools
 
 While Lingui provides a powerful API for managing your translations, it doesn't provide an integrated solution for managing synchronization and collaboration with your translators.

--- a/website/docs/tools/translation-io.md
+++ b/website/docs/tools/translation-io.md
@@ -1,6 +1,6 @@
 ---
 title: Translation.io
-description: Sync Lingui catalogs with Translation.io. Push source messages, pull translations, and give translators syntax highlighting and plural management for ICU messages
+description: Sync Lingui catalogs with Translation.io. Push source messages, pull translations, and give translators ICU syntax highlighting and plural management
 ---
 
 # Translation.io

--- a/website/docs/tools/translation-io.md
+++ b/website/docs/tools/translation-io.md
@@ -1,3 +1,8 @@
+---
+title: Translation.io
+description: Sync Lingui catalogs with Translation.io. Push source messages, pull translations, and give translators syntax highlighting and plural management for ICU messages
+---
+
 # Translation.io
 
 <p align="center">

--- a/website/docs/tutorials/react-rsc.md
+++ b/website/docs/tutorials/react-rsc.md
@@ -1,6 +1,6 @@
 ---
-title: Lingui with React Server Components
-description: Learn how to setup and use Lingui with RSC & Next.js
+title: Next.js App Router i18n with React Server Components
+description: Add internationalization to a Next.js App Router app with Lingui. Set up the SWC plugin, load catalogs in server and client components and switch languages
 ---
 
 Lingui provides support for React Server Components (RSC) as of v4.10.0. In this tutorial, we'll learn how to add internationalization to an application with the Next.js [App Router](https://nextjs.org/docs/app). However, the same principles are applicable to any RSC-based solution.

--- a/website/docs/tutorials/react-rsc.md
+++ b/website/docs/tutorials/react-rsc.md
@@ -21,18 +21,20 @@ After configuring the middleware, make sure your page and route files are moved 
 
 ### Next.js Config
 
-Secondly, add the `swc-plugin` to the `next.config.js`, so that you can use [Lingui Macros](/ref/macro).
+Secondly, add the `swc-plugin` to the Next.js config, so that you can use [Lingui Macros](/ref/macro).
 
-```js title="next.config.js"
+```js title="next.config.mjs"
 import { linguiMacroSwcPlugin } from "@lingui/swc-plugin/options";
 
 /** @type {import('next').NextConfig} */
-module.exports = {
+const nextConfig = {
   // to use Lingui macros
   experimental: {
     swcPlugins: [linguiMacroSwcPlugin()],
   },
 };
+
+export default nextConfig;
 ```
 
 ### Setup with Server Components

--- a/website/docs/tutorials/react.md
+++ b/website/docs/tutorials/react.md
@@ -704,6 +704,6 @@ That's it for this tutorial! For more details, see the reference documentation o
 
 ## See Also
 
-- [React Server Components Tutorial](/tutorials/react-rsc)
+- [Next.js App Router i18n Tutorial](/tutorials/react-rsc)
 - [React Native i18n Tutorial](/tutorials/react-native)
 - [`@lingui/react` Reference](/ref/react)

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -143,8 +143,11 @@ const config: Config = {
     [
       "@signalwire/docusaurus-plugin-llms-txt",
       {
+        siteDescription:
+          "Lingui is a lightweight, open-source internationalization (i18n) library for JavaScript and TypeScript. It brings compile-time macros and a CLI for message extraction to React, React Native, Vue, SolidJS, Astro, Svelte, and Node.js.",
         content: {
           enableLlmsFullTxt: true,
+          relativePaths: false,
           excludeRoutes: [
             "/",
             "/search",
@@ -154,9 +157,46 @@ const config: Config = {
             "/misc/tooling",
             "/releases/*",
           ],
-          routeRules: [{ route: "/misc/**", categoryName: "Comparisons" }],
+          routeRules: [
+            { route: "/introduction", categoryName: "Introduction" },
+            { route: "/installation", categoryName: "Installation" },
+            { route: "/tutorials/**", categoryName: "Tutorials" },
+            { route: "/guides/**", categoryName: "Guides" },
+            { route: "/ref/**", categoryName: "API Reference" },
+            { route: "/examples", categoryName: "Examples" },
+            { route: "/tools/**", categoryName: "Sync & Collaboration Tools" },
+            { route: "/ai-tools", categoryName: "i18n with AI" },
+            { route: "/misc/**", categoryName: "Comparisons" },
+          ],
         },
-        includeOrder: ["/installation", "/tutorials/**", "/guides/**", "/ref/**", "/examples/**"],
+        includeOrder: [
+          "/introduction",
+          "/installation",
+          "/tutorials/**",
+          "/guides/**",
+          "/ref/**",
+          "/examples/**",
+          "/tools/**",
+          "/ai-tools/**",
+          "/misc/**",
+        ],
+        optionalLinks: [
+          {
+            title: "GitHub repository",
+            url: "https://github.com/lingui/js-lingui",
+            description: "Source code, issues and discussions",
+          },
+          {
+            title: "Agent Skills",
+            url: "https://github.com/lingui/skills",
+            description: "Lingui best practices packaged as Agent Skills for coding agents",
+          },
+          {
+            title: "Context7",
+            url: "https://context7.com/lingui/js-lingui",
+            description: "The current documentation served over MCP",
+          },
+        ],
       },
     ],
   ],

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -35,7 +35,7 @@ const config: Config = {
       {
         name: "description",
         content:
-          "Lingui is a modern internationalization framework for global products. It provides the best developer experience for managing translations and supports all major frameworks.",
+          "Lingui is a lightweight, open-source i18n library for JavaScript and TypeScript: compile-time macros and a CLI for React, React Native, Vue, SolidJS, Astro, Svelte and Node.js.",
       },
     ],
     navbar: {

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -187,6 +187,12 @@ const config: Config = {
             description: "Source code, issues and discussions",
           },
           {
+            title: "npm: @lingui/core",
+            url: "https://www.npmjs.com/package/@lingui/core",
+            description:
+              "The runtime package; @lingui/react adds the React bindings and @lingui/cli the command line tool",
+          },
+          {
             title: "Agent Skills",
             url: "https://github.com/lingui/skills",
             description: "Lingui best practices packaged as Agent Skills for coding agents",

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -145,7 +145,16 @@ const config: Config = {
       {
         content: {
           enableLlmsFullTxt: true,
-          excludeRoutes: ["/", "/search", "/community", "/misc/*", "/releases/*"],
+          excludeRoutes: [
+            "/",
+            "/search",
+            "/community",
+            "/misc/resources",
+            "/misc/showroom",
+            "/misc/tooling",
+            "/releases/*",
+          ],
+          routeRules: [{ route: "/misc/**", categoryName: "Comparisons" }],
         },
         includeOrder: ["/installation", "/tutorials/**", "/guides/**", "/ref/**", "/examples/**"],
       },

--- a/website/src/components/faq.tsx
+++ b/website/src/components/faq.tsx
@@ -35,9 +35,9 @@ const FAQ: FaqItem[] = [
       <p>
         Development keeps the source messages and the message compiler in the bundle; production strips both and relies
         on compiled catalogs, so anything not extracted before the build renders as its ID. Run{" "}
-        <code>lingui extract</code> before building, or let <code>@lingui/vite-plugin</code>,{" "}
-        <code>@lingui/loader</code> or <code>@lingui/metro-transformer</code> compile catalogs for you. Details in{" "}
-        <a href="/guides/optimizing-bundle-size">Keeping Your Bundle Small</a>.
+        <code>lingui extract</code> and <code>lingui compile</code> before building. <code>@lingui/vite-plugin</code>,{" "}
+        <code>@lingui/loader</code> and <code>@lingui/metro-transformer</code> can take over the compile step, but
+        extraction still has to run. Details in <a href="/guides/optimizing-bundle-size">Keeping Your Bundle Small</a>.
       </p>
     ),
   },

--- a/website/src/components/faq.tsx
+++ b/website/src/components/faq.tsx
@@ -1,0 +1,115 @@
+import React from "react";
+
+interface FaqItem {
+  question: string;
+  answer: JSX.Element;
+}
+
+const FAQ: FaqItem[] = [
+  {
+    question: "Does Lingui work with the Next.js App Router and React Server Components?",
+    answer: (
+      <p>
+        Yes. <code>@lingui/react</code> supports React Server Components with both the SWC and the Babel setup of
+        Next.js. See the <a href="/tutorials/react-rsc">React Server Components tutorial</a> for an App Router
+        walkthrough and the{" "}
+        <a href="https://github.com/lingui/js-lingui/tree/main/examples/nextjs-swc">Next.js example</a>, which covers
+        both routers.
+      </p>
+    ),
+  },
+  {
+    question: "How do I translate strings outside a React component, for example in constants or validation schemas?",
+    answer: (
+      <p>
+        Tag the string with the <code>msg</code> macro to get a message descriptor you can define at module level and
+        translate where it is rendered with <code>i18n.t()</code> or <code>_</code> from <code>useLingui</code>. The
+        same pattern picks a message by a runtime value. See <a href="/guides/lazy-translations">Lazy Translations</a>{" "}
+        and the <a href="/ref/macro#using-macros">macro usage notes</a>.
+      </p>
+    ),
+  },
+  {
+    question: "Why do translations work in development but show message IDs in production?",
+    answer: (
+      <p>
+        Development keeps the source messages and the message compiler in the bundle; production strips both and relies
+        on compiled catalogs, so anything not extracted before the build renders as its ID. Run{" "}
+        <code>lingui extract</code> before building, or let <code>@lingui/vite-plugin</code>,{" "}
+        <code>@lingui/loader</code> or <code>@lingui/metro-transformer</code> compile catalogs for you. Details in{" "}
+        <a href="/guides/optimizing-bundle-size">Keeping Your Bundle Small</a>.
+      </p>
+    ),
+  },
+  {
+    question: "Can I use Lingui without React, for example in Node.js, Vue or Svelte?",
+    answer: (
+      <p>
+        Yes. <code>@lingui/core</code> is framework-agnostic and works in the browser, on a Node.js server or in a
+        script, and the core macros work in any JavaScript code. Vue files are handled by{" "}
+        <code>@lingui/extractor-vue</code>; Svelte and Astro use community packages. Start with the{" "}
+        <a href="/tutorials/javascript">JavaScript tutorial</a> or the <a href="/ref/extractor-vue">Vue extractor</a>.
+      </p>
+    ),
+  },
+  {
+    question: "How do I load only the active language's catalog instead of bundling every locale?",
+    answer: (
+      <p>
+        Compiled catalogs are ordinary modules: dynamically <code>import()</code> the one for the requested locale, then
+        call <code>i18n.load()</code> and <code>i18n.activate()</code>. Bundlers emit one chunk per language and fetch
+        only the active one. Load the source locale too, since production builds drop the default messages. See{" "}
+        <a href="/guides/dynamic-loading-catalogs">Dynamic Loading of Message Catalogs</a>.
+      </p>
+    ),
+  },
+  {
+    question: "Does Lingui work with React Native and Expo?",
+    answer: (
+      <p>
+        Yes. React Native uses the same packages and extract-and-compile workflow as the web, and the optional{" "}
+        <code>@lingui/metro-transformer</code> compiles <code>.po</code> files on the fly. Give{" "}
+        <code>I18nProvider</code> a default component that renders <code>Text</code>, and polyfill{" "}
+        <code>Intl.Locale</code> and <code>Intl.PluralRules</code> if your engine lacks them. See the{" "}
+        <a href="/tutorials/react-native">React Native tutorial</a> and the{" "}
+        <a href="https://github.com/lingui/js-lingui/tree/main/examples/react-native">Expo example</a>.
+      </p>
+    ),
+  },
+];
+
+export function Faq(): React.ReactElement {
+  return (
+    <section className="px-4">
+      <div className="mx-auto max-w-3xl">
+        <h2 className="mb-12 text-center text-3xl font-medium tracking-tight text-heading sm:text-4xl">
+          Frequently asked questions
+        </h2>
+        <div className="divide-y divide-secondary/25 border-y border-secondary/25 dark:divide-white/10 dark:border-white/10">
+          {FAQ.map(({ question, answer }) => (
+            <details key={question} className="group py-5">
+              <summary className="flex cursor-pointer list-none items-center justify-between gap-4 text-left [&::-webkit-details-marker]:hidden">
+                <h3 className="m-0 text-lg font-medium tracking-tight text-heading">{question}</h3>
+                <svg
+                  aria-hidden="true"
+                  viewBox="0 0 20 20"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className="h-5 w-5 shrink-0 text-body-fg motion-safe:transition-transform group-open:rotate-180"
+                >
+                  <path d="M5 8l5 5 5-5" />
+                </svg>
+              </summary>
+              <div className="mt-3 pr-9 text-base leading-relaxed text-body-fg [&_p]:m-0 [&_a]:text-link [&_a]:no-underline [&_a]:underline-offset-2 [&_a:hover]:underline [&_code]:rounded-md [&_code]:bg-secondary/15 [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:text-[0.875em]">
+                {answer}
+              </div>
+            </details>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/website/src/components/features.tsx
+++ b/website/src/components/features.tsx
@@ -131,7 +131,12 @@ const FEATURES: FeatureDetails[] = [
   },
   {
     title: "Verified by Thousands of Developers",
-    description: <p>Lingui is used and tested by thousands of developers in production. Join the community.</p>,
+    description: (
+      <p>
+        Lingui is used and tested by thousands of developers in production, with more than 6 million npm downloads a
+        month. Join the community.
+      </p>
+    ),
     image: "verified.svg",
   },
   {

--- a/website/src/components/header.tsx
+++ b/website/src/components/header.tsx
@@ -32,8 +32,9 @@ export function Header(): React.ReactElement {
           />
           <h1 className="mb-4 text-3xl font-bold sm:text-5xl">{siteConfig.tagline}</h1>
           <p className="mb-8 text-balance text-base leading-relaxed text-body-fg">
-            A lightweight i18n library for JavaScript and TypeScript. Supports React, React Native, Vue, SolidJS, Astro,
-            Svelte, Node.js, and more.
+            Lingui is a lightweight, open-source internationalization (i18n) library for JavaScript and TypeScript. It
+            brings compile-time macros and a CLI for message extraction to React, React Native, Vue, SolidJS, Astro,
+            Svelte, and Node.js.
           </p>
 
           <div className="my-6 flex flex-wrap items-center justify-center gap-4">

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -1,20 +1,66 @@
 import React from "react";
 import Layout from "@theme/Layout";
 import Head from "@docusaurus/Head";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import { Features } from "../components/features";
 import { Header } from "../components/header";
 import { Users } from "../components/users";
 import { CallToAction } from "../components/call-to-action";
 import { Code } from "../components/code";
+import { Faq } from "../components/faq";
 import { PartnerBanner } from "../components/partner-banner";
 import { LinguiWorkflow } from "../components/lingui-workflow";
 import { SiteFooter } from "../components/site-footer";
 
 const TITLE = "Lingui | Lightweight i18n Framework for React & JS";
 const DESCRIPTION =
-  "Build global products with Lingui, the lightweight JavaScript i18n framework. Features full React and RSC support, JSX rich-text, and powerful CLI tooling.";
+  "Lingui is a lightweight, open-source i18n library for JavaScript and TypeScript: compile-time macros and a CLI for React, React Native, Vue, SolidJS, Astro, Svelte and Node.js.";
 
 function Home() {
+  const { siteConfig } = useDocusaurusContext();
+  const siteUrl = siteConfig.url.replace(/\/$/, "");
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "Organization",
+        "@id": `${siteUrl}/#organization`,
+        name: "Lingui",
+        url: siteUrl,
+        logo: `${siteUrl}/img/logo-small.svg`,
+        sameAs: [
+          "https://github.com/lingui/js-lingui",
+          "https://www.npmjs.com/package/@lingui/core",
+          "https://x.com/LinguiJS",
+          "https://discord.gg/hdNuF3rupQ",
+        ],
+      },
+      {
+        "@type": "WebSite",
+        "@id": `${siteUrl}/#website`,
+        url: siteUrl,
+        name: "Lingui",
+        description: DESCRIPTION,
+        publisher: { "@id": `${siteUrl}/#organization` },
+      },
+      {
+        "@type": "SoftwareSourceCode",
+        "@id": `${siteUrl}/#software`,
+        name: "Lingui",
+        description:
+          "Lingui is a lightweight, open-source internationalization (i18n) library for JavaScript and TypeScript. It brings compile-time macros and a CLI for message extraction to React, React Native, Vue, SolidJS, Astro, Svelte, and Node.js.",
+        url: siteUrl,
+        codeRepository: "https://github.com/lingui/js-lingui",
+        programmingLanguage: ["JavaScript", "TypeScript"],
+        runtimePlatform: ["Node.js", "Web browser", "React Native"],
+        license: "https://github.com/lingui/js-lingui/blob/main/LICENSE",
+        keywords: "i18n, internationalization, localization, ICU MessageFormat, React, JavaScript, TypeScript",
+        author: { "@id": `${siteUrl}/#organization` },
+      },
+    ],
+  };
+
   return (
     <Layout>
       <Head>
@@ -24,6 +70,7 @@ function Home() {
         <meta property="og:description" content={DESCRIPTION} />
         <meta name="twitter:title" content={TITLE} />
         <meta name="twitter:description" content={DESCRIPTION} />
+        <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
       </Head>
       <main className="space-y-24">
         <Header />
@@ -32,6 +79,7 @@ function Home() {
         <LinguiWorkflow />
         <Code />
         <Users />
+        <Faq />
         <CallToAction />
         <SiteFooter />
       </main>

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -70,7 +70,7 @@ function Home() {
         <meta property="og:description" content={DESCRIPTION} />
         <meta name="twitter:title" content={TITLE} />
         <meta name="twitter:description" content={DESCRIPTION} />
-        <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
+        <script type="application/ld+json">{JSON.stringify(jsonLd).replace(/</g, "\\u003c")}</script>
       </Head>
       <main className="space-y-24">
         <Header />

--- a/website/static/robots.txt
+++ b/website/static/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://lingui.dev/sitemap.xml


### PR DESCRIPTION
# Description

One definition of Lingui now appears everywhere it is described: README, homepage hero and JSON-LD, docs introduction, llms.txt header and the 17 package READMEs. Around it, the pages people and coding agents land on first were rewritten or completed.

**README**: leads with the definition, a short quick start, a "Why Lingui" section, who uses it, requirements and a section on the docs for AI agents (per-page `.md`, llms.txt, Context7, skills).

**Website**
- Homepage: definition in the hero, a collapsible FAQ with six research-backed questions, JSON-LD, aligned meta description.
- Introduction: opens with the definition and a "Design Decisions" section instead of a feature pitch.
- Comparisons (`/misc/i18next`, `/misc/react-intl`): "At a Glance" tables, every competitor claim re-checked against current docs, stale Lingui examples updated, pages included in llms.txt under "Comparisons". URLs and sidebar unchanged.
- Next.js: the RSC tutorial is titled for the query people search, and the installation page gained a Next.js subsection.
- 15 pages without front matter got a `title` and `description`.
- Hygiene: `robots.txt`, named `llms.txt` sections with absolute links and an Optional links block, `context7.json` with agent rules and a v5 previous version.

**Packages**: all 17 published READMEs follow one template with the tagline synced to `package.json` description; internal packages are marked as such.

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Examples update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
