### PR TITLE
fix(core): look up select choices and message ids as own properties

### DIFF
--- a/packages/core/src/i18n.test.ts
+++ b/packages/core/src/i18n.test.ts
@@ -427,6 +427,19 @@ describe("I18n", () => {
     expect(handler).toHaveBeenCalledTimes(2)
   })
 
+  it("._ should treat an id inherited from Object.prototype as missing", () => {
+    const i18n = setupI18n({
+      locale: "en",
+      messages: { en: { exists: "exists" } },
+    })
+
+    const handler = vi.fn()
+    i18n.on("missing", handler)
+    expect(i18n._("constructor")).toEqual("constructor")
+    expect(i18n._("toString")).toEqual("toString")
+    expect(handler).toHaveBeenCalledTimes(2)
+  })
+
   it("._ should emit missing event for undefined id", () => {
     const i18n = setupI18n({
       locale: "en",

--- a/packages/core/src/i18n.ts
+++ b/packages/core/src/i18n.ts
@@ -236,7 +236,13 @@ export class I18n extends EventEmitter<Events> {
       id = id.id
     }
 
-    const messageForId = this.messages[id]
+    // Own-property check so an id like "constructor" or "toString" is
+    // reported as missing instead of resolving to a member inherited from
+    // Object.prototype.
+    const messages = this.messages
+    const messageForId = Object.prototype.hasOwnProperty.call(messages, id)
+      ? messages[id]
+      : undefined
     const messageMissing = messageForId === undefined
 
     // replace missing messages with custom message for debugging

--- a/packages/core/src/interpolate.test.ts
+++ b/packages/core/src/interpolate.test.ts
@@ -142,6 +142,13 @@ describe("interpolate", () => {
     expect(cache2({ value: "n/a" })).toEqual("They")
   })
 
+  it("should use the other choice for a value inherited from Object.prototype", () => {
+    const cache = prepare("{value, select, female {She} other {They}}")
+    expect(cache({ value: "constructor" })).toEqual("They")
+    expect(cache({ value: "toString" })).toEqual("They")
+    expect(cache({ value: "hasOwnProperty" })).toEqual("They")
+  })
+
   describe("Custom format", () => {
     const testVector = [
       ["en", undefined, "0.1", "10%", "20%", "€0.10", "€1.00"],

--- a/packages/core/src/interpolate.ts
+++ b/packages/core/src/interpolate.ts
@@ -73,7 +73,12 @@ const getDefaultFormats = (
 }
 
 const selectFormatter = (value: string, rules: Record<string, any>) =>
-  rules[value] ?? rules.other
+  // Own-property check so a runtime value like "constructor" or "toString"
+  // falls back to the `other` branch instead of resolving to a member
+  // inherited from Object.prototype.
+  (Object.prototype.hasOwnProperty.call(rules, value)
+    ? rules[value]
+    : undefined) ?? rules.other
 
 /**
  * @param translation compiled message


### PR DESCRIPTION
# Description

`select` choices and message ids are read straight off a plain object, so a value that matches a member of `Object.prototype` resolves to that inherited member.

```ts
const i18n = setupI18n({
  locale: "en",
  messages: {
    en: { greeting: compileMessage("{role, select, admin {Admin} other {Member}}") },
  },
})

i18n._("greeting", { role: "member" })      // "Member"
i18n._("greeting", { role: "constructor" }) // "function Object() { [native code] }"

i18n._("toString") // "function toString() { [native code] }", and neither the
                   // `missing` handler nor the `missing` event fires
```

This is the same shape as #2658 (`this._messages[locale]`), on the two lookups left in the runtime path:

* `selectFormatter` in `interpolate.ts` does `rules[value] ?? rules.other`. `value` is application data (a role, a status, a gender field), so the collision is reachable from stored or user input, and the `other` choice that ICU guarantees is skipped.
* `I18n._` in `i18n.ts` does `this.messages[id]`. The result is not `undefined`, so `messageMissing` stays false, the `missing` handler and event are skipped, and the function source is returned as the translation.

The guard sits at the lookup rather than at compile time because compiled catalogs reach the runtime as ordinary objects (CLI output imported as a module, JSON from a translation service, an object passed to `loadAndActivate`), so their prototype is not something `@lingui/core` controls. It uses the same `Object.prototype.hasOwnProperty.call` as #2658.

Left unchanged, because they are keyed by the message text a developer writes rather than by runtime data: `values[name]` and `(formatters as any)[type]` in `interpolate.ts`, and the `!this._messages[locale]` warning in `activate`.

One test per site was added.

Before, on `main` with the two tests applied:

```
 FAIL  |@lingui/core| src/interpolate.test.ts > interpolate > should use the other choice for a value inherited from Object.prototype
AssertionError: expected 'function Object() { [native code] }' to deeply equal 'They'

 FAIL  |@lingui/core| src/i18n.test.ts > I18n > ._ should treat an id inherited from Object.prototype as missing
AssertionError: expected 'function Object() { [native code] }' to deeply equal 'constructor'

      Tests  2 failed | 63 passed (65)
```

After:

```
 Test Files  7 passed (7)
      Tests  89 passed (89)
```

`yarn vitest --run packages/core`, plus `prettier --check`, `eslint` and `yarn check-types` in `packages/core`, all clean.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

No issue filed for this; it was found while reading #2658.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
