### PR TITLE
fix: make orderBy handling consistent

### DIFF
--- a/packages/cli/src/api/catalog.test.ts
+++ b/packages/cli/src/api/catalog.test.ts
@@ -668,6 +668,25 @@ describe("order", () => {
     expect(Object.keys(orderedCatalogs)).toMatchSnapshot()
   })
 
+  it("should not depend on String.localeCompare when ordering message ids", () => {
+    const localeCompare = vi
+      .spyOn(String.prototype, "localeCompare")
+      .mockImplementation(() => {
+        throw new Error("host-locale-dependent comparison")
+      })
+    const catalog = {
+      z: makeNextMessage({ translation: "Z" }),
+      a: makeNextMessage({ translation: "A" }),
+    }
+
+    try {
+      expect(Object.keys(order("messageId", catalog))).toEqual(["a", "z"])
+      expect(localeCompare).not.toHaveBeenCalled()
+    } finally {
+      localeCompare.mockRestore()
+    }
+  })
+
   it("should order messages by origin", () => {
     const catalog = {
       LabelB: makeNextMessage({

--- a/packages/cli/src/api/catalog.ts
+++ b/packages/cli/src/api/catalog.ts
@@ -462,8 +462,12 @@ export function order<T extends CatalogType>(by: OrderBy, catalog: T): T {
  * Object keys are in the same order as they were created
  * https://stackoverflow.com/a/31102605/1535540
  */
+// hardcoded en-US locale to have consistent sorting
+// @see https://github.com/lingui/js-lingui/pull/1808
+const collator = new Intl.Collator("en-US")
+
 const orderByMessageId: OrderByFn = (a, b) => {
-  return a.messageId.localeCompare(b.messageId)
+  return collator.compare(a.messageId, b.messageId)
 }
 
 const orderByOrigin: OrderByFn = (a, b) => {
@@ -515,10 +519,6 @@ export async function writeCompiled(
   await writeFile(filename, compiledCatalog)
   return filename
 }
-
-// hardcoded en-US locale to have consistent sorting
-// @see https://github.com/lingui/js-lingui/pull/1808
-const collator = new Intl.Collator("en-US")
 
 export const orderByMessage: OrderByFn = (a, b) => {
   const aMsg = a.entry.message || ""

--- a/packages/cli/src/api/catalog.ts
+++ b/packages/cli/src/api/catalog.ts
@@ -458,14 +458,14 @@ export function order<T extends CatalogType>(by: OrderBy, catalog: T): T {
       return acc
     }, {} as T)
 }
-/**
- * Object keys are in the same order as they were created
- * https://stackoverflow.com/a/31102605/1535540
- */
 // hardcoded en-US locale to have consistent sorting
 // @see https://github.com/lingui/js-lingui/pull/1808
 const collator = new Intl.Collator("en-US")
 
+/**
+ * Object keys are in the same order as they were created
+ * https://stackoverflow.com/a/31102605/1535540
+ */
 const orderByMessageId: OrderByFn = (a, b) => {
   return collator.compare(a.messageId, b.messageId)
 }

--- a/packages/conf/src/index.test.ts
+++ b/packages/conf/src/index.test.ts
@@ -60,6 +60,13 @@ describe("@lingui/conf", () => {
     })
   })
 
+  it("should accept a custom `orderBy` function", () => {
+    const orderBy = () => 0
+    const config = makeConfig({ locales: ["en"], orderBy })
+
+    expect(config.orderBy).toBe(orderBy)
+  })
+
   it("should validate `format` and throw error if old string format passed (remove in v7)", () => {
     expect(() =>
       makeConfig({

--- a/packages/conf/src/index.test.ts
+++ b/packages/conf/src/index.test.ts
@@ -61,10 +61,14 @@ describe("@lingui/conf", () => {
   })
 
   it("should accept a custom `orderBy` function", () => {
-    const orderBy = () => 0
-    const config = makeConfig({ locales: ["en"], orderBy })
+    mockConsole((console) => {
+      const orderBy = () => 0
+      const config = makeConfig({ locales: ["en"], orderBy })
 
-    expect(config.orderBy).toBe(orderBy)
+      expect(config.orderBy).toBe(orderBy)
+      expect(console.warn).not.toBeCalled()
+      expect(console.error).not.toBeCalled()
+    })
   })
 
   it("should validate `format` and throw error if old string format passed (remove in v7)", () => {

--- a/packages/conf/src/makeConfig.ts
+++ b/packages/conf/src/makeConfig.ts
@@ -100,6 +100,7 @@ export const defaultConfig = {
 
 export const exampleConfig = {
   ...defaultConfig,
+  orderBy: multipleValidOptions("message", Function),
   macro: {
     ...defaultConfig.macro,
     idPrefixLeader: ".",


### PR DESCRIPTION
## Summary
- reuse the existing `en-US` collator when ordering catalogs by message ID
- allow custom `orderBy` functions through configuration validation
- add focused regression tests for both behaviors

## Testing
- `yarn test` (1423 passed, 2 skipped)
- `yarn vitest --run packages/cli/src/api/catalog.test.ts`
- `yarn vitest --run packages/conf/src/index.test.ts`
- `yarn tsc --noEmit -p packages/cli/tsconfig.json`
- `yarn tsc --noEmit -p packages/conf/tsconfig.json`
- `yarn exec eslint packages/cli/src/api/catalog.ts packages/cli/src/api/catalog.test.ts packages/conf/src/makeConfig.ts packages/conf/src/index.test.ts --flag v10_config_lookup_from_file`
- `yarn exec prettier --check packages/cli/src/api/catalog.ts packages/cli/src/api/catalog.test.ts packages/conf/src/makeConfig.ts packages/conf/src/index.test.ts`

Closes #2662